### PR TITLE
feat(statusline): track other account's 5h reset for account-switching

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -296,10 +296,67 @@ format_epoch_datetime() {
   if [ -n "$t" ]; then echo "$t" | sed 's/  / /g'; return; fi
 }
 
+# Helper: format remaining seconds as a compact countdown "2h30m" / "45m" / "5d3h"
+format_countdown() {
+  local remaining_secs="$1"
+  local mins=$(( (remaining_secs + 30) / 60 ))
+  local h=$(( mins / 60 ))
+  local m=$(( mins % 60 ))
+  if [ "$h" -ge 24 ]; then
+    printf '%dd%dh' "$((h / 24))" "$((h % 24))"
+  elif [ "$h" -gt 0 ]; then
+    printf '%dh%dm' "$h" "$m"
+  else
+    printf '%dm' "$m"
+  fi
+}
+
+# ============================================================================
+# MULTI-ACCOUNT TRACKING (other logged-out account's last-known 5h reset)
+# ============================================================================
+# Account switching here means log-out/log-in on this same ~/.claude — not
+# separate CLAUDE_CONFIG_DIR instances — so only one account's credentials
+# are ever live at a time. We snapshot the *active* account's 5h reset into a
+# persistent, email-keyed cache on every tick, and surface whichever *other*
+# entry exists as a last-known countdown. Persists across logout (unlike the
+# volatile TMPDIR usage cache above, which is overwritten per active account).
+accounts_cache_dir="$HOME/.claude/usage-data"
+accounts_cache_file="$accounts_cache_dir/accounts.json"
+
+# Helper: current account's identity (email), the cache key
+get_account_email() {
+  local claude_json="$HOME/.claude.json"
+  [ -f "$claude_json" ] || return 1
+  local email
+  email=$(jq -r '.oauthAccount.emailAddress // empty' "$claude_json" 2>/dev/null)
+  [ -n "$email" ] && [ "$email" != "null" ] && { echo "$email"; return 0; }
+  return 1
+}
+
 # Render usage bars
 if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
   five_pct=$(echo "$usage_data" | jq -r '.five_hour.utilization // 0' | awk '{printf "%.0f", $1}')
   seven_pct=$(echo "$usage_data" | jq -r '.seven_day.utilization // 0' | awk '{printf "%.0f", $1}')
+
+  # Snapshot this account into the persistent multi-account cache, keyed by
+  # email, so the *other* (logged-out) account's last-known 5h reset can
+  # still be surfaced after switching away from it.
+  current_account_email=$(get_account_email)
+  if [ -n "$current_account_email" ]; then
+    mkdir -p "$accounts_cache_dir" 2>/dev/null
+    five_resets_for_cache=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty')
+    if [ -n "$five_resets_for_cache" ]; then
+      existing_accounts="{}"
+      [ -f "$accounts_cache_file" ] && existing_accounts=$(cat "$accounts_cache_file" 2>/dev/null)
+      [ -n "$existing_accounts" ] || existing_accounts="{}"
+      echo "$existing_accounts" | jq \
+        --arg email "$current_account_email" \
+        --arg resets "$five_resets_for_cache" \
+        --argjson pct "$five_pct" \
+        '.[$email] = {five_hour_resets_at: $resets, five_hour_pct: $pct}' \
+        > "$accounts_cache_file.tmp" 2>/dev/null && mv "$accounts_cache_file.tmp" "$accounts_cache_file"
+    fi
+  fi
 
   printf "\n"
 
@@ -382,6 +439,25 @@ if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
       fi
     done < <(echo "$usage_data" | jq -r '.limits[]? | select(.kind == "weekly_scoped") | select(.scope.model.display_name != null) | [.scope.model.display_name, (.percent // 0), (.resets_at // "")] | @tsv')
 
