### PR TITLE
fix(clear-mac-apps): don't abort on selective-close failure, parallelize slow-quit

### DIFF
--- a/custom_bins/clear-mac-apps
+++ b/custom_bins/clear-mac-apps
@@ -73,6 +73,27 @@ quit_app() {
     osascript -e "tell application \"$app\" to quit" 2>/dev/null || true
 }
 
+# Quit an app and poll until it exits (max 30s), for apps that ignore keystrokes.
+# No focus dependency (System Events polling is name-based), safe to run in parallel.
+# Usage: slow_quit_and_wait "AppName"
+slow_quit_and_wait() {
+    local app="$1"
+    echo "Quitting (slow): $app"
+    quit_app "$app"
+    local elapsed=0
+    while (( elapsed < 30 )); do
+        sleep 2
+        elapsed=$((elapsed + 2))
+        local still_running
+        still_running=$(osascript -e "tell application \"System Events\" to return (name of every process whose name is \"$app\")" 2>/dev/null || echo "")
+        if [[ -z "$still_running" ]]; then
+            echo "  $app exited after ${elapsed}s"
+            return 0
+        fi
+    done
+    echo "  Warning: $app still running after 30s, moving on"
+}
+
 # Close all windows of an app without quitting
 # Usage: close_app_windows "AppName" [patience]
 #   patience: number of no-progress attempts before escalating/giving up (default: 3)
@@ -184,14 +205,15 @@ close_app_selectively() {
         script+="    close (every window whose id is ${wid})"$'\n'
     done
     script+='end tell'
-    osascript -e "$script"
+    osascript -e "$script" 2>/dev/null || true
 
     # Zombie check: if 0 windows remain after close, quit the app
     local remaining
-    remaining=$(osascript -e 'tell application "Google Chrome" to return count of windows')
+    remaining=$(osascript -e 'tell application "Google Chrome" to return count of windows' 2>/dev/null || echo "")
     if [[ "$remaining" == "0" ]]; then
         quit_app "$app"
     fi
+    return 0
 }
 
 main() {
@@ -347,26 +369,15 @@ main() {
         close_app_windows "$app" 3
     done
 
-    # Slow-quit apps: send quit, then poll until process exits (max 30s)
-    for app in "${apps_slow_quit[@]}"; do
-        echo "Quitting (slow): $app"
-        quit_app "$app"
-        local elapsed=0
-        while (( elapsed < 30 )); do
-            sleep 2
-            elapsed=$((elapsed + 2))
-            # Check if process is still running via System Events
-            local still_running
-            still_running=$(osascript -e "tell application \"System Events\" to return (name of every process whose name is \"$app\")" 2>/dev/null || echo "")
-            if [[ -z "$still_running" ]]; then
-                echo "  $app exited after ${elapsed}s"
-                break
-            fi
+    # Slow-quit apps in parallel: send quit, then poll each until exit (max 30s each).
+    # No focus needed (System Events polling is name-based), so safe to background.
+    if (( ${#apps_slow_quit} > 0 )); then
+        echo "Quitting (slow) ${#apps_slow_quit} apps in parallel..."
+        for app in "${apps_slow_quit[@]}"; do
+            slow_quit_and_wait "$app" &
         done
-        if (( elapsed >= 30 )); then
-            echo "  Warning: $app still running after 30s, moving on"
-        fi
-    done
+        wait
+    fi
 
     # Selective-close: close non-protected windows, keep app alive
     for app in "${apps_selective_close[@]}"; do


### PR DESCRIPTION
## Summary
- Fix: `close_app_selectively()` returned the exit status of its final `[[ "$remaining" == "0" ]]` check. When a selective close leaves windows open (the normal case), that's false → function returns 1 → the unguarded call site in `main()` trips `set -e` → the whole script aborts, skipping every remaining app. Fixed with an explicit `return 0` plus guarding both `osascript` calls in that function.
- Parallelize the slow-quit phase: extracted the per-app quit-and-poll logic into `slow_quit_and_wait()`, backgrounded per app + `wait`, matching the existing quit-phase pattern. Worst case for N slow-quit apps drops from up to 30s × N to ~30s total.

## Scope decision (flagging for review)
`close_app_windows` (Cmd+W) and `close_app_selectively` stay **sequential**. Both require the target app to be frontmost (`set frontmost to true` + keystrokes), so running them concurrently across apps would race over which app has focus. Only the quit and slow-quit phases (no focus dependency — `quit`/System Events polling by name) are parallelized.

## Test plan
- [x] `zsh -n custom_bins/clear-mac-apps` — syntax OK
- [x] `shellcheck --shell=bash` — all findings are pre-existing zsh-syntax false positives (`${(L)...}`, `${(k)...}`, etc.), none introduced by this diff
- [x] `--dry-run` — runs clean, no crash
- [x] Confirmed the `-10810` osascript warning during dry-run is identical on HEAD (pre-existing, unrelated to this change)
- [ ] Live test of `close_app_selectively` against real Chrome windows (not done — would actually close the user's browser windows)
