### PR TITLE
fix(llm-billing): handle missing org-admin perms without re-diagnosing

### DIFF
--- a/claude/agents/llm-billing.md
+++ b/claude/agents/llm-billing.md
@@ -12,3 +12,5 @@ For process details, environment variables, and troubleshooting, see:
 `~/.claude/skills/llm-billing/references/billing-process.md`
 
 **Quick start:** Run `cd "${DOT_DIR:-$HOME/code/dotfiles}" && uv run claude/agents/llm-billing.py` and show the output directly. Do not reformat or summarize.
+
+**If a provider shows "No data — needs an org/admin key":** this is the definitive answer, not an error to investigate further. The user's OpenAI/Anthropic keys are usually project-scoped (`sk-proj-...` / `sk-ant-api03-...`), which cannot read org-level billing — this is an OpenAI/Anthropic API restriction, not a bug in this script. Relay the message and the manual dashboard URL it prints, then stop. Do NOT spend extra tool calls verifying the key otherwise works (e.g. hitting `/v1/models`) — that doesn't answer the billing question and wastes a turn on an already-known limitation.

--- a/claude/agents/llm-billing.py
+++ b/claude/agents/llm-billing.py
@@ -298,22 +298,27 @@ def main() -> None:
     else:
         missing.append("OPENROUTER_API_KEY")
 
-    # Providers with usage history (daily + hourly breakdowns)
+    # Providers with usage history (daily + hourly breakdowns).
+    # Anthropic tries ANTHROPIC_ADMIN_API_KEY first, falling back to the regular
+    # ANTHROPIC_API_KEY most users actually have set — the regular key will 403
+    # on the cost endpoint, which is exactly what triggers the fallback_msg below
+    # instead of silently reporting a key the user will never set as "missing".
     usage_providers = [
-        ("OPENAI_API_KEY", "OpenAI", query_openai,
+        (["OPENAI_API_KEY"], "OpenAI", query_openai,
          "No data — needs an org-level key (not a project-scoped sk-proj-... key). "
          "This is expected if you're not an org admin — check manually: "
-         "https://platform.openai.com/settings/organization/billing/overview"),
-        ("ANTHROPIC_ADMIN_API_KEY (sk-ant-admin-...)", "Anthropic", query_anthropic,
-         "No data — needs an admin key (sk-ant-admin-...), not a regular sk-ant-api03-... key. "
+         "https://platform.openai.com/settings/organization/billing/overview",
+         "OPENAI_API_KEY"),
+        (["ANTHROPIC_ADMIN_API_KEY", "ANTHROPIC_API_KEY"], "Anthropic", query_anthropic,
+         "No data — this key isn't admin-scoped (needs sk-ant-admin-..., not sk-ant-api03-...). "
          "This is expected if you're not an org admin — check manually: "
-         "https://console.anthropic.com/settings/billing"),
+         "https://console.anthropic.com/settings/billing",
+         "ANTHROPIC_ADMIN_API_KEY or ANTHROPIC_API_KEY"),
     ]
-    for env_var, name, query_fn, fallback_msg in usage_providers:
-        env_key = env_var.split(" ")[0]  # strip parenthetical hint
-        key = os.getenv(env_key)
+    for env_keys, name, query_fn, fallback_msg, missing_label in usage_providers:
+        key = next((os.getenv(k) for k in env_keys if os.getenv(k)), None)
         if not key:
-            missing.append(env_var)
+            missing.append(missing_label)
             continue
         console.print(f"[dim]Querying {name}...[/]")
         bal, d, h = query_fn(key)

--- a/claude/agents/llm-billing.py
+++ b/claude/agents/llm-billing.py
@@ -301,8 +301,13 @@ def main() -> None:
     # Providers with usage history (daily + hourly breakdowns)
     usage_providers = [
         ("OPENAI_API_KEY", "OpenAI", query_openai,
-         "No data — needs org-level key (not project-scoped sk-proj-...)"),
-        ("ANTHROPIC_ADMIN_API_KEY (sk-ant-admin-...)", "Anthropic", query_anthropic, None),
+         "No data — needs an org-level key (not a project-scoped sk-proj-... key). "
+         "This is expected if you're not an org admin — check manually: "
+         "https://platform.openai.com/settings/organization/billing/overview"),
+        ("ANTHROPIC_ADMIN_API_KEY (sk-ant-admin-...)", "Anthropic", query_anthropic,
+         "No data — needs an admin key (sk-ant-admin-...), not a regular sk-ant-api03-... key. "
+         "This is expected if you're not an org admin — check manually: "
+         "https://console.anthropic.com/settings/billing"),
     ]
     for env_var, name, query_fn, fallback_msg in usage_providers:
         env_key = env_var.split(" ")[0]  # strip parenthetical hint

--- a/claude/skills/llm-billing/references/billing-process.md
+++ b/claude/skills/llm-billing/references/billing-process.md
@@ -23,7 +23,7 @@ API keys live in `${DOT_DIR:-$HOME/code/dotfiles}/.env`:
 |----------|----------|---------------------------|
 | OpenRouter | `OPENROUTER_API_KEY` | any key (balance endpoint is key-scoped) |
 | OpenAI | `OPENAI_API_KEY` | **org-level** key — a project-scoped `sk-proj-...` key works for inference but 403s on `/v1/organization/costs` |
-| Anthropic | `ANTHROPIC_ADMIN_API_KEY` | **admin** key (`sk-ant-admin-...`) — a regular `sk-ant-api03-...` key can't read cost/usage reports |
+| Anthropic | `ANTHROPIC_ADMIN_API_KEY`, falls back to `ANTHROPIC_API_KEY` | **admin** key (`sk-ant-admin-...`) needed for cost/usage reports — the script tries `ANTHROPIC_ADMIN_API_KEY` first, then falls back to the regular `ANTHROPIC_API_KEY` most users have set (which will 403 and trigger the manual-check fallback message rather than being skipped as "missing") |
 
 ## Troubleshooting
 

--- a/claude/skills/llm-billing/references/billing-process.md
+++ b/claude/skills/llm-billing/references/billing-process.md
@@ -19,12 +19,24 @@ The script produces rich-formatted tables with color coding. Present the output 
 
 API keys live in `${DOT_DIR:-$HOME/code/dotfiles}/.env`:
 
-| Provider | Variable |
-|----------|----------|
-| OpenRouter | `OPENROUTER_API_KEY` |
-| OpenAI | `OPENAI_API_KEY` |
-| Anthropic | `ANTHROPIC_API_KEY` |
+| Provider | Variable | Scope needed for billing |
+|----------|----------|---------------------------|
+| OpenRouter | `OPENROUTER_API_KEY` | any key (balance endpoint is key-scoped) |
+| OpenAI | `OPENAI_API_KEY` | **org-level** key — a project-scoped `sk-proj-...` key works for inference but 403s on `/v1/organization/costs` |
+| Anthropic | `ANTHROPIC_ADMIN_API_KEY` | **admin** key (`sk-ant-admin-...`) — a regular `sk-ant-api03-...` key can't read cost/usage reports |
 
 ## Troubleshooting
 
 If all providers show errors or missing keys, inform the user which environment variables need to be set in the `.env` file.
+
+### No org-admin access (common — not a bug)
+
+If you (the user) only have a project-scoped OpenAI key or a non-admin Anthropic key, the script will print
+`No data — needs an org/admin key` for that provider plus a manual dashboard URL. This is an API-level
+restriction, not something the script or agent can work around — there is no read-only "check my balance"
+endpoint for non-admin keys on either provider. The agent should relay this immediately and stop; it should
+not spend extra tool calls (e.g. probing `/v1/models`) trying to re-derive what's already a known limitation.
+
+Manual balance/usage checks:
+- OpenAI: https://platform.openai.com/settings/organization/billing/overview (requires org owner/admin role)
+- Anthropic: https://console.anthropic.com/settings/billing (requires admin role)


### PR DESCRIPTION
## Summary
- OpenAI billing (`/v1/organization/costs`) and Anthropic billing (admin cost/usage reports) both 403 for regular project-scoped keys — the common case when you're not an org admin.
- Previously the agent had no clear signal for this, so on a real run it burned an extra background call probing `/v1/models` just to confirm the key was otherwise fine, then reported "inconclusive" instead of a clear answer.
- Now: both providers print an explicit fallback message with the manual dashboard URL to check the balance by hand, and the agent doc tells the agent to relay it and stop rather than re-diagnosing a known limitation.
- Also fixed `billing-process.md`'s env var table, which claimed `ANTHROPIC_API_KEY` when the script actually reads `ANTHROPIC_ADMIN_API_KEY`.

## Test plan
- [x] `py_compile` on the modified script
- [x] Ran the script with no keys set — clean "missing keys" output, no crash
- [x] Synthetic render check of the new fallback message (rich formatting, clickable URL)
- [ ] Live run against a real project-scoped OpenAI/Anthropic key (couldn't test — no `.env` present in this sandboxed session)

https://claude.ai/code/session_01SX1xqUBnioGEogtdvukKVH
