### PR TITLE
fix(deploy): guard associative-array lookup so extension sync can't abort deploy.sh

### DIFF
--- a/scripts/shared/helpers.sh
+++ b/scripts/shared/helpers.sh
@@ -1632,7 +1632,9 @@ install_editor_extensions() {
     typeset -a to_remove
     for ext in "${installed[@]}"; do
         [[ -z "$ext" ]] && continue
-        if [[ -z "${wanted_map[${ext:l}]}" ]]; then
+        # `:-` is required: under `set -u`, reading a missing associative-array key
+        # is a fatal zsh error (kills the whole script, not catchable with `||`).
+        if [[ -z "${wanted_map[${ext:l}]:-}" ]]; then
             to_remove+=("$ext")
         fi
     done


### PR DESCRIPTION
## Summary
- `install_editor_extensions` (scripts/shared/helpers.sh) read `wanted_map[${ext:l}]` without a `:-` default. Under `set -euo pipefail` (deploy.sh line 15), zsh treats reading a missing associative-array key as a **fatal, uncatchable error** — not a normal non-zero exit.
- Any editor extension installed but absent from `config/vscode_extensions.txt` triggered this, killing `deploy.sh` at the editor-settings step (~line 381 of 1340). The `|| log_warning "Editor settings deployment failed"` guard could not catch it, so the failure was silent — everything after that line (Finicky, Ghostty, Zed, gitui, Claude, Codex, Serena, Mouseless, Alfred repair, text replacements, all launchd/cron jobs) was skipped without any error message.
- Fix: add the `:-` default so a missing key reads as empty, matching the intended "not in wanted list → mark for removal" logic.
- Swept the other 3 associative arrays in the repo (`SSH_THEME_OVERRIDES`, `pids`, `git_settings`) — none have the same issue since they only read keys they iterate from the array's own key list.

## Test plan
- [x] Reproduced the exact zsh nounset failure standalone: `zsh -c 'set -euo pipefail; typeset -A m; m[foo]=1; for e in FOO BAR; do [[ -z "${m[${e:l}]}" ]] && echo miss; done; echo END'` dies before printing END.
- [x] Confirmed the `:-`-guarded form reaches the end under the same `set -euo pipefail`.
- [ ] Run `./deploy.sh --editor` end-to-end on a machine with an unlisted Cursor/VSCode extension installed, confirm it now completes deployment past the editor-settings step.