### PR TITLE
fix(deploy): avoid nounset crash in editor extension sync

### DIFF
--- a/scripts/shared/helpers.sh
+++ b/scripts/shared/helpers.sh
@@ -1632,7 +1632,7 @@ install_editor_extensions() {
     typeset -a to_remove
     for ext in "${installed[@]}"; do
         [[ -z "$ext" ]] && continue
-        if [[ -z "${wanted_map[${ext:l}]}" ]]; then
+        if [[ -z "${wanted_map[${ext:l}]-}" ]]; then
             to_remove+=("$ext")
         fi
     done


### PR DESCRIPTION
## Summary
- `install_editor_extensions()` runs under `deploy.sh`'s `set -euo pipefail`. Under zsh `nounset`, `${wanted_map[$key]}` throws `parameter not set` for any installed extension not present in the wanted map (instead of expanding to empty like bash does).
- This crashed the "uninstall unlisted extensions" diff loop whenever an editor had an extension installed that wasn't in `config/vscode_extensions.txt` — exactly the observed failure: `install_editor_extensions:48: wanted_map[${ext:l}]: parameter not set`.
- Fix: add the `-` default modifier (`${wanted_map[${ext:l}]-}`) so a missing key expands to empty instead of erroring.

Not interactivity-related — this fires identically whether `./deploy.sh` is run interactively or non-interactively, since the surrounding code has no prompts (extensions are read from a file, and unlisted extensions are auto-removed without confirmation).

## Test plan
- [ ] Run `./deploy.sh --editor` (or the relevant `--only=editor` invocation) on a machine with an extension installed that's not in `config/vscode_extensions.txt`, confirm it no longer crashes and correctly lists it under "Removing N unlisted extension(s)"