### PR TITLE
feat(security): enable uv OSV malware check by default

### DIFF
--- a/claude/rules/supply-chain-security.md
+++ b/claude/rules/supply-chain-security.md
@@ -29,6 +29,13 @@ All package managers are configured with a **7-day quarantine** (`min-release-ag
 - pnpm: `pnpm add --minimum-release-age=0 <pkg>` (or set to 0 in global rc temporarily)
 - uv: `UV_EXCLUDE_NEWER= uv pip install <pkg>` (unset the env var for this command)
 
+## uv OSV Malware Check
+
+`UV_MALWARE_CHECK=1` is exported globally (`config/aliases/misc.sh`). uv cross-references the OSV database (OpenSSF malicious-packages MAL advisories) on every install/sync and aborts before any malicious code runs.
+
+- Requires uv >=0.11.16; older uv silently ignores the variable. Preview feature (announced 2026-06-08) — behavior may change.
+- **When an install is blocked as malware:** this is NOT a bug. Tell the user which package/version was flagged and link the OSV advisory. Never bypass by unsetting `UV_MALWARE_CHECK` without explicit user approval.
+
 ## Python Dependencies
 
 - Use `uv pip compile --generate-hashes` to produce hash-pinned requirements

--- a/claude/rules/supply-chain-security.md
+++ b/claude/rules/supply-chain-security.md
@@ -31,9 +31,10 @@ All package managers are configured with a **7-day quarantine** (`min-release-ag
 
 ## uv OSV Malware Check
 
-`UV_MALWARE_CHECK=1` is exported globally (`config/aliases/misc.sh`). uv cross-references the OSV database (OpenSSF malicious-packages MAL advisories) on every install/sync and aborts before any malicious code runs.
+`UV_MALWARE_CHECK=1` is exported globally (`config/aliases/misc.sh`). uv cross-references the OSV database (OpenSSF malicious-packages MAL advisories) against the project lockfile and aborts the sync before any malicious code runs.
 
-- Requires uv >=0.11.16; older uv silently ignores the variable. Preview feature (announced 2026-06-08) — behavior may change.
+- **Coverage: lockfile syncs only** — `uv add`, `uv sync`, and other lock-driven flows. `uv pip install` and `uv tool install` do NOT run the check; for those paths the 7-day `UV_EXCLUDE_NEWER` quarantine and hash-pinning below are the guards. Prefer project (lockfile) flows when installing anything untrusted.
+- Requires uv >=0.11.16; older uv silently ignores the variable (`install.sh` enforces this floor by upgrading older uv). Preview feature (announced 2026-06-08) — behavior may change.
 - **When an install is blocked as malware:** this is NOT a bug. Tell the user which package/version was flagged and link the OSV advisory. Never bypass by unsetting `UV_MALWARE_CHECK` without explicit user approval.
 
 ## Python Dependencies

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -855,7 +855,9 @@
         "cerebras.ai",
         "anthropic.com",
         "hub.docker.com",
-        "api.zotero.org"
+        "api.zotero.org",
+        "osv.dev",
+        "api.osv.dev"
       ],
       "allowLocalBinding": true
     },

--- a/config/aliases/misc.sh
+++ b/config/aliases/misc.sh
@@ -23,7 +23,8 @@ alias sync-gist='"$DOT_DIR/scripts/sync_gist.sh"'
 
 # Supply chain defense: 7-day quarantine for uv (exclude-newer needs absolute date)
 export UV_EXCLUDE_NEWER="$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
-# Supply chain defense: block install of packages with OSV MAL advisories (uv >=0.11.16; preview feature, older uv ignores it)
+# Supply chain defense: block lockfile syncs (uv add/sync) of packages with OSV MAL advisories
+# (uv >=0.11.16, floor enforced in install.sh; preview feature; does NOT cover uv pip/tool install)
 export UV_MALWARE_CHECK=1
 
 #-------------------------------------------------------------

--- a/config/aliases/misc.sh
+++ b/config/aliases/misc.sh
@@ -23,6 +23,8 @@ alias sync-gist='"$DOT_DIR/scripts/sync_gist.sh"'
 
 # Supply chain defense: 7-day quarantine for uv (exclude-newer needs absolute date)
 export UV_EXCLUDE_NEWER="$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+# Supply chain defense: block install of packages with OSV MAL advisories (uv >=0.11.16; preview feature, older uv ignores it)
+export UV_MALWARE_CHECK=1
 
 #-------------------------------------------------------------
 # Ghostty themed windows

--- a/config/uv.toml
+++ b/config/uv.toml
@@ -1,3 +1,4 @@
 # Global uv config — deployed by dotfiles (deploy.sh --pkg-configs)
 # uv's exclude-newer requires an absolute date (RFC 3339), not a relative duration.
 # 7-day quarantine is enforced via UV_EXCLUDE_NEWER env var (set dynamically in aliases.sh).
+# OSV malware check is enforced via UV_MALWARE_CHECK=1 env var (aliases/misc.sh; needs uv >=0.11.16).

--- a/install.sh
+++ b/install.sh
@@ -182,6 +182,17 @@ if ! is_installed uv; then
     fi
 fi
 
+# UV_MALWARE_CHECK (aliases/misc.sh) needs uv >=0.11.16 — older uv silently ignores it,
+# so enforce the floor on existing installations that the block above skips.
+if cmd_exists uv; then
+    uv_version=$(uv --version 2>/dev/null | awk '{print $2}')
+    if [ -n "$uv_version" ] && [ "$(printf '%s\n' "0.11.16" "$uv_version" | sort -V | head -1)" != "0.11.16" ]; then
+        log_info "Upgrading uv $uv_version (>=0.11.16 required for UV_MALWARE_CHECK)..."
+        uv self update 2>/dev/null || { is_macos && cmd_exists brew && brew upgrade uv; } || \
+            log_warning "uv upgrade failed — UV_MALWARE_CHECK inactive on uv $uv_version"
+    fi
+fi
+
 # ─── Python Dev Tools (uv ecosystem) ────────────────────────────────────────
 
 if cmd_exists uv; then


### PR DESCRIPTION
## Summary

Make `UV_MALWARE_CHECK=1` the global default so uv cross-references the OSV database (OpenSSF malicious-packages MAL advisories) before installing packages, blocking known malware at install time.

- `config/aliases/misc.sh`: export `UV_MALWARE_CHECK=1` next to the existing `UV_EXCLUDE_NEWER` 7-day quarantine
- `claude/rules/supply-chain-security.md`: document the check, the uv >=0.11.16 requirement, and how to respond when an install is blocked
- `config/uv.toml`: comment pointing at the env var

Requires uv >=0.11.16 (preview feature announced 2026-06-08). Older uv silently ignores the variable, so this is safe on machines that have not upgraded yet. Local machine upgraded 0.9.26 -> 0.11.29 alongside this change.

https://claude.ai/code/session_0196ftcstjWrbPp9XvUZ2fQw
