### PR TITLE
feat(statusline): show reasoning effort level alongside model name

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -78,12 +78,17 @@ if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
 fi
 
 # ============================================================================
-# MODEL NAME
+# MODEL NAME (+ reasoning effort level, when the model supports it)
 # ============================================================================
 model_info=""
 model_name=$(echo "$input" | jq -r '.model.display_name // empty')
+effort_level=$(echo "$input" | jq -r '.effort.level // empty')
 if [ -n "$model_name" ]; then
-  model_info="$(printf '\033[34m')[${model_name}]$(printf '\033[0m')"
+  if [ -n "$effort_level" ]; then
+    model_info="$(printf '\033[34m')[${model_name} · ${effort_level}]$(printf '\033[0m')"
+  else
+    model_info="$(printf '\033[34m')[${model_name}]$(printf '\033[0m')"
+  fi
 fi
 
 # ============================================================================

--- a/tools/claude-tools/SHA256SUMS
+++ b/tools/claude-tools/SHA256SUMS
@@ -1,3 +1,3 @@
 f61cd6df43db4cc4d822a222b187d4abecdc64fced91de2a5ea1c601c6c1c7e0  claude-tools-darwin-arm64
 9913f3a32638375e67e6dd132c9d36f5f2d8793051c66cf7127a4b7b774f7385  claude-tools-linux-aarch64
-93b842f5ada8f1d4d341c3b0a4d7f433bb5a0723713ac91a353b6dcd813b7fae  claude-tools-linux-x86_64
+351f678c943ab0d80cd8647e78b8e7f8865d680826e9a4de468b7dd23910dc5c  claude-tools-linux-x86_64

--- a/tools/claude-tools/src/statusline.rs
+++ b/tools/claude-tools/src/statusline.rs
@@ -13,11 +13,17 @@ struct Input {
     model: Option<Model>,
     cost: Option<Cost>,
     context_window: Option<ContextWindow>,
+    effort: Option<Effort>,
 }
 
 #[derive(Deserialize)]
 struct Model {
     display_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Effort {
+    level: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -64,7 +70,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Line 2: session state (collect parts, join with " · ")
     let mut session_parts: Vec<String> = Vec::new();
-    if let Some(s) = format_model_str(input.model.as_ref()) {
+    if let Some(s) = format_model_str(input.model.as_ref(), input.effort.as_ref()) {
         session_parts.push(s);
     }
     if let Some(s) = format_context_usage_str(input.context_window.as_ref()) {
@@ -223,10 +229,16 @@ fn format_git_info(output: &mut String, cwd: &str) {
     }
 }
 
-/// Model display name in brackets.
-fn format_model_str(model: Option<&Model>) -> Option<String> {
+/// Model display name in brackets, with reasoning effort level appended when present
+/// (e.g. `[Sonnet 5 · high]`). `effort` is only sent by Claude Code for models that
+/// support configurable effort levels.
+fn format_model_str(model: Option<&Model>, effort: Option<&Effort>) -> Option<String> {
     let name = model.and_then(|m| m.display_name.as_deref()).filter(|n| !n.is_empty())?;
-    Some(format!("\x1b[34m[{}]\x1b[0m", name))
+    let level = effort.and_then(|e| e.level.as_deref()).filter(|l| !l.is_empty());
+    match level {
+        Some(level) => Some(format!("\x1b[34m[{} \u{00b7} {}]\x1b[0m", name, level)),
+        None => Some(format!("\x1b[34m[{}]\x1b[0m", name)),
+    }
 }
 
 /// Context usage percentage from `context_window.used_percentage` (pre-computed by Claude Code).


### PR DESCRIPTION
## Summary
- Statusline now appends the current reasoning-effort level to the model name bracket, e.g. `[Sonnet 5 · high]`, for models that support configurable effort (falls back to plain `[Model Name]` otherwise).
- Implemented in both dual-implementation statuslines: `claude/statusline.sh` (bash fallback) and `tools/claude-tools/src/statusline.rs` (Rust primary).
- The `effort.level` field was reverse-engineered from the installed Claude Code CLI binary (2.1.216) — it's a top-level `effort: {level: "low"|"medium"|"high"|"xhigh"}` sibling to `model`/`cost`/`context_window` in the statusline stdin JSON, sent only for models that support configurable effort.
- Rebuilt `claude-tools` for `linux-x86_64` and regenerated `tools/claude-tools/SHA256SUMS` to match.

## Test plan
- [x] Verified Rust binary end-to-end against sample stdin JSON, both with and without `effort` present
- [x] Verified full `claude/statusline.sh` end-to-end against sample stdin JSON, both with and without `effort` present — output matches Rust implementation exactly (`[Sonnet 5 · high]` / `[Haiku 4.5]`)
- [x] Confirmed `custom_bins/claude-tools-linux-x86_64` checksum matches the newly built binary

https://claude.ai/code/session_019m9jsBpvKn79DC1vGnWeF6