### PR TITLE
feat(skills): grill via AskUserQuestion instead of prose

### DIFF
--- a/claude/skills/grilling/SKILL.md
+++ b/claude/skills/grilling/SKILL.md
@@ -3,12 +3,16 @@ name: grilling
 description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or says "grill me", "grill this plan", "poke holes in this", or "play devil's advocate."
 ---
 
-Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one.
 
-Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+Put each question to me with the **AskUserQuestion** tool, **one question per call** — asking several at once is bewildering. Your recommended answer is the first option, labelled `(Recommended)`; the rest are the live alternatives, and the automatic `Other` catches whatever you missed.
 
-If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+I have asked you to make these calls, so override AskUserQuestion's usual "only when genuinely blocked" instinct: never skip a question because a sensible default exists. The default is your first option, not a reason to stay quiet.
+
+For open-ended probes ("what failure mode worries you most?"), synthesise 2-4 candidate answers rather than falling back to prose. Ask in plain text only when the answer space is genuinely unbounded — paste an error, name a file. When the question compares two concrete artifacts (schemas, API shapes, framings), put each on an option's `preview` (single-select only) so I can see them side by side.
+
+If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine.
 
 Do not act on it until I confirm we have reached a shared understanding.
 
-<!-- Source: mattpocock/skills@9603c1c (skills/productivity/grilling) -->
+<!-- Source: mattpocock/skills@9603c1c (skills/productivity/grilling) — modified locally: AskUserQuestion flow -->


### PR DESCRIPTION
`/grill-me` now puts each decision to the user through the **AskUserQuestion** tool instead of prose questions.

## What changed

`claude/skills/grilling/SKILL.md` — the file `/grill-me` delegates to (the wrapper's entire body is "Run a `/grilling` session.", so duplicating the flow there would drift). This also changes the model-invoked path ("poke holes in this").

| Existing rule | How it maps onto AskUserQuestion |
|---|---|
| One question at a time | One question per tool call (the tool permits 4 — the skill says use one) |
| Provide your recommended answer | First option, labelled `(Recommended)` |
| Look facts up, don't ask | Unchanged |
| Don't act until confirmed | Unchanged — the tool doesn't replace the final confirmation |

## The line that matters

AskUserQuestion's own guidance says to reserve it for decisions you "cannot resolve from the request, the code, or sensible defaults." A grilling session deliberately asks *even where a default exists* — that's the point. Without an explicit override the skill would ask three questions instead of twenty and quietly stop grilling, so it now states that the default goes in the first option rather than being a reason to stay quiet.

Also added: synthesise 2-4 candidates for open-ended probes rather than dropping to prose (plain text only when the answer space is genuinely unbounded), and use `preview` when comparing two concrete artifacts side by side.

The upstream source comment is kept but marked locally modified, so a future upstream sync doesn't silently revert this.

## Verification

Not exercised end-to-end — `~/.claude/` symlinks the **main** checkout, so `/grill-me` can't be run from this worktree. Checked: frontmatter still parses with `name`/`description`, the `grill-me` wrapper is untouched and still delegates, file reads back as intended. Net +8/-4 lines.

https://claude.ai/code/session_01YX9esS31paGduGnfQbWPHg