+  fi
+
+  # Other account's last-known 5h reset — always-on compact indicator,
+  # visually separated with "|" since it's a different account's data.
+  if [ -n "$current_account_email" ] && [ -f "$accounts_cache_file" ]; then
+    other_resets=$(jq -r --arg email "$current_account_email" \
+      'to_entries | map(select(.key != $email)) | sort_by(.value.five_hour_resets_at) | last.value.five_hour_resets_at // empty' \
+      "$accounts_cache_file" 2>/dev/null)
+    if [ -n "$other_resets" ] && [ "$other_resets" != "null" ]; then
+      other_epoch=$(parse_iso_epoch "$other_resets")
+      if [ -n "$other_epoch" ]; then
+        now_epoch=$(date +%s)
+        if [ "$other_epoch" -gt "$now_epoch" ]; then
+          printf "  |  \033[2m⇄ %s\033[0m" "$(format_countdown "$((other_epoch - now_epoch))")"
+        else
+          printf "  |  \033[32m⇄ ready\033[0m"
+        fi
+      fi
+    fi
   fi
 else
   if [ -n "$token" ] || [ -z "$(get_oauth_token)" ]; then

--- a/tools/claude-tools/src/usage.rs
+++ b/tools/claude-tools/src/usage.rs
@@ -6,7 +6,7 @@
 //!
 //! Fetch strategy: ureq (native Rust) → curl fallback → stale cache → error.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -56,6 +56,14 @@ pub struct LimitModel {
     pub display_name: Option<String>,
 }
 
+/// One account's last-known 5h usage, persisted across logout in the
+/// multi-account cache (`~/.claude/usage-data/accounts.json`).
+#[derive(Serialize, Deserialize, Clone)]
+struct AccountEntry {
+    five_hour_resets_at: Option<String>,
+    five_hour_pct: Option<u8>,
+}
+
 // --- Public entry point ---
 
 /// Append usage bars (or error) to output as a second statusline line.
@@ -73,9 +81,22 @@ fn format_usage_bars(output: &mut String, usage: &UsageResponse) {
     let five = usage.five_hour.as_ref().and_then(|b| b.utilization);
     let seven = usage.seven_day.as_ref().and_then(|b| b.utilization);
 
+    // Snapshot this account into the persistent multi-account cache, keyed
+    // by email, so the *other* (logged-out) account's last-known 5h reset
+    // can still be surfaced after switching away from it.
+    let current_email = resolve_account_identity();
+    if let (Some(email), Some(pct)) = (current_email.as_deref(), five) {
+        if let Some(resets_at) = usage.five_hour.as_ref().and_then(|b| b.resets_at.as_deref()) {
+            upsert_account_usage(email, resets_at, pct.round().clamp(0.0, 100.0) as u8);
+        }
+    }
+
     if five.is_none() && seven.is_none() {
         output.push('\n');
         let _ = write!(output, "\x1b[2m\u{2014}\x1b[0m"); // dim em-dash placeholder
+        if let Some(email) = current_email.as_deref() {
+            render_other_account(output, email);
+        }
         return;
     }
 
@@ -111,6 +132,10 @@ fn format_usage_bars(output: &mut String, usage: &UsageResponse) {
         let pct = pct.round().clamp(0.0, 100.0) as u8;
         output.push_str("  \u{00b7}  ");
         render_bucket(output, name, pct, limit.resets_at.as_deref(), SEVEN_DAY_SECS);
+    }
+
+    if let Some(email) = current_email.as_deref() {
+        render_other_account(output, email);
     }
 }
 
@@ -266,6 +291,85 @@ fn color_for_pct(pct: u8) -> &'static str {
         "\x1b[38;2;255;176;85m" // Orange
     } else {
         "\x1b[32m" // Green
+    }
+}
+
+// --- Multi-account tracking ---
+//
+// Account switching here means log-out/log-in on the same ~/.claude — not
+// separate CLAUDE_CONFIG_DIR instances — so only one account's credentials
+// are ever live at a time. We snapshot the *active* account's 5h reset into
+// a persistent, email-keyed cache on every tick, and surface whichever
+// *other* entry exists as a last-known countdown. This persists across
+// logout (unlike the volatile TMPDIR usage cache above, which reflects only
+// the currently active account).
+
+/// Current account's identity (email), the multi-account cache key.
+fn resolve_account_identity() -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    let path = PathBuf::from(home).join(".claude.json");
+    let data = std::fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&data).ok()?;
+    json.get("oauthAccount")?
+        .get("emailAddress")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn accounts_cache_path() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let dir = PathBuf::from(home).join(".claude").join("usage-data");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join("accounts.json"))
+}
+
+fn read_accounts_cache() -> std::collections::HashMap<String, AccountEntry> {
+    accounts_cache_path()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn upsert_account_usage(email: &str, resets_at: &str, pct: u8) {
+    let Some(path) = accounts_cache_path() else { return };
+    let mut accounts = read_accounts_cache();
+    accounts.insert(
+        email.to_string(),
+        AccountEntry {
+            five_hour_resets_at: Some(resets_at.to_string()),
+            five_hour_pct: Some(pct),
+        },
+    );
+    if let Ok(serialized) = serde_json::to_string_pretty(&accounts) {
+        let _ = std::fs::write(&path, serialized);
+    }
+}
+
+/// Surface the other (logged-out) account's last-known 5h reset as an
+/// always-on compact indicator: a countdown while waiting, "ready" once the
+/// cached reset time has passed. No-op if no other account has ever synced.
+fn render_other_account(output: &mut String, current_email: &str) {
+    let accounts = read_accounts_cache();
+    let other_reset_epoch = accounts
+        .iter()
+        .filter(|(email, _)| email.as_str() != current_email)
+        .filter_map(|(_, entry)| entry.five_hour_resets_at.as_deref())
+        .filter_map(parse_iso_epoch)
+        .max();
+
+    let Some(reset_epoch) = other_reset_epoch else { return };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+
+    output.push_str("  |  ");
+    if reset_epoch > now {
+        let remaining = (reset_epoch - now) as f64;
+        let _ = write!(output, "\x1b[2m\u{21c4} {}\x1b[0m", fmt_time_remaining(remaining));
+    } else {
+        let _ = write!(output, "\x1b[32m\u{21c4} ready\x1b[0m");
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a persistent, email-keyed cache (`~/.claude/usage-data/accounts.json`) that snapshots each account's 5h reset time on every statusline tick
- Surfaces the *other* (currently logged-out) account's last-known 5h reset as an always-on compact indicator: `| ⇄ 41m` while waiting, `| ⇄ ready` once the cached reset time has passed
- Implemented in both the bash fallback (`claude/statusline.sh`) and the Rust primary (`tools/claude-tools/src/usage.rs`), rebuilt and redeployed to `custom_bins/claude-tools-linux-x86_64`

Design context: account switching here means log-out/log-in on the same `~/.claude` config dir, not separate `CLAUDE_CONFIG_DIR` instances, so only one account's credentials are ever live at a time. The cache is what lets the other account's countdown survive being logged out of.

## Test plan
- [x] Rust: `cargo build --release`, redeployed binary, ran against real production data — confirmed current-account snapshot/upsert into `accounts.json`
- [x] Rust: confirmed the past-reset "ready" branch renders correctly (`⇄ ready` in green) against real data
- [ ] Rust: future-reset countdown branch (`⇄ 2h42m`-style) verified by code review + hand-checked arithmetic only, not a live run — repeatedly blocked by the safety classifier when attempting to mutate the live `accounts.json` cache to force that state
- [ ] Bash fallback: `bash -n` syntax check passed; direct execution of `claude/statusline.sh` (which makes a live network call with OAuth credentials) was blocked by the safety classifier in this session and not independently verified end-to-end — jq query logic hand-traced for correctness (no-other-account case confirmed to resolve to empty)
- [ ] "No other account" case (only current account in cache) not tested with a live run; confirmed via jq semantics that `[] | last` → `null` → `// empty` renders nothing
