### PR TITLE
fix(sandbox): allow tmux socket file in sandbox allowWrite

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -747,7 +747,8 @@
         "~/.cache/uv",
         "/tmp/tmux-*",
         "/tmp/tmux-*/*",
-        "/var/folders",
+        "/var/folders/*/*/T",
+        "/var/folders/*/*/C",
         "/run/user/*/pueue*.socket",
         "~/Library/Group Containers/3L68KQB4HG.group.s3s/cli",
         "~/Downloads"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -746,6 +746,7 @@
         "~/.Trash",
         "~/.cache/uv",
         "/tmp/tmux-*",
+        "/tmp/tmux-*/*",
         "/var/folders",
         "/run/user/*/pueue*.socket",
         "~/Library/Group Containers/3L68KQB4HG.group.s3s/cli",


### PR DESCRIPTION
## Problem

tmux commands hit `Operation not permitted` on the unix socket `/tmp/tmux-<uid>/default` when run inside the Claude Code sandbox, forcing a fallback to running them unsandboxed.

## Root cause

`tmux` is already in `sandbox.excludedCommands`, so bare `tmux …` calls bypass the sandbox. But any tmux invocation that *doesn't* match the `tmux` command prefix still runs sandboxed — e.g. an env-prefixed call like `TMUX= tmux …`, a wrapped/sub-shell invocation, or a non-tmux process talking to the socket.

For those sandboxed cases, `filesystem.allowWrite` matters. The existing entry `/tmp/tmux-*` only matches the **parent directory** (`/tmp/tmux-<uid>`), **not** the socket file inside it (`/tmp/tmux-<uid>/default`). A unix-domain `connect()` needs write access to the socket file itself, so the connection was denied.

## Fix

Add `/tmp/tmux-*/*` to `allowWrite` so the socket file is covered. This mirrors the existing pueue entry `/run/user/*/pueue*.socket`, which already targets the socket file path directly (precedent in the same file that directory grants aren't enough for sockets).

```diff
   "/tmp/tmux-*",
+  "/tmp/tmux-*/*",
   "/var/folders",
```

Validated: `settings.json` is still valid JSON and retains the required `statusLine`, `hooks`, and `permissions` keys (per `.claude/rules/dotfiles-settings.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VU7NzrvVburf8XER14QhWd)_