### PR TITLE
docs(rules): spend authorization policy for billed runs

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -158,7 +158,7 @@ Standard paths:
 Behavioral rules that apply to every session are in `~/.claude/rules/`:
 
 - `rules/safety-and-git.md` — Zero tolerance table, git safety, destructive command warnings
-- `rules/workflow-defaults.md` — Task/agent organization, file creation policy, output strategy
+- `rules/workflow-defaults.md` — Task/agent organization, file creation policy, output strategy, spend authorization for billed runs
 - `rules/context-management.md` — PDF/large file rules, bulk edit constraints, verbose output handling
 - `rules/agents-and-delegation.md` — Subagent strategy, delegation decision tree, factual verification, team escalation
 - `rules/coding-conventions.md` — Python/TypeScript/shell basics, language selection, package managers

--- a/claude/rules/workflow-defaults.md
+++ b/claude/rules/workflow-defaults.md
@@ -113,15 +113,9 @@ User gives instruction →
 
 ## Spend Authorization for Runs
 
-Any run with a real cost in money or significant compute time — experiments, evals (e.g. `ai-safety-plugins`), cloud/GPU jobs (Modal, RunPod, Lambda), batches of API-billed LLM calls, or a hook/automation that triggers one of these — needs a cost estimate before launching, not a blanket "ask permission every time" gate.
+Before a billed run (experiments, evals, cloud/GPU jobs, API-billed LLM batches): estimate cost in time + money from actual rates, not a guess (`llm-billing` agent for current pricing). Under $100 → run now, report the estimate with the result. $100+ → propose the estimate and wait for go-ahead.
 
-- **Estimate first**: state the expected cost in both time and money (compute-hours × rate, API tokens × pricing, cloud instance-hours). Calculate from known rates — don't guess vaguely (see `rules/refusal-alternatives.md` § Agent Throughput Awareness: no cost estimate unless it's actually calculated). Use the `llm-billing` agent to check current provider rates/balance if unsure.
-- **Estimated total < $100 → run immediately**, no approval wait. Still report the estimate alongside the result — don't gate on it, just surface it.
-- **Estimated total >= $100 → propose the run** (cost estimate + what it buys) and wait for explicit go-ahead before launching.
-- If actual spend looks set to materially exceed the estimate mid-run, pause and flag — the estimate is the basis for the $100 gate, not a one-time check-the-box.
-- **SLURM cluster jobs are exempt** — allocations are already paid for (institutional/program grant), so there's no marginal cost to estimate or gate on. Currently: Silico, MATS. Treat jobs on these as free at the margin (still subject to `jexp`-style queueing and resource courtesy, just not the cost gate); if a new cluster shows up, ask whether it's a similarly pre-paid allocation before assuming it's free.
-
-**Why:** replaces a blanket "never spend without asking" default (too conservative — forces a round-trip for trivial-cost runs) with a threshold model: real money still needs a human decision, small spend shouldn't block momentum.
+SLURM jobs (currently Silico, MATS) run on pre-paid allocations — no marginal cost, skip the gate. Confirm before assuming a new cluster is similarly free.
 
 ## Mid-Implementation Checkpoints
 

--- a/claude/rules/workflow-defaults.md
+++ b/claude/rules/workflow-defaults.md
@@ -119,6 +119,7 @@ Any run with a real cost in money or significant compute time — experiments, e
 - **Estimated total < $100 → run immediately**, no approval wait. Still report the estimate alongside the result — don't gate on it, just surface it.
 - **Estimated total >= $100 → propose the run** (cost estimate + what it buys) and wait for explicit go-ahead before launching.
 - If actual spend looks set to materially exceed the estimate mid-run, pause and flag — the estimate is the basis for the $100 gate, not a one-time check-the-box.
+- **SLURM cluster jobs are exempt** — allocations are already paid for (institutional/program grant), so there's no marginal cost to estimate or gate on. Currently: Silico, MATS. Treat jobs on these as free at the margin (still subject to `jexp`-style queueing and resource courtesy, just not the cost gate); if a new cluster shows up, ask whether it's a similarly pre-paid allocation before assuming it's free.
 
 **Why:** replaces a blanket "never spend without asking" default (too conservative — forces a round-trip for trivial-cost runs) with a threshold model: real money still needs a human decision, small spend shouldn't block momentum.
 

--- a/claude/rules/workflow-defaults.md
+++ b/claude/rules/workflow-defaults.md
@@ -111,6 +111,17 @@ User gives instruction →
 
 **Sandbox note:** `pueue` and `systemctl` are in `excludedCommands` — they bypass the sandbox so `jexp` works from Claude Code sessions.
 
+## Spend Authorization for Runs
+
+Any run with a real cost in money or significant compute time — experiments, evals (e.g. `ai-safety-plugins`), cloud/GPU jobs (Modal, RunPod, Lambda), batches of API-billed LLM calls, or a hook/automation that triggers one of these — needs a cost estimate before launching, not a blanket "ask permission every time" gate.
+
+- **Estimate first**: state the expected cost in both time and money (compute-hours × rate, API tokens × pricing, cloud instance-hours). Calculate from known rates — don't guess vaguely (see `rules/refusal-alternatives.md` § Agent Throughput Awareness: no cost estimate unless it's actually calculated). Use the `llm-billing` agent to check current provider rates/balance if unsure.
+- **Estimated total < $100 → run immediately**, no approval wait. Still report the estimate alongside the result — don't gate on it, just surface it.
+- **Estimated total >= $100 → propose the run** (cost estimate + what it buys) and wait for explicit go-ahead before launching.
+- If actual spend looks set to materially exceed the estimate mid-run, pause and flag — the estimate is the basis for the $100 gate, not a one-time check-the-box.
+
+**Why:** replaces a blanket "never spend without asking" default (too conservative — forces a round-trip for trivial-cost runs) with a threshold model: real money still needs a human decision, small spend shouldn't block momentum.
+
 ## Mid-Implementation Checkpoints
 
 **Problem:** Claude reads code, makes assumptions, and starts implementing against a wrong mental model. This causes misunderstandings that waste context and require rework.


### PR DESCRIPTION
## Summary
- Adds a `Spend Authorization for Runs` section to `claude/rules/workflow-defaults.md`: replaces the blanket "never spend without asking" default with a threshold model.
- Estimate cost (time + money) before launching billed runs (experiments, evals, cloud/GPU jobs, API-billed LLM batches).
- Under $100 estimated → run immediately, report the estimate alongside results. $100+ → propose the run with the estimate and wait for go-ahead.
- Updates the `rules/workflow-defaults.md` one-liner in `claude/CLAUDE.md`'s rules index.

## Test plan
- [x] Rule text reviewed for consistency with existing `refusal-alternatives.md` § Agent Throughput Awareness (no vague cost estimates)
- [x] Cross-referenced `llm-billing` agent for rate/balance checks

https://claude.ai/code/session_0179ztqyabUg66UC3evfRBMC