### PR TITLE
fix(dotfiles-secrets): EOF abort + bws ANSI-color JSON corruption

### DIFF
--- a/custom_bins/dotfiles-secrets
+++ b/custom_bins/dotfiles-secrets
@@ -156,7 +156,7 @@ load_secrets_cache_bws() {
     require_bws
     local json bws_stderr
     bws_stderr=$(mktemp "${TMPDIR:-/tmp}/bws_stderr.XXXXXX")
-    json=$(bws secret list 2>"$bws_stderr") || {
+    json=$(bws --color no secret list 2>"$bws_stderr") || {
         local err
         err=$(cat "$bws_stderr")
         rm -f "$bws_stderr"
@@ -423,7 +423,7 @@ write_telegram_env() {
 
 bws_project_id() {
     require_bws
-    bws project list 2>/dev/null | python3 -c '
+    bws --color no project list 2>/dev/null | python3 -c '
 import json, sys
 data = json.load(sys.stdin)
 if not data:
@@ -440,7 +440,7 @@ bws_find_secrets() {
     # found — callers must count lines to detect absence.
     local target_env="$1" exact_key="${2:-}"
     require_bws
-    bws secret list 2>/dev/null | python3 -c '
+    bws --color no secret list 2>/dev/null | python3 -c '
 import json, sys
 env_name = sys.argv[1]
 exact_key = sys.argv[2] if len(sys.argv) > 2 else ""
@@ -462,7 +462,7 @@ for s in data:
 
 bws_list_full() {
     require_bws
-    bws secret list 2>/dev/null | python3 -c '
+    bws --color no secret list 2>/dev/null | python3 -c '
 import json, sys, re
 data = json.load(sys.stdin)
 for s in data:
@@ -655,7 +655,10 @@ case "${1:-}" in
         [[ -n "$set_key" ]] || die "Usage: dotfiles-secrets set KEY [VALUE] [--note DESC]"
         if [[ -z "$set_value" ]]; then
             printf 'Value for %s: ' "$set_key" >&2
-            IFS= read -rs set_value
+            # read exits nonzero on EOF without a trailing newline (piped secret
+            # files rarely end in one) — `|| true` keeps set -e from aborting
+            # before the emptiness check below runs.
+            IFS= read -rs set_value || true
             echo "" >&2
         fi
         [[ -n "$set_value" ]] || die "Empty value"


### PR DESCRIPTION
## Summary
- Fix `dotfiles-secrets set`: `set -e` treated `read -rs`'s nonzero exit on EOF-without-trailing-newline (the normal case when piping a secret file in) as fatal, silently aborting before the empty-value check ever ran, with no error message printed.
- Fix `bws` JSON parsing: `bws`'s `--color auto` misdetects color support even when piped into `python3 -c 'json.load(sys.stdin)'`, wrapping the JSON in ANSI escape codes and breaking `bws_project_id`, `bws_find_secrets`, `bws_list_full`, and the secrets cache loader. Force `--color no` on every `bws` call whose output is parsed as JSON.

## Test plan
- [x] `bash -n custom_bins/dotfiles-secrets` — syntax check passes
- [x] Seeded `OBSIDIAN_AUTH_TOKEN`, `OBSIDIAN_ENCRYPTION_KEY`, `OBSIDIAN_ENCRYPTION_SALT` end-to-end via `dotfiles-secrets set KEY --note ...` piped from local files
- [x] Verified all three via `dotfiles-secrets keys`
- [x] Verified byte-identical round-trip via `dotfiles-secrets get-value` vs. original files (`cmp`)

https://claude.ai/code/session_0139VmN3a8q2wzqc1AtYcoop
