### PR TITLE
fix(claude-tools): gate bear-mcp enabledPlugins state by OS

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "enabledPlugins": {
-    "bear-mcp@productivity-tools": false,
     "claude-md-management@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "code@ai-safety-plugins": true,
@@ -15,7 +14,6 @@
     "hookify@claude-plugins-official": true,
     "huggingface-skills@claude-plugins-official": false,
     "imessage@claude-plugins-official": false,
-    "linear@claude-plugins-official": false,
     "llms-fetch-mcp@alignment-hive": true,
     "playground@claude-plugins-official": true,
     "playwright@claude-plugins-official": false,

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -169,8 +169,8 @@ source_type = "local"
 source = "/Users/yulong/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
 
 [marketplaces.claude-plugins-official]
-last_updated = "2026-06-22T15:39:46Z"
-last_revision = "5fc2987a44918a455ef7dc583b51f8faf875c3ed"
+last_updated = "2026-07-03T10:05:33Z"
+last_revision = "358ee646f45b39424320d47abbb15554d4eb31e3"
 source_type = "git"
 source = "https://github.com/anthropics/claude-plugins-official.git"
 

--- a/tools/claude-tools/src/context/mod.rs
+++ b/tools/claude-tools/src/context/mod.rs
@@ -70,7 +70,7 @@ pub fn run(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     } else if !ctx_args.profiles.is_empty() {
         // Non-interactive apply with specified profiles
         let reg = registry::load_registry()?;
-        let (base, profiles) = profiles::load_profiles()?;
+        let (base, profiles) = profiles::load_profiles_os_aware()?;
         let enabled = builder::build_plugins(&reg, &base, &profiles, &ctx_args.profiles, &[], &[])?;
         settings::apply_to_settings(&enabled)?;
         settings::write_context_yaml(&ctx_args.profiles, &[], &[])?;

--- a/tools/claude-tools/src/context/profiles.rs
+++ b/tools/claude-tools/src/context/profiles.rs
@@ -32,14 +32,29 @@ fn load_profiles_yaml() -> Result<ProfilesYaml, Box<dyn std::error::Error>> {
 }
 
 /// Load base plugins and profile definitions from profiles.yaml.
-/// Note: does NOT include the `macos:` list; use `collect_wanted_plugins` for the full
-/// OS-aware set. This function is used by callers that only need base + profile defs.
+/// Note: does NOT include the `macos:` list; use `load_profiles_os_aware` for any
+/// caller feeding into `build_plugins`/`enabledPlugins` (build_plugins itself has no
+/// OS awareness — it just enables whatever `base` contains).
 pub fn load_profiles() -> Result<(Vec<String>, BTreeMap<String, ProfileDef>), Box<dyn std::error::Error>> {
     let data = load_profiles_yaml()?;
     Ok((
         data.base.unwrap_or_default(),
         data.profiles.unwrap_or_default(),
     ))
+}
+
+/// Like `load_profiles`, but extends `base` with the `macos:` list when running on
+/// macOS. This is what makes OS-gated plugins (e.g. bear-mcp) resolve to enabled on
+/// macOS and disabled elsewhere when passed into `build_plugins`.
+pub fn load_profiles_os_aware() -> Result<(Vec<String>, BTreeMap<String, ProfileDef>), Box<dyn std::error::Error>> {
+    let data = load_profiles_yaml()?;
+    let mut base = data.base.unwrap_or_default();
+    if std::env::consts::OS == "macos" {
+        if let Some(macos_plugins) = data.macos {
+            base.extend(macos_plugins);
+        }
+    }
+    Ok((base, data.profiles.unwrap_or_default()))
 }
 
 /// Load marketplace configurations from profiles.yaml.

--- a/tools/claude-tools/src/context/settings.rs
+++ b/tools/claude-tools/src/context/settings.rs
@@ -110,7 +110,7 @@ pub fn apply_from_context_yaml() -> Result<Option<(Vec<String>, BTreeMap<String,
         Ok(r) => r,
         Err(_) => return Ok(None),
     };
-    let (base, profiles) = match super::profiles::load_profiles() {
+    let (base, profiles) = match super::profiles::load_profiles_os_aware() {
         Ok(p) => p,
         Err(_) => return Ok(None),
     };


### PR DESCRIPTION
## Summary
- `collect_wanted_plugins()` (marketplace install/prune) was already OS-aware, but the actual `enabledPlugins` true/false computation (`build_plugins`, fed by `base`) went through the OS-unaware `load_profiles()` — so on the SessionStart hook path (`apply_from_context_yaml`, runs every session on every machine) bear-mcp would resolve to disabled everywhere, including macOS.
- Added `load_profiles_os_aware()`, which extends `base` with the `macos:` list only when `std::env::consts::OS == "macos"`, and routed both the hook path (`settings::apply_from_context_yaml`) and the non-interactive CLI apply path (`mod.rs`) through it. Rebuilt binary included.
- Second commit: synced two small pieces of pre-existing config drift that were separately approved — dropped stale `bear-mcp`/`linear` `enabledPlugins` keys (no longer in the local plugin registry) from `.claude/settings.json`, and bumped the `claude-plugins-official` marketplace revision in `codex/config.toml`.

## Test plan
- [x] Verified via code reading that `build_plugins()`'s `base`-driven enable logic now sees the `macos:` list only on macOS
- [x] `cargo build --release` succeeds; rebuilt binary committed
- [x] On this Linux machine, `bear-mcp` correctly resolves to disabled (unaffected by the fix, since it never included the `macos:` list on Linux to begin with — the bug was macOS-only)
- [ ] Not yet verified live on a macOS machine (no macOS box in this session)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Context profile application now correctly enables macOS-specific plugins when running on macOS.
  * Profile-based settings updates consistently account for operating-system-specific plugin configuration.

* **Configuration**
  * Removed the Bear and Linear integrations from the default enabled plugin list.
  * Refreshed the Claude plugin marketplace metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->