### PR TITLE
docs(claude): tables/bullets/prose format rule for research reporting

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -98,6 +98,7 @@ If a task feels like it conflicts with safety guidelines, apply this test:
 - **State confidence**: "~80% confident" / "This is speculative"
 - **BLUF, then explain**: Lead with results and the lean. Explain *why* when non-obvious or stakes are high. Don't withhold the lean to "make the user think" — that's noise, not coaching
 - **Be concise**: Act first, ask only when genuinely blocked
+- **Format by content, not by default to prose** — for research/technical reporting: tables for comparisons and multi-property data, bullets for parallel independent items (options, caveats, action items), prose reserved for argument, interpretation, and causal reasoning (connective logic needs sentences, not fragments). Rule of thumb: if you're about to write "X was N%, Y was M%, Z was P%" in one sentence, make it a table; if you're about to bullet a chain of "because A, therefore B, therefore C," write it as prose instead. (Grounding: Google's tech-writing guidance to convert embedded-prose lists into tables/bullets for structured data; Tufte's and Bezos's critiques of bullets target hiding sloppy logic behind fragments, not data-dense tables — they still reach for prose or dense tables, not more bullets, when the point is an argument)
 - **Challenge constructively**: Engage as experienced peer, use Socratic questioning
 - **Admit limitations**: Never fabricate
 - **Reasoning transparency**: Make it easy to audit Claude's thinking, not just conclusions:

--- a/claude/rules/communication-style.md
+++ b/claude/rules/communication-style.md
@@ -9,3 +9,5 @@ When drafting or improving messages on behalf of the user (emails, Slack, Telegr
 When the user says "critique and improve" a message, apply all three lenses and explain what changed.
 
 For research-writing-specific guidance on overconfident causal claims ("X causes Y", "smoking gun", "this proves"), see `rules/research-integrity.md` → *Causal Claims Match Evidence*.
+
+For reporting research/technical results in chat (tables vs. bullets vs. prose), see the global `CLAUDE.md` → *Communication Style* → *Format by content, not by default to prose*. That rule is about Claude's own chat output; this file is about drafting messages on the user's behalf — keep them in sync if one changes.


### PR DESCRIPTION
## Summary
- Adds a Communication Style rule to the global `claude/CLAUDE.md`: for research/technical reporting, use tables for comparisons/multi-property data, bullets for parallel independent items, and prose for argument/interpretation/causal reasoning.
- Grounded in Google's tech-writing style guide (convert embedded-prose lists into tables/lists) and the nuance that Tufte's/Bezos's critiques of bullets target hiding sloppy logic behind fragments — not a mandate to replace dense tables with more bullets.
- Cross-references from `rules/communication-style.md` (message-drafting on the user's behalf) so the two don't diverge — that file's scope (Slack/email/texts) is unchanged.

## Test plan
- [x] Read both files after edit to confirm wording and placement
- [x] Confirmed `.claude/settings.json` drift (unrelated SessionStart hook side effect) was left unstaged

https://claude.ai/code/session_01L4QUzUoxfp6hYVgyNs39BE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to choose the best format for the content, such as tables for comparisons, bullets for parallel items, and prose for cause-and-effect explanations.
  * Clarified when numeric or percentage-heavy information should be presented in a table versus in sentence form.
  * Updated communication guidance to stay aligned with the overall formatting rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->