### PR TITLE
rules(markdown-style): one paragraph = one line, no newlines within paragraphs

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -165,7 +165,7 @@ Behavioral rules that apply to every session are in `~/.claude/rules/`:
 - `rules/multi-agent-coordination.md` — Multi-agent awareness, `.agent-claims` chope mechanism, conflict resolution
 - `rules/research-integrity.md` — No circular reasoning, report all results, no shortcut hacks, label/score/analysis separation
 - `rules/desktop-control.md` — Ask before launching apps, computer-use clicks/typing, claude-in-chrome navigation, or anything that moves focus on the user's machine
-- `rules/markdown-style.md` — Markdown authoring: no mid-sentence line breaks; clarity + rigour/honesty over volume
+- `rules/markdown-style.md` — Markdown authoring: no hard line breaks within paragraphs (one paragraph = one line); clarity + rigour/honesty over volume
 
 ## Knowledge Docs (On-Demand)
 

--- a/claude/rules/markdown-style.md
+++ b/claude/rules/markdown-style.md
@@ -2,22 +2,25 @@
 
 Rules for how Claude writes `.md` files (CLAUDE.md, rules, docs, plans, READMEs).
 
-## No mid-sentence line breaks
+## No hard line breaks within paragraphs
 
-Never insert a hard newline in the middle of a sentence or paragraph.
-Each sentence or continuous thought goes on its own line — editors and viewers soft-wrap.
-Long lines are fine.
-This applies to prose, bullet-point bodies, and table cells.
+A paragraph is one line. Never insert a hard newline inside a paragraph — not mid-sentence, and not between sentences. Blank lines separate paragraphs; the reading software soft-wraps long lines, so long lines are fine. This applies to prose, bullet-point bodies, and table cells.
 
-❌ Wrong — wrapping mid-sentence:
+❌ Wrong — hard-wrapped mid-sentence:
 ```
 The hook runs on every permission request and checks whether
 the tool call is safe to auto-approve.
 ```
 
-✅ Right — one thought per line:
+❌ Also wrong — sentence-per-line within one paragraph:
 ```
-The hook runs on every permission request and checks whether the tool call is safe to auto-approve.
+The hook runs on every permission request.
+It checks whether the tool call is safe to auto-approve.
+```
+
+✅ Right — the whole paragraph on one line:
+```
+The hook runs on every permission request. It checks whether the tool call is safe to auto-approve.
 ```
 
 ## Rich markdown highlighting (Bear syntax)


### PR DESCRIPTION
Encodes Yulong's instruction: reading software soft-wraps, so md files should never hard-wrap inside a paragraph — one paragraph = one line, blank lines between paragraphs.

Changes:
- claude/rules/markdown-style.md: renames the section to "No hard line breaks within paragraphs" and tightens it — the old rule still allowed sentence-per-line breaks within a paragraph; those are now explicitly wrong (new counter-example added).
- claude/CLAUDE.md: updates the rules-list pointer to match the new rule name.

https://claude.ai/code/session_01ELTHyavb5J1ZEqBw2x1r61
