### PR TITLE
feat(claude-hooks): add simplify nudge after code edits

### DIFF
--- a/claude/hooks/simplify_mark_dirty.sh
+++ b/claude/hooks/simplify_mark_dirty.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PostToolUse hook (matcher: Write|Edit): marks the session dirty when a code
+# file changes, so the paired Stop hook (simplify_nudge.sh) can nudge Claude
+# to run the simplify skill before finishing.
+set -euo pipefail
+
+# Extensions worth nudging on — code files, not docs/config/data (those would
+# make this hook noisy on every markdown/JSON/YAML edit).
+CODE_EXT_RE='\.(py|ts|tsx|js|jsx|mjs|cjs|rs|go|rb|sh|bash|zsh|c|cc|cpp|h|hpp|java|kt|swift|scala|php|cs|lua|sql)$'
+
+INPUT=$(cat)
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
+[ -z "$SESSION_ID" ] && exit 0
+
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -z "$FILE_PATH" ] && exit 0
+
+if [[ "$FILE_PATH" =~ $CODE_EXT_RE ]]; then
+  touch "${TMPDIR:-/tmp}/claude-simplify-dirty-${SESSION_ID}" 2>/dev/null || true
+fi
+
+exit 0

--- a/claude/hooks/simplify_nudge.sh
+++ b/claude/hooks/simplify_nudge.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Stop hook: if a code file changed this turn (marked by
+# simplify_mark_dirty.sh), nudge Claude via additionalContext to run the
+# simplify skill before finishing. Soft nudge only — never blocks the stop.
+#
+# stop_hook_active guard: additionalContext keeps the conversation going
+# through the same loop protections as decision:block, so without this guard
+# a simplify pass that itself edits code would re-mark the session dirty and
+# re-trigger the nudge on the next Stop check.
+set -euo pipefail
+
+INPUT=$(cat)
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
+[ -z "$SESSION_ID" ] && exit 0
+
+MARKER="${TMPDIR:-/tmp}/claude-simplify-dirty-${SESSION_ID}"
+[ -f "$MARKER" ] || exit 0
+rm -f "$MARKER" 2>/dev/null || true
+
+STOP_HOOK_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null) || exit 0
+[[ "$STOP_HOOK_ACTIVE" == "true" ]] && exit 0
+
+cat <<'HOOK_EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": "Code was written this turn — consider running the simplify skill (Skill tool, skill: \"simplify\") on the changed files before finishing."
+  }
+}
+HOOK_EOF
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -451,6 +451,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/simplify_mark_dirty.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PreToolUse": [
@@ -686,6 +696,11 @@
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/with-anthropic-key.sh $HOME/.claude/hooks/session_rename_auto.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/simplify_nudge.sh",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- Adds a PostToolUse hook (`simplify_mark_dirty.sh`, matcher `Write|Edit`) that marks the session dirty when a code file (by extension) changes.
- Adds a paired Stop hook (`simplify_nudge.sh`) that, if the session was marked dirty, nudges Claude via `hookSpecificOutput.additionalContext` to run the `simplify` skill before finishing the turn.
- Soft nudge only (per explicit user choice via AskUserQuestion) — never uses `decision: "block"`. Guards against the `additionalContext` loop-continuation mechanism via `stop_hook_active`, since that field goes through the same loop protections as a hard block.

## Test plan
- [x] Pipe-tested both scripts directly against synthesized stdin JSON (marker creation/filtering by code extension, nudge emission + marker consumption, `stop_hook_active` loop-guard suppression) — all cases passed.
- [x] `jq -e` validated both new hook entries resolve correctly in `claude/settings.json` (new `Write|Edit` PostToolUse matcher group; 4th entry in the existing `Stop` array).
- [x] Verified `claude/settings.json` still has `statusLine`, `hooks`, `permissions` keys per `.claude/rules/dotfiles-settings.md`.
- [ ] Manual: after deploying, edit a code file and confirm the Stop-hook nudge appears; confirm it's silent on doc-only edits.

https://claude.ai/code/session_01BpbLJrrgghjjQn68MVmzsJ