### PR TITLE
feat: /wrap-up skill + AskUserQuestion rule + tmux-resume literal-step fix

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -178,6 +178,7 @@ Behavioral rules that apply to every session are in `~/.claude/rules/`:
 - `rules/communication-style.md` — Drafting messages on the user's behalf: friendliness, clarity, persuasiveness
 - `rules/effortful-learning.md` — Scoping gate for debugging/design/research decisions (mirrors the output style)
 - `rules/fable-second-opinion.md` — When to spawn a Fable subagent (`model: "fable"`) for a second opinion: stuck loops, hard/ambiguous problems, high-stakes conclusions
+- `rules/background-job-questions.md` — In a background job, every decision point must go through `AskUserQuestion`; a prose question never reaches the user
 
 ## Knowledge Docs (On-Demand)
 

--- a/claude/agents/context-fetcher.md
+++ b/claude/agents/context-fetcher.md
@@ -27,7 +27,7 @@ If multiple threads, lead with the most recent or most action-requiring. Cap at 
    - Gmail: `search_threads` with `from:<name>` or `<name>` and `newer_than:60d`
    - Slack: `slack_search_public_and_private` with `from:<name>` or the name as keyword
    - Granola (if they're likely an internal contact): `query_granola_meetings` for the name
-2. If multiple people match the name, pick based on recency. If ambiguous, note all candidates briefly and ask for disambiguation.
+2. If multiple people match the name, pick based on recency. If genuinely ambiguous, return **all** candidates briefly, each with its distinguishing signal (org, last-contact date, channel), and lead your response with `AMBIGUOUS:` so the caller disambiguates. Do **not** try to ask the user yourself — `AskUserQuestion` is not in your tool list, so a question you write is text your caller reads, not a prompt anyone sees. The caller owns the question; you own the candidate list.
 3. For the top thread, optionally fetch full content only if the snippet is insufficient.
 4. Synthesize the summary in the format above.
 

--- a/claude/rules/background-job-questions.md
+++ b/claude/rules/background-job-questions.md
@@ -1,0 +1,31 @@
+# Asking Questions From Background Jobs
+
+## The Rule
+
+**In a background job, every decision point MUST go through `AskUserQuestion`. A question written as prose does not reach the user.**
+
+Background jobs (`claude --agent`, detached daemon sessions, anything in `~/.claude/jobs/`) render their text into a job list the user reads later, if at all. `AskUserQuestion` fires a notification; prose does not. A prose question in a background job is therefore not a question — it is a session that has silently stopped, indistinguishable from a stall, and it is the mechanism by which jobs pile up in `blocked` with nobody aware a decision was owed.
+
+## What This Means Concretely
+
+| Situation | Wrong | Right |
+|---|---|---|
+| One genuine decision to make | "Which would you prefer — A or B?" then stop | `AskUserQuestion` with A and B as options |
+| Several decisions, interviewing (`/grill-me`) | Numbered list of questions in prose | One `AskUserQuestion` per decision, sequentially, waiting for each |
+| A reasonable default exists | Ask anyway | Take the default, state the assumption in your narration, keep working |
+| Genuinely blocked on access you can't grant | Prose explanation and stop | `AskUserQuestion`, then `needs input:` on its own line |
+
+The escape hatch is not "ask in prose instead" — it is **don't ask**. Make the call, say which assumption you took, and continue. A background job's whole value is that it runs without supervision; a round-trip you didn't need costs more than a guess you can label.
+
+## Applies To The Whole Class
+
+This is not only about literal questions. Any output whose purpose is to *elicit a response* — a confirmation request, an "OK to proceed?", a menu of options, a request to review before continuing — MUST be an `AskUserQuestion` call in a background job, or must not be emitted at all.
+
+## Foreground Sessions
+
+In an interactive session the user is present and prose questions do reach them, so `AskUserQuestion` is a formatting choice rather than a requirement. Prefer it anyway when the answer is a pick from a small option set: it records the choice as structured data and lets the user answer with one keystroke.
+
+## Related
+
+- The `grilling` skill's one-question-at-a-time discipline composes with this: one question at a time, each one an `AskUserQuestion` call
+- `rules/workflow-defaults.md` § Config-First Responses — why this is a rule file and not a memory entry

--- a/claude/rules/background-job-questions.md
+++ b/claude/rules/background-job-questions.md
@@ -4,7 +4,7 @@
 
 **In a background job, every decision point MUST go through `AskUserQuestion`. A question written as prose does not reach the user.**
 
-Background jobs (`claude --agent`, detached daemon sessions, anything in `~/.claude/jobs/`) render their text into a job list the user reads later, if at all. `AskUserQuestion` fires a notification; prose does not. A prose question in a background job is therefore not a question — it is a session that has silently stopped, indistinguishable from a stall, and it is the mechanism by which jobs pile up in `blocked` with nobody aware a decision was owed.
+Background jobs (`claude --bg` / `--background`, detached daemon sessions, anything in `~/.claude/jobs/`) render their text into a job list the user reads later, if at all. `AskUserQuestion` fires a notification; prose does not. A prose question in a background job is therefore not a question — it is a session that has silently stopped, indistinguishable from a stall, and it is the mechanism by which jobs pile up in `blocked` with nobody aware a decision was owed.
 
 ## What This Means Concretely
 

--- a/claude/rules/background-job-questions.md
+++ b/claude/rules/background-job-questions.md
@@ -12,10 +12,19 @@ Background jobs (`claude --agent`, detached daemon sessions, anything in `~/.cla
 |---|---|---|
 | One genuine decision to make | "Which would you prefer — A or B?" then stop | `AskUserQuestion` with A and B as options |
 | Several decisions, interviewing (`/grill-me`) | Numbered list of questions in prose | One `AskUserQuestion` per decision, sequentially, waiting for each |
-| A reasonable default exists | Ask anyway | Take the default, state the assumption in your narration, keep working |
+| A **scoped, low-risk, reversible** default exists | Ask anyway | Take the default, state the assumption in your narration, keep working |
+| An **unscoped** choice — the design, framing, or approach itself — where one option merely *looks* like the default | Decide autonomously because a default is available | `AskUserQuestion`. Looking like a default is not the same as being one |
 | Genuinely blocked on access you can't grant | Prose explanation and stop | `AskUserQuestion`, then `needs input:` on its own line |
 
 The escape hatch is not "ask in prose instead" — it is **don't ask**. Make the call, say which assumption you took, and continue. A background job's whole value is that it runs without supervision; a round-trip you didn't need costs more than a guess you can label.
+
+**The escape hatch is bounded, and the bound is load-bearing.** It covers decisions that are scoped, low-risk, and reversible — those, and nothing else. It does not license deciding unscoped, irreversible, or security-sensitive questions just because the job is unattended and one option looks obvious. `CLAUDE.md` § Decision Engagement makes scoping the primary gate precisely because *stakes* is the seductive axis: a decision can be low-stakes and still be the user's to make, and running unsupervised makes a wrong autonomous call *harder* to catch, not easier. When the two readings conflict, the narrower one wins: ask.
+
+## Subagents Without The Tool
+
+A custom agent's `tools:` allowlist may exclude `AskUserQuestion` (e.g. `agents/context-fetcher.md`). Such an agent **cannot** comply with the rule above and must not try: anything it writes as a question is text its *caller* reads, not a prompt the user ever sees, so it would block or fail while looking like it asked.
+
+The rule for those agents is a **handoff, not a question**: return the decision — options, distinguishing detail, and a recommendation — as structured output, flagged so the caller can spot it (`AMBIGUOUS:` or similar). The caller, which does have the tool, raises it. The obligation to surface the decision is unchanged; only who calls the tool moves. When writing a new custom agent, decide deliberately which of the two it is, and say so in its process section.
 
 ## Applies To The Whole Class
 

--- a/claude/skills/catalog/SKILL.md
+++ b/claude/skills/catalog/SKILL.md
@@ -19,6 +19,7 @@ Most skills below are **model-invoked**: Claude fires them automatically when yo
 | `commit-push-sync` | "commit and push", "sync changes", "update remote" |
 | `merge-worktree` | "merge this worktree", "merge my branch back", "finish this worktree" |
 | `finishing-a-development-branch` | Implementation is done, tests pass, deciding merge/PR/cleanup |
+| `wrap-up` | A session needs to reach a terminal state — land it as a draft PR, state the blocker, or say it's done (dotfiles trial) |
 | `diagnosing-bugs` | "diagnose"/"debug this", something broken/throwing/failing/slow |
 | `mv-repo` | Moving a repo to a new directory (venv, project state, tmux sessions) |
 | `migrate-to-codex` | Migrating instructions/skills/agents/MCP config into Codex |

--- a/claude/skills/wrap-up/SKILL.md
+++ b/claude/skills/wrap-up/SKILL.md
@@ -24,10 +24,12 @@ The hourly nudge in `config/tmux-resume-patterns.conf` sends a bare `continue`. 
 This skill is being trialled on `dotfiles` only. Before anything else:
 
 ```bash
-git rev-parse --show-toplevel 2>/dev/null
+basename "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")"
 ```
 
-**If the repo root's basename is not `dotfiles`** (including any worktree under `dotfiles/.claude/worktrees/`), stop immediately. Print one line — `wrap-up: out of trial scope (<repo>), no action taken` — and end your turn without touching the working tree. Do not fall back to `continue`. Do not do the work "just this once."
+**If that basename is not `dotfiles`**, stop immediately. Print one line — `wrap-up: out of trial scope (<repo>), no action taken` — and end your turn without touching the working tree. Do not fall back to `continue`. Do not do the work "just this once."
+
+Use `--git-common-dir`, not `--show-toplevel`. In a linked worktree (`cw`, `claude --worktree`) `--show-toplevel` returns the *worktree* path, whose basename is the worktree's name — `agent-sprawl-spec`, not `dotfiles` — so a `show-toplevel` test excludes every branch worktree, which is where most sessions actually live. `--git-common-dir` resolves to the owning repo's `.git` in both a worktree and the root checkout, so its parent's basename is the repo name either way. Worktrees are in scope: they are the intended home for a wrap-up commit, since Step 2 forbids committing on `main`.
 
 This guard exists because the nudge fires against every pane the scheduler can see, and the pattern file has no per-repo field. The skill is the only place scoping can live right now.
 
@@ -51,8 +53,10 @@ Pick exactly one. The classification decides everything downstream, so get it ri
 2. **Stage by name**: `git add <path> <path> …`, including new files this session created. Never `git add -u` (it sweeps up every tracked edit in the tree, including someone else's) and never `git add -A` (it also stages the sandbox's char-device masks). A blanket untracked ban is equally wrong in the other direction — it silently drops the session's own new files and the run ends having landed nothing.
 3. **Verify before committing**: `git diff --cached --name-only` must match your list exactly, nothing extra. Anything modified that you cannot attribute to this session stays unstaged; name it in the PR body so the owner knows it is there. If you cannot attribute the changes at all, stop and go to Step 3 — an unattributable diff is a decision for the owner, not a commit.
 4. Commit with a real message that says *why*, not just what. No heredocs — write to `/tmp/claude/<job>-msg.txt` and `git commit -F`.
-5. If the branch is ahead of `main` and the tree is clean, push and open a **draft** PR (`gh pr create --draft`). Never push to `main`, never force-push, never merge.
-6. Rename the session (Step 5), then **end your turn.**
+5. **If the branch is ahead of `main`, push and open a draft PR — a dirty tree does not excuse skipping this.** the staging rule above deliberately leaves unattributable edits unstaged, so a dirty tree is the *expected* end state, not an error; gating the push on cleanliness would mean the common case commits locally, exits "done", and leaves the work invisible on a machine nobody looks at. Push the commit; mention the leftover unstaged paths in the PR body. Never push to `main`, never force-push, never merge.
+6. **The PR command must be non-interactive.** `gh pr create --draft` alone prompts for title and body, and an unattended job has no way to answer — it hangs or dies before it can terminate, which is the exact failure this skill exists to prevent. Always supply both: `gh pr create --draft --title "<subject>" --body-file /tmp/claude/<job>-pr.md`. (`--fill` works too, but it derives the body from commit messages and loses the leftover-paths note.)
+7. If push or PR creation fails — no remote, auth expired, a protected branch — do **not** exit as done. The commit exists but nobody can see it, which is indistinguishable from the pile-up this skill was written to stop. Classify as **blocked** (Step 3), name the failure, and say where the commit is.
+8. Rename the session (Step 5), then **end your turn.**
 
 If tests exist and you have not run them, run them and report the result plainly in the PR body. A failing suite does not block landing a draft PR — it blocks claiming the work is finished. Say which it is.
 
@@ -65,9 +69,11 @@ This is the branch that matters most. Produce, in this order:
 3. **Your recommendation**, with one sentence of reasoning.
 4. **What it gates** — what stays stuck until this is answered.
 
-Then surface it via **`AskUserQuestion`**, not prose. This session is a background job; prose questions do not notify the owner, and an unnotified question is indistinguishable from no question at all. See `rules/background-job-questions.md`.
+**Order matters: rename first, ask second.** Do the Step 5 rename (`blocked: <one-line decision>`) and write the four items above into your narration *before* calling `AskUserQuestion`. `AskUserQuestion` is synchronous — if the owner does not answer, it does not return, and every instruction after it is unreachable. Put the rename after the call and an unanswered question leaves the session sitting under its old name with the blocker recorded nowhere: exactly the invisible-stall state this skill exists to eliminate, now produced by the skill itself. Renaming first means the disposition survives regardless of whether an answer ever arrives.
 
-Then rename the session (Step 5) and **end your turn.**
+Then surface the decision via **`AskUserQuestion`**, not prose. This session is a background job; prose questions do not notify the owner, and an unnotified question is indistinguishable from no question at all. See `rules/background-job-questions.md`.
+
+Write `needs input:` on its own line. If the call returns with an answer, act on it. If it never returns, the session is already named and the blocker already stated — that is the correct terminal state, not a failure.
 
 > **Never choose on the owner's behalf in order to look finished.** A stalled session is visibly stalled and costs an hour. A silently-wrong autonomous choice is invisible and lands in `main`. This constraint is not negotiable for the sake of a tidier job list — if you are unsure whether a call is yours, it is not yours.
 

--- a/claude/skills/wrap-up/SKILL.md
+++ b/claude/skills/wrap-up/SKILL.md
@@ -16,11 +16,11 @@ You have been woken by the hourly `tmux-resume` nudge, not by a human. Something
 
 ## Why this exists
 
-The hourly nudge in `config/tmux-resume-patterns.conf` sends a bare `continue`. `continue` has no exit branch, so sessions resume hourly forever and accumulate: 101 of 157 jobs on this machine were hourly `continue` nudges, and 56 sessions sat blocked on a human decision that was never surfaced. Fixing the inflow means the nudge must be able to *end* a session.
+The hourly nudge in `config/tmux-resume-patterns.conf` used to send a bare `continue`. `continue` has no exit branch, so sessions resume hourly forever and accumulate: 101 of 157 jobs on this machine were hourly `continue` nudges, and 56 sessions sat blocked on a human decision that was never surfaced. Fixing the inflow means the nudge must be able to *end* a session — so the nudge now types `/wrap-up` instead.
 
-**Status: the config still sends `continue`.** Repointing it is blocked on capturing the exact wording of a real rate-limit prompt, so this skill is currently reachable only by typing `/wrap-up` yourself. That is deliberate — the alternative was guessing a match pattern, and a wrong guess ships a nudge that silently never fires.
+**Status: the nudge is wired, the keystrokes are not yet confirmed.** Detection anchors on rate-limit wordings captured from real prompts, but the *action* — `1 Enter`, then `/wrap-up`, then two `Enter`s — has never been fired at a live prompt, because a sandboxed session cannot open a tmux socket. Both guesses are marked as such in the pattern file and are settled by one `tmux-resume --dry-run` against a real rate-limited pane.
 
-That gate is enforced by `disable-model-invocation: true` in the frontmatter, not by this paragraph. Omitting it makes a skill model-invoked (see `claude/skills/writing-great-skills/SKILL.md` § Invocation), which would let a matching dotfiles prompt fire an autonomous commit-and-push path before the nudge itself has ever been verified against a real rate-limit prompt. Discovery during the trial is via `claude/skills/catalog/SKILL.md`. Drop the flag only when the nudge is wired up and trusted.
+**`disable-model-invocation: true` stays on regardless.** It makes this skill reachable only by someone typing `/wrap-up` — and the nudge sending those keystrokes *is* that invocation, so wiring the nudge is not a reason to drop the flag. Omitting it would instead make the skill model-invoked (see `claude/skills/writing-great-skills/SKILL.md` § Invocation), letting any matching dotfiles prompt fire an autonomous commit-and-push path with no nudge involved at all. That is a different and much wider trigger surface than the one being trialled here. Discovery during the trial is via `claude/skills/catalog/SKILL.md`.
 
 ## Step 0: Scope guard (required first)
 
@@ -30,7 +30,9 @@ This skill is being trialled on `dotfiles` only. Before anything else:
 basename "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")"
 ```
 
-**If that basename is not `dotfiles`**, stop immediately. Print one line — `wrap-up: out of trial scope (<repo>), no action taken` — and end your turn without touching the working tree. Do not fall back to `continue`. Do not do the work "just this once."
+**If that basename is not `dotfiles`**, do none of the steps below. Print one line — `wrap-up: out of trial scope (<repo>), resuming prior task` — and then **carry on with whatever the session was already doing**, exactly as a bare `continue` would have. Do not do the wrap-up work "just this once."
+
+That fall-back is deliberate and load-bearing. The nudge in `config/tmux-resume-patterns.conf` no longer sends `continue` — it sends `/wrap-up` — so this branch is what every rate-limited pane *outside* dotfiles now lands on. Stopping dead here would strand those panes mid-work with no PR, no blocker stated, and no rename; and because a resumed pane stops displaying a rate-limit banner, no row would match on the next hourly scan to retry. That is strictly worse than the `continue` it replaced, and it is the same shape as the detect-only regression this PR already had to fix once. A trial scoped to `dotfiles` must not change behaviour outside `dotfiles`.
 
 Use `--git-common-dir`, not `--show-toplevel`. In a linked worktree (`cw`, `claude --worktree`) `--show-toplevel` returns the *worktree* path, whose basename is the worktree's name — `agent-sprawl-spec`, not `dotfiles` — so a `show-toplevel` test excludes every branch worktree, which is where most sessions actually live. `--git-common-dir` resolves to the owning repo's `.git` in both a worktree and the root checkout, so its parent's basename is the repo name either way. Worktrees are in scope: they are the intended home for a wrap-up commit, since Step 2 forbids committing on `main`.
 
@@ -120,7 +122,7 @@ Keep `<topic>` to two or three words. If `tmux rename-window` fails (no tmux, de
 |---|---|
 | "I'll just keep going, I'm close" | That is what `continue` did 101 times. Classify and terminate. |
 | "I'll pick the sensible option and note it" | Step 3 exists precisely to stop this. Surface it. |
-| "This repo isn't dotfiles but the work is obviously fine" | Step 0 is a hard stop. The trial scope is the point. |
+| "This repo isn't dotfiles but the work is obviously fine" | Step 0 is a hard stop *on the wrap-up steps*. The trial scope is the point. Announce out-of-scope, resume the prior task, and do none of the steps below it. |
 | "I'll commit everything to be safe" | Stage the paths you touched, by name. `git add -u` commits other people's work; `git add -A` also stages sandbox char-device masks. |
 | "I'm on `main` but the change is small" | Step 2's precondition is a hard stop. Unattended commits onto `main` are exactly what the draft-PR flow exists to prevent. |
 | "I'll just switch the checkout to a branch first" | Only in a linked worktree. In the root checkout that moves HEAD for every other pane and cron job pointed at it. |

--- a/claude/skills/wrap-up/SKILL.md
+++ b/claude/skills/wrap-up/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: wrap-up
+description: Use when an hourly nudge asks a stalled session to conclude - drives a session to a terminating end state (land the work, state the blocker, or take one step) instead of continuing indefinitely
+---
+
+# Wrap Up
+
+## Overview
+
+You have been woken by the hourly `tmux-resume` nudge, not by a human. Something in this session hit a rate limit and the scheduler is prompting you to resume.
+
+**Your job is to reach an end state, not to keep working.** Every branch below terminates. If you finish this skill still working, you have used it wrong.
+
+**Announce at start:** "Using the wrap-up skill to bring this session to a close."
+
+## Why this exists
+
+The hourly nudge in `config/tmux-resume-patterns.conf` sends a bare `continue`. `continue` has no exit branch, so sessions resume hourly forever and accumulate: 101 of 157 jobs on this machine were hourly `continue` nudges, and 56 sessions sat blocked on a human decision that was never surfaced. Fixing the inflow means the nudge must be able to *end* a session.
+
+**Status: the config still sends `continue`.** Repointing it is blocked on capturing the exact wording of a real rate-limit prompt, so this skill is currently reachable only by typing `/wrap-up` yourself. That is deliberate — the alternative was guessing a match pattern, and a wrong guess ships a nudge that silently never fires.
+
+## Step 0: Scope guard (required first)
+
+This skill is being trialled on `dotfiles` only. Before anything else:
+
+```bash
+git rev-parse --show-toplevel 2>/dev/null
+```
+
+**If the repo root's basename is not `dotfiles`** (including any worktree under `dotfiles/.claude/worktrees/`), stop immediately. Print one line — `wrap-up: out of trial scope (<repo>), no action taken` — and end your turn without touching the working tree. Do not fall back to `continue`. Do not do the work "just this once."
+
+This guard exists because the nudge fires against every pane the scheduler can see, and the pattern file has no per-repo field. The skill is the only place scoping can live right now.
+
+## Step 1: Classify honestly
+
+Pick exactly one. The classification decides everything downstream, so get it right before acting.
+
+| State | Test | Go to |
+|---|---|---|
+| **Done** | The work the session was asked to do is complete, or complete enough to land behind review | Step 2 |
+| **Blocked** | Progress requires a decision, credential, or approval only the owner can give | Step 3 |
+| **Mid-flight** | There is a concrete next step you can take alone, right now, without a decision | Step 4 |
+
+**The honest classification is usually "blocked."** If you find yourself reasoning toward "mid-flight" because it feels more productive, re-read the blocked test. A session that invents a next step to avoid stating a blocker is the exact failure this skill was written to stop.
+
+## Step 2: Done — land it and exit
+
+1. Verify the tree: `git status --porcelain`. Never stage untracked files; use `git add -u` only, and only after confirming the index is otherwise clean (`git diff --cached --name-only`).
+2. Commit with a real message that says *why*, not just what. No heredocs — write to `/tmp/claude/<job>-msg.txt` and `git commit -F`.
+3. If the branch is ahead of `main` and the tree is clean, push and open a **draft** PR (`gh pr create --draft`). Never push to `main`, never force-push, never merge.
+4. Rename the session (Step 5), then **end your turn.**
+
+If tests exist and you have not run them, run them and report the result plainly in the PR body. A failing suite does not block landing a draft PR — it blocks claiming the work is finished. Say which it is.
+
+## Step 3: Blocked — state the decision and exit
+
+This is the branch that matters most. Produce, in this order:
+
+1. **The decision**, in one sentence, phrased as a question.
+2. **The options**, each with its real tradeoff — not a strawman and a favourite.
+3. **Your recommendation**, with one sentence of reasoning.
+4. **What it gates** — what stays stuck until this is answered.
+
+Then surface it via **`AskUserQuestion`**, not prose. This session is a background job; prose questions do not notify the owner, and an unnotified question is indistinguishable from no question at all. See `rules/background-job-questions.md`.
+
+Then rename the session (Step 5) and **end your turn.**
+
+> **Never choose on the owner's behalf in order to look finished.** A stalled session is visibly stalled and costs an hour. A silently-wrong autonomous choice is invisible and lands in `main`. This constraint is not negotiable for the sake of a tidier job list — if you are unsure whether a call is yours, it is not yours.
+
+## Step 4: Mid-flight — one step, then land or state
+
+Take **one** concrete step. Not a work session — one step, the one you already knew you needed.
+
+Then re-classify against Step 1 and follow Step 2 or Step 3. You may not return to Step 4 twice in a row: if the next nudge finds you mid-flight again, treat that as evidence you are actually blocked and go to Step 3.
+
+## Step 5: Rename so the list is readable
+
+The jobs list shows `nameSource: "auto"` names that say nothing about outcome, which is why 157 entries are unreadable at a glance. Set the tmux window name to encode disposition:
+
+```bash
+tmux rename-window "done-<topic>"      # landed, PR open or committed
+tmux rename-window "blocked-<topic>"   # question surfaced, awaiting the owner
+```
+
+Keep `<topic>` to two or three words. If `tmux rename-window` fails (no tmux, detached), skip it — it is a legibility nicety, not a correctness step, and it must never abort a wrap-up.
+
+**Known limitation, stated rather than papered over:** this renames the *tmux window*, which is what you see in a terminal. The `name` field in `~/.claude/jobs/<id>/state.json` — what the agents list reads — is not writable from inside a session, and the sandbox denies writes under `~/.claude/jobs` regardless. So this improves tmux legibility only. Closing the gap for the agents list needs a change outside this skill.
+
+## Anti-patterns
+
+| Thought | Reality |
+|---|---|
+| "I'll just keep going, I'm close" | That is what `continue` did 101 times. Classify and terminate. |
+| "I'll pick the sensible option and note it" | Step 3 exists precisely to stop this. Surface it. |
+| "This repo isn't dotfiles but the work is obviously fine" | Step 0 is a hard stop. The trial scope is the point. |
+| "I'll commit everything to be safe" | Untracked files never get staged. `git add -u`, index verified clean first. |
+| "No blocker, so I'll invent a next step" | Re-read Step 1. Inventing work to avoid stating a blocker is the failure mode. |
+| "I'll ask in prose, the owner will see it" | Background jobs do not notify on prose. `AskUserQuestion` or it did not happen. |

--- a/claude/skills/wrap-up/SKILL.md
+++ b/claude/skills/wrap-up/SKILL.md
@@ -45,10 +45,14 @@ Pick exactly one. The classification decides everything downstream, so get it ri
 
 ## Step 2: Done — land it and exit
 
-1. Verify the tree: `git status --porcelain`. Never stage untracked files; use `git add -u` only, and only after confirming the index is otherwise clean (`git diff --cached --name-only`).
-2. Commit with a real message that says *why*, not just what. No heredocs — write to `/tmp/claude/<job>-msg.txt` and `git commit -F`.
-3. If the branch is ahead of `main` and the tree is clean, push and open a **draft** PR (`gh pr create --draft`). Never push to `main`, never force-push, never merge.
-4. Rename the session (Step 5), then **end your turn.**
+**Precondition, before anything is staged: check the branch.** `git rev-parse --abbrev-ref HEAD`. If it is `main` or `master`, you may not commit. "Never push to `main`" suppresses only the *push* — committing first still lands a direct local commit on `main` with no review path, and the nudge runs unattended in whatever checkout the pane happened to be in. Either move the work to a branch (`git switch -c wrap-up/<topic>`) if it is unambiguously this session's, or classify as **blocked** (Step 3) and say the tree holds work you could not safely land. There is no third option.
+
+1. **List the paths this session touched**, from your own transcript — not from `git status`. A shared checkout can hold edits from the user, a runtime process, or another job running concurrently, and none of those are yours to commit.
+2. **Stage by name**: `git add <path> <path> …`, including new files this session created. Never `git add -u` (it sweeps up every tracked edit in the tree, including someone else's) and never `git add -A` (it also stages the sandbox's char-device masks). A blanket untracked ban is equally wrong in the other direction — it silently drops the session's own new files and the run ends having landed nothing.
+3. **Verify before committing**: `git diff --cached --name-only` must match your list exactly, nothing extra. Anything modified that you cannot attribute to this session stays unstaged; name it in the PR body so the owner knows it is there. If you cannot attribute the changes at all, stop and go to Step 3 — an unattributable diff is a decision for the owner, not a commit.
+4. Commit with a real message that says *why*, not just what. No heredocs — write to `/tmp/claude/<job>-msg.txt` and `git commit -F`.
+5. If the branch is ahead of `main` and the tree is clean, push and open a **draft** PR (`gh pr create --draft`). Never push to `main`, never force-push, never merge.
+6. Rename the session (Step 5), then **end your turn.**
 
 If tests exist and you have not run them, run them and report the result plainly in the PR body. A failing suite does not block landing a draft PR — it blocks claiming the work is finished. Say which it is.
 
@@ -93,6 +97,7 @@ Keep `<topic>` to two or three words. If `tmux rename-window` fails (no tmux, de
 | "I'll just keep going, I'm close" | That is what `continue` did 101 times. Classify and terminate. |
 | "I'll pick the sensible option and note it" | Step 3 exists precisely to stop this. Surface it. |
 | "This repo isn't dotfiles but the work is obviously fine" | Step 0 is a hard stop. The trial scope is the point. |
-| "I'll commit everything to be safe" | Untracked files never get staged. `git add -u`, index verified clean first. |
+| "I'll commit everything to be safe" | Stage the paths you touched, by name. `git add -u` commits other people's work; `git add -A` also stages sandbox char-device masks. |
+| "I'm on `main` but the change is small" | Step 2's precondition is a hard stop. Unattended commits onto `main` are exactly what the draft-PR flow exists to prevent. |
 | "No blocker, so I'll invent a next step" | Re-read Step 1. Inventing work to avoid stating a blocker is the failure mode. |
 | "I'll ask in prose, the owner will see it" | Background jobs do not notify on prose. `AskUserQuestion` or it did not happen. |

--- a/claude/skills/wrap-up/SKILL.md
+++ b/claude/skills/wrap-up/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: wrap-up
-description: Use when an hourly nudge asks a stalled session to conclude - drives a session to a terminating end state (land the work, state the blocker, or take one step) instead of continuing indefinitely
+description: Drives a stalled session to a terminating end state - land the work, state the blocker, or take one step (dotfiles trial, manual-only)
+disable-model-invocation: true
 ---
 
 # Wrap Up
@@ -18,6 +19,8 @@ You have been woken by the hourly `tmux-resume` nudge, not by a human. Something
 The hourly nudge in `config/tmux-resume-patterns.conf` sends a bare `continue`. `continue` has no exit branch, so sessions resume hourly forever and accumulate: 101 of 157 jobs on this machine were hourly `continue` nudges, and 56 sessions sat blocked on a human decision that was never surfaced. Fixing the inflow means the nudge must be able to *end* a session.
 
 **Status: the config still sends `continue`.** Repointing it is blocked on capturing the exact wording of a real rate-limit prompt, so this skill is currently reachable only by typing `/wrap-up` yourself. That is deliberate — the alternative was guessing a match pattern, and a wrong guess ships a nudge that silently never fires.
+
+That gate is enforced by `disable-model-invocation: true` in the frontmatter, not by this paragraph. Omitting it makes a skill model-invoked (see `claude/skills/writing-great-skills/SKILL.md` § Invocation), which would let a matching dotfiles prompt fire an autonomous commit-and-push path before the nudge itself has ever been verified against a real rate-limit prompt. Discovery during the trial is via `claude/skills/catalog/SKILL.md`. Drop the flag only when the nudge is wired up and trusted.
 
 ## Step 0: Scope guard (required first)
 
@@ -47,18 +50,33 @@ Pick exactly one. The classification decides everything downstream, so get it ri
 
 ## Step 2: Done — land it and exit
 
-**Precondition, before anything is staged: check the branch.** `git rev-parse --abbrev-ref HEAD`. If it is `main` or `master`, you may not commit. "Never push to `main`" suppresses only the *push* — committing first still lands a direct local commit on `main` with no review path, and the nudge runs unattended in whatever checkout the pane happened to be in. Either move the work to a branch (`git switch -c wrap-up/<topic>`) if it is unambiguously this session's, or classify as **blocked** (Step 3) and say the tree holds work you could not safely land. There is no third option.
+**Precondition, before anything is staged: check the branch *and* the checkout.**
 
+```bash
+git rev-parse --abbrev-ref HEAD
+[ "$(git rev-parse --git-dir)" = "$(git rev-parse --git-common-dir)" ] && echo "root checkout" || echo "linked worktree"
+```
+
+If the branch is `main` or `master`, you may not commit. "Never push to `main`" suppresses only the *push* — committing first still lands a direct local commit on `main` with no review path, and the nudge runs unattended in whatever checkout the pane happened to be in.
+
+What you may do about it depends on which checkout you are in, because a branch switch is not a private act:
+
+| Checkout | On `main`/`master` | On a feature branch |
+|---|---|---|
+| **Linked worktree** (`cw`, `claude --worktree`) | `git switch -c wrap-up/<topic>` — the worktree owns its own HEAD, so nobody else is affected | Commit here |
+| **Root checkout** (`/home/yulong/code/dotfiles`) | **Classify blocked (Step 3).** Do not switch | Commit here, but still do not switch branches |
+
+**Never `git switch` in the root checkout.** A checkout has one HEAD shared by every pane, editor, and cron job pointed at it. Switching it to `wrap-up/<topic>` silently moves everyone else's working branch, so their next commit, pull, or `deploy.sh` runs against a branch they never chose — from their side it looks like the repo changed under them for no reason. Owning the *edits* does not mean owning the *checkout*. If the work genuinely needs to land, that is a decision for the owner: state it in Step 3 and say the tree holds work that needs a worktree to land safely.
+
+0. **Run the tests first, if any exist and you have not run them.** This has to happen before staging, not after: a test run can generate fixes or artifacts that belong in the commit, and the PR body created in item 6 is supposed to carry the result. A failing suite does not block landing a draft PR — it blocks *claiming the work is finished*. Report the outcome plainly in the PR body and say which of the two it is.
 1. **List the paths this session touched**, from your own transcript — not from `git status`. A shared checkout can hold edits from the user, a runtime process, or another job running concurrently, and none of those are yours to commit.
 2. **Stage by name**: `git add <path> <path> …`, including new files this session created. Never `git add -u` (it sweeps up every tracked edit in the tree, including someone else's) and never `git add -A` (it also stages the sandbox's char-device masks). A blanket untracked ban is equally wrong in the other direction — it silently drops the session's own new files and the run ends having landed nothing.
-3. **Verify before committing**: `git diff --cached --name-only` must match your list exactly, nothing extra. Anything modified that you cannot attribute to this session stays unstaged; name it in the PR body so the owner knows it is there. If you cannot attribute the changes at all, stop and go to Step 3 — an unattributable diff is a decision for the owner, not a commit.
+3. **Verify before committing — read the content, not just the names.** `git diff --cached --name-only` must match your list exactly, nothing extra. That is necessary but *not sufficient*: a path is not an ownership boundary. In a shared checkout, another actor can have edited a different hunk of a file you also touched, and `git add <path>` stages their hunk alongside yours while the name-only check still passes cleanly. So also read `git diff --cached` and confirm every hunk is one you recognise. If a hunk is not yours, `git restore --staged <path>` and leave that file out. Anything modified that you cannot attribute to this session stays unstaged; name it in the PR body so the owner knows it is there. If you cannot attribute the changes at all, stop and go to Step 3 — an unattributable diff is a decision for the owner, not a commit.
 4. Commit with a real message that says *why*, not just what. No heredocs — write to `/tmp/claude/<job>-msg.txt` and `git commit -F`.
 5. **If the branch is ahead of `main`, push and open a draft PR — a dirty tree does not excuse skipping this.** the staging rule above deliberately leaves unattributable edits unstaged, so a dirty tree is the *expected* end state, not an error; gating the push on cleanliness would mean the common case commits locally, exits "done", and leaves the work invisible on a machine nobody looks at. Push the commit; mention the leftover unstaged paths in the PR body. Never push to `main`, never force-push, never merge.
 6. **The PR command must be non-interactive.** `gh pr create --draft` alone prompts for title and body, and an unattended job has no way to answer — it hangs or dies before it can terminate, which is the exact failure this skill exists to prevent. Always supply both: `gh pr create --draft --title "<subject>" --body-file /tmp/claude/<job>-pr.md`. (`--fill` works too, but it derives the body from commit messages and loses the leftover-paths note.)
 7. If push or PR creation fails — no remote, auth expired, a protected branch — do **not** exit as done. The commit exists but nobody can see it, which is indistinguishable from the pile-up this skill was written to stop. Classify as **blocked** (Step 3), name the failure, and say where the commit is.
 8. Rename the session (Step 5), then **end your turn.**
-
-If tests exist and you have not run them, run them and report the result plainly in the PR body. A failing suite does not block landing a draft PR — it blocks claiming the work is finished. Say which it is.
 
 ## Step 3: Blocked — state the decision and exit
 
@@ -105,5 +123,7 @@ Keep `<topic>` to two or three words. If `tmux rename-window` fails (no tmux, de
 | "This repo isn't dotfiles but the work is obviously fine" | Step 0 is a hard stop. The trial scope is the point. |
 | "I'll commit everything to be safe" | Stage the paths you touched, by name. `git add -u` commits other people's work; `git add -A` also stages sandbox char-device masks. |
 | "I'm on `main` but the change is small" | Step 2's precondition is a hard stop. Unattended commits onto `main` are exactly what the draft-PR flow exists to prevent. |
+| "I'll just switch the checkout to a branch first" | Only in a linked worktree. In the root checkout that moves HEAD for every other pane and cron job pointed at it. |
+| "The file is on my list, so the staged diff is mine" | A path is not an ownership boundary. Read `git diff --cached`, not just `--name-only`. |
 | "No blocker, so I'll invent a next step" | Re-read Step 1. Inventing work to avoid stating a blocker is the failure mode. |
 | "I'll ask in prose, the owner will see it" | Background jobs do not notify on prose. `AskUserQuestion` or it did not happen. |

--- a/config/tmux-resume-patterns.conf
+++ b/config/tmux-resume-patterns.conf
@@ -6,10 +6,22 @@
 #                    lines. DO NOT prefix with `(?i)` — that is PCRE, not ERE;
 #                    grep -E matches it literally and breaks the pattern. The
 #                    `-i` flag already makes matching case-insensitive.
-#   send_sequence  : ';'-separated steps; each step's tokens are passed verbatim
-#                    to `tmux send-keys`. Type literal text as words ("continue");
-#                    use tmux key names for keys (Enter, Down, C-c). ~0.6s between
-#                    steps. Leave the field blank to detect-and-log only.
+#   send_sequence  : ';'-separated steps, ~0.6s apart. Leave blank to detect-and-log
+#                    only. Each step is one of:
+#                      unquoted  -> WORD-SPLIT into separate `tmux send-keys` key
+#                                   tokens. Correct for key names (Enter, Down,
+#                                   C-c) and for single words (continue).
+#                                   FOOTGUN: multi-word text LOSES its spaces here
+#                                   — `wrap up work` types as `wrapupwork`.
+#                      "quoted"  -> sent as LITERAL text via `send-keys -l`, so
+#                                   spaces survive. Key names are NOT interpreted,
+#                                   so send Enter as its own unquoted step:
+#                                     "wrap up the work" ; Enter
+#                                   Avoid a leading `-` inside the quotes; tmux
+#                                   would parse it as a flag.
+#
+#                    NOTE: a step is only literal if BOTH ends are `"`. Unquoted
+#                    remains the default, so every pre-existing row is unaffected.
 #
 # DESIGN: detection vs action are deliberately decoupled.
 #   - DETECTION (trigger_regex) anchors on the durable rate-limit *state* strings

--- a/config/tmux-resume-patterns.conf
+++ b/config/tmux-resume-patterns.conf
@@ -51,14 +51,27 @@
 # into a pane that is working fine. Two guards, both verified by test:
 #   - `resets? [A-Z]` was deliberately NOT added to cover "resets Jul 29". Under
 #     `-i` it matches any letter, so `git reset HEAD` would trip it. That wording
-#     is already covered by "weekly limit" on the detect-only row.
-#   - `rate limit` is bounded as `rate limit([^a-z]|$)` so it does not match
-#     "rate limiter configured with limit=500". `([^a-z]|$)` is used rather than
-#     `\b` because BSD grep on macOS does not reliably support `\b` in ERE.
+#     is already covered by "hit your weekly limit" on the detect-only row.
+#   - `rate limit` is bounded as `rate limit([^a-zA-Z]|$)` so it does not match
+#     "rate limiter configured with limit=500". Used rather than `\b` because BSD
+#     grep on macOS does not reliably support `\b` in ERE; the class spells out
+#     both cases rather than relying on `-i` to fold a NEGATED class, which is
+#     the one construct where BSD and GNU grep are most likely to differ.
 
 # Detect-only (empty send): a weekly/credit exhaustion can be days out, so nudging
 # hourly is ~55 no-op keystroke sequences into a pane that cannot proceed. First
 # match wins, so this row must stay ABOVE usage-limit to shadow it.
-weekly-limit | weekly limit|out of usage credits
+#
+# THIS ROW IS A SHADOW, SO ITS FALSE POSITIVES ARE THE WORST KIND — a pane that
+# matches here is never keystroked again, i.e. exactly the permanently stalled
+# session this whole mechanism exists to prevent. The two failure directions are
+# not symmetric: a false NEGATIVE here just falls through to hourly no-op nudging
+# (cheap), a false POSITIVE strands the pane (expensive). So match the captured
+# PHRASE "hit your weekly limit", never the bare noun "weekly limit" — the bare
+# form also matches `/usage` output or a banner reporting both windows, either of
+# which would strand a working pane. Not fixed by narrowing, and unfixable here:
+# a pane displaying THIS FILE matches whatever literals the rows contain. That is
+# inherent to a pattern config and applies to the action row equally.
+weekly-limit | hit your weekly limit|out of usage credits
 
-usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-z]|$)|resets? (at|on)|try again at | 1 Enter ; continue Enter
+usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-zA-Z]|$)|resets? (at|on)|try again at | 1 Enter ; continue Enter

--- a/config/tmux-resume-patterns.conf
+++ b/config/tmux-resume-patterns.conf
@@ -34,12 +34,31 @@
 #     the `Enter`; if there is no menu, drop `1 Enter ;` entirely; if the option
 #     is on a different number, change it. Verify against one real prompt first.
 #
-# Confidence tiers for the trigger phrases (only the high-confidence ones are live
-# below; add the others ONLY after a dry-run confirms they appear in your build):
-#   high   (claude): "usage limit reached", "5-hour limit reached", "resets at/on"
-#   high   (codex):  "rate limit", "weekly limit", "try again at"
-#   medium (don't assume present): "wait until reset", "resume after reset"
-#   low    (avoid):  "automatically resume", exact menu numbering/option wording
+# VERIFIED WORDINGS (captured from real prompts 2026-07-27). These drive the rows
+# below; anything not on this list is a guess and must be dry-run before adding:
+#   "Usage limit reached" / "You've hit your weekly limit · resets Jul 29, 3pm (UTC)"
+#   "Claude usage limit reached. Your limit will reset at ..."
+#   "Out of usage credits"
+#
+# WHY ONE ACTION ROW, NOT ONE PER HARNESS: rows are matched against the whole
+# N-line capture, first match wins. The old claude/codex split therefore selected
+# an ACTION by scrollback position, not by harness — the weekly wording above hit
+# the claude row only while its FIRST line was still inside the window, then fell
+# through to the codex row and got `continue` with no menu dismissal. Same pane,
+# same harness, different keystrokes. One action row removes that ambiguity.
+#
+# FALSE POSITIVES ARE THE EXPENSIVE FAILURE: a spurious match injects keystrokes
+# into a pane that is working fine. Two guards, both verified by test:
+#   - `resets? [A-Z]` was deliberately NOT added to cover "resets Jul 29". Under
+#     `-i` it matches any letter, so `git reset HEAD` would trip it. That wording
+#     is already covered by "weekly limit" on the detect-only row.
+#   - `rate limit` is bounded as `rate limit([^a-z]|$)` so it does not match
+#     "rate limiter configured with limit=500". `([^a-z]|$)` is used rather than
+#     `\b` because BSD grep on macOS does not reliably support `\b` in ERE.
 
-claude-code | usage limit reached|5-hour limit reached|resets? (at|on) | 1 Enter ; continue Enter
-codex       | rate limit|weekly limit|try again at                     | continue Enter
+# Detect-only (empty send): a weekly/credit exhaustion can be days out, so nudging
+# hourly is ~55 no-op keystroke sequences into a pane that cannot proceed. First
+# match wins, so this row must stay ABOVE usage-limit to shadow it.
+weekly-limit | weekly limit|out of usage credits
+
+usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-z]|$)|resets? (at|on)|try again at | 1 Enter ; continue Enter

--- a/config/tmux-resume-patterns.conf
+++ b/config/tmux-resume-patterns.conf
@@ -58,20 +58,20 @@
 #     both cases rather than relying on `-i` to fold a NEGATED class, which is
 #     the one construct where BSD and GNU grep are most likely to differ.
 
-# Detect-only (empty send): a weekly/credit exhaustion can be days out, so nudging
-# hourly is ~55 no-op keystroke sequences into a pane that cannot proceed. First
-# match wins, so this row must stay ABOVE usage-limit to shadow it.
+# DETECT-ONLY ROW (third field omitted — not left blank; the splitter needs ` | `
+# with spaces BOTH sides, so a trailing pipe would land inside the regex as an
+# empty alternative that matches every pane). Weekly/credit exhaustion can be days
+# out, so nudging hourly would fire ~55 no-op keystroke sequences into a pane that
+# cannot proceed. First match wins, so this row must stay ABOVE usage-limit.
 #
-# THIS ROW IS A SHADOW, SO ITS FALSE POSITIVES ARE THE WORST KIND — a pane that
-# matches here is never keystroked again, i.e. exactly the permanently stalled
-# session this whole mechanism exists to prevent. The two failure directions are
-# not symmetric: a false NEGATIVE here just falls through to hourly no-op nudging
-# (cheap), a false POSITIVE strands the pane (expensive). So match the captured
-# PHRASE "hit your weekly limit", never the bare noun "weekly limit" — the bare
-# form also matches `/usage` output or a banner reporting both windows, either of
-# which would strand a working pane. Not fixed by narrowing, and unfixable here:
-# a pane displaying THIS FILE matches whatever literals the rows contain. That is
-# inherent to a pattern config and applies to the action row equally.
+# Because it shadows, its false positives are the worst failure available here: a
+# pane caught by this row is never keystroked again — exactly the permanently
+# stalled session this mechanism exists to prevent. The directions are asymmetric
+# (false negative -> harmless no-op nudging; false positive -> stranded pane), so
+# bias toward UNDER-matching: anchor on the captured PHRASE "hit your weekly
+# limit", never the bare noun, which also matches `/usage` output or a banner
+# reporting both windows. Unfixable either way, and true of the action row too:
+# a pane displaying THIS FILE matches whatever literals the rows contain.
 weekly-limit | hit your weekly limit|out of usage credits
 
 usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-zA-Z]|$)|resets? (at|on)|try again at | 1 Enter ; continue Enter

--- a/config/tmux-resume-patterns.conf
+++ b/config/tmux-resume-patterns.conf
@@ -29,10 +29,46 @@
 #     so they survive UI changes across releases.
 #   - ACTION (send_sequence) is the FRAGILE part: exact menu numbering and option
 #     wording change between releases. The user's flow is "select 'wait for limits
-#     to reset' (usually option 1), then type continue". Treat `1 Enter` as a
+#     to reset' (usually option 1), then resume". Treat `1 Enter` as a
 #     guess to CONFIRM in dry-run — if the menu auto-selects on the digit, drop
 #     the `Enter`; if there is no menu, drop `1 Enter ;` entirely; if the option
 #     is on a different number, change it. Verify against one real prompt first.
+#
+# WHY `/wrap-up` AND NOT `continue`: `continue` has no exit branch, so a nudged
+# session resumes hourly forever — 101 of 157 jobs on this machine were exactly
+# that. `/wrap-up` (claude/skills/wrap-up/SKILL.md) forces a terminating end
+# state: land the work behind a draft PR, state the blocker via AskUserQuestion,
+# or take one step and re-classify. Every branch of it ends the turn.
+#
+# The skill sets `disable-model-invocation: true`, i.e. it is reachable ONLY by
+# someone typing `/wrap-up`. Sending the keystrokes here IS that invocation, so
+# the flag stays on — wiring the nudge does not require dropping it, and must
+# not be taken as a reason to.
+#
+# `/wrap-up` IS SENT QUOTED, i.e. as literal text via `send-keys -l`, not as an
+# unquoted key token. Unquoted tokens go through tmux's key-name lookup, where
+# `-` is the modifier separator (`C-c`, `M-x`); `wrap-up` contains one, so the
+# literal form removes any question of how tmux parses it. It is a single word,
+# so the word-splitting footgun is not the reason — key-name lookup is.
+#
+# TWO `Enter`s AFTER `/wrap-up`, DELIBERATELY. Typing a slash command opens
+# Claude Code's command picker; the first Enter may only SELECT the highlighted
+# entry rather than submit it. The failure modes are asymmetric: a spare Enter
+# lands on an empty input box and is ignored, whereas one Enter too few leaves
+# `/wrap-up` sitting unsent and the pane stalled exactly as before. This is the
+# second guess in this row — confirm it in the same dry-run as `1 Enter`, and if
+# a single Enter submits, drop the extra.
+#
+# SCOPE: the skill is trialled on `dotfiles` only and enforces that itself in its
+# Step 0 guard, which is why this row does not need a per-repo field (it has none
+# to give). Outside dotfiles that guard does NOT stop dead — it announces
+# out-of-scope and then resumes the prior task, exactly as the bare `continue`
+# this row used to send. That fall-back is what makes global wiring safe. Without
+# it, every rate-limited pane outside dotfiles would be parked mid-work with no
+# PR and no blocker stated, and would never retry: a resumed pane stops showing a
+# rate-limit banner, so nothing here matches on the next scan. If you ever edit
+# Step 0, keep the fall-back — a trial scoped to dotfiles must not change
+# behaviour outside dotfiles.
 #
 # VERIFIED WORDINGS (captured from real prompts 2026-07-27). These drive the rows
 # below; anything not on this list is a guess and must be dry-run before adding:
@@ -86,4 +122,4 @@ weekly-limit | hit your weekly limit|out of usage credits
 # — those panes would have fallen through to nothing and never retried. The
 # weekly row above still wins first-match while its hold is live; this row only
 # sees those banners once the cooldown has elapsed.
-usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-zA-Z]|$)|resets? (at|on)|try again at|hit your weekly limit|out of usage credits | 1 Enter ; continue Enter
+usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-zA-Z]|$)|resets? (at|on)|try again at|hit your weekly limit|out of usage credits | 1 Enter ; "/wrap-up" ; Enter Enter

--- a/config/tmux-resume-patterns.conf
+++ b/config/tmux-resume-patterns.conf
@@ -64,14 +64,26 @@
 # out, so nudging hourly would fire ~55 no-op keystroke sequences into a pane that
 # cannot proceed. First match wins, so this row must stay ABOVE usage-limit.
 #
-# Because it shadows, its false positives are the worst failure available here: a
-# pane caught by this row is never keystroked again — exactly the permanently
-# stalled session this mechanism exists to prevent. The directions are asymmetric
-# (false negative -> harmless no-op nudging; false positive -> stranded pane), so
-# bias toward UNDER-matching: anchor on the captured PHRASE "hit your weekly
+# The hold is time-boxed, and that is load-bearing. A rate-limited pane emits no
+# new output, so the banner never scrolls out of the capture window; a detect-only
+# row that suppressed unconditionally would keep winning first-match every hour
+# FOREVER, including after the limit resets — stranding the pane until a human
+# touched it, which is the exact failure this mechanism exists to prevent. So
+# tmux-resume holds a detect-only match for TMUX_RESUME_DETECT_COOLDOWN_HOURS
+# (default 6) and then falls through to the rows below, restarting the clock. Net:
+# ~4 nudges/day instead of 24, and the pane frees itself within 6h of reset.
+#
+# Still bias toward UNDER-matching: anchor on the captured PHRASE "hit your weekly
 # limit", never the bare noun, which also matches `/usage` output or a banner
-# reporting both windows. Unfixable either way, and true of the action row too:
-# a pane displaying THIS FILE matches whatever literals the rows contain.
+# reporting both windows. A false positive now costs a 6h delay rather than a dead
+# pane, but it is still a cost. Unfixable in one respect either way, and true of
+# the action row too: a pane displaying THIS FILE matches the literals below.
 weekly-limit | hit your weekly limit|out of usage credits
 
-usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-zA-Z]|$)|resets? (at|on)|try again at | 1 Enter ; continue Enter
+# The weekly/credit alternatives are repeated here on purpose. Fall-through is
+# only worth anything if a row BELOW actually matches the same banner, and
+# "Out of usage credits" on its own matched none of the alternatives that follow
+# — those panes would have fallen through to nothing and never retried. The
+# weekly row above still wins first-match while its hold is live; this row only
+# sees those banners once the cooldown has elapsed.
+usage-limit | usage limit reached|5-hour limit reached|rate limit([^a-zA-Z]|$)|resets? (at|on)|try again at|hit your weekly limit|out of usage credits | 1 Enter ; continue Enter

--- a/custom_bins/tmux-resume
+++ b/custom_bins/tmux-resume
@@ -75,8 +75,17 @@ resume_pane() {
         for step in "${steps[@]}"; do
           step="$(printf '%s' "$step" | trim)"
           [[ -z "$step" ]] && continue
-          # shellcheck disable=SC2086  # deliberate word-split into tmux key tokens
-          tmux -S "$socket" send-keys -t "$target" $step
+          if [[ ${#step} -ge 2 && "$step" == \"*\" ]]; then
+            # Double-quoted step -> literal text. `-l` disables key-name lookup,
+            # so spaces survive and "Enter" would be typed as the word Enter.
+            # Send real keys as their own unquoted step: "some text" ; Enter
+            tmux -S "$socket" send-keys -t "$target" -l "${step:1:${#step}-2}"
+          else
+            # Unquoted step -> word-split into separate tmux key tokens. Multi-word
+            # text here LOSES its spaces (`wrap up` types as `wrapup`); quote it.
+            # shellcheck disable=SC2086  # deliberate word-split into tmux key tokens
+            tmux -S "$socket" send-keys -t "$target" $step
+          fi
           sleep 0.6
         done
       fi

--- a/custom_bins/tmux-resume
+++ b/custom_bins/tmux-resume
@@ -13,11 +13,28 @@ DOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PATTERNS_FILE="${TMUX_RESUME_PATTERNS:-$DOT_DIR/config/tmux-resume-patterns.conf}"
 CAPTURE_LINES="${TMUX_RESUME_LINES:-12}"
 
+# Detect-only rows are throttled, not permanent. A pane sitting on a rate-limit
+# banner produces no new output, so the banner never leaves the capture window —
+# a detect-only row that returned unconditionally would keep winning first-match
+# every hour forever, including after the limit resets, stranding the pane until
+# a human touched it. Instead: hold the pane for this cooldown, then fall through
+# so a later action row can retry. Set to 0 to disable holding entirely (every
+# scan retries, i.e. detect-only rows become no-ops).
+STATE_DIR="${TMUX_RESUME_STATE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/tmux-resume}"
+DETECT_COOLDOWN_HOURS="${TMUX_RESUME_DETECT_COOLDOWN_HOURS:-6}"
+
 DRY_RUN=false
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
 
 ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
 trim() { sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+
+# One 0-byte marker file per (socket, pane, row); its mtime is the hold's start.
+# Key is sanitised to a flat filename — collisions are harmless (worst case two
+# panes share a cooldown clock) and the alternative is parsing a shared file that
+# concurrent runs would race on.
+state_key() { printf '%s' "$1" | tr -c '[:alnum:]' '_'; }
+file_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0; }
 
 command -v tmux &>/dev/null || { echo "[$(ts)] tmux-resume: tmux not found" >&2; exit 0; }
 [[ -f "$PATTERNS_FILE" ]] || { echo "[$(ts)] tmux-resume: patterns file missing: $PATTERNS_FILE" >&2; exit 0; }
@@ -43,7 +60,7 @@ discover_sockets() {
 
 resume_pane() {
   local socket="$1" target="$2" captured="$3"
-  local line name after_name regex send
+  local line name after_name regex send state_file cooldown held
   while IFS= read -r line; do
     line="$(printf '%s' "$line" | trim)"
     [[ -z "$line" || "$line" == \#* ]] && continue
@@ -64,10 +81,36 @@ resume_pane() {
     send="$(printf '%s' "$send" | trim)"
     [[ -z "$name" || -z "$regex" ]] && continue
     if printf '%s' "$captured" | grep -iqE "$regex"; then
+      if [[ -z "$send" ]]; then
+        # Detect-only row: hold the pane, then release it to the action rows below.
+        cooldown=$(( DETECT_COOLDOWN_HOURS * 3600 ))
+        if (( cooldown <= 0 )); then
+          echo "[$(ts)] MATCH [$name] $target — detect-only disabled (cooldown 0), falling through"
+          continue
+        fi
+        state_file="$STATE_DIR/$(state_key "${socket}|${target}|${name}")"
+        if [[ -f "$state_file" ]]; then
+          held=$(( $(date -u +%s) - $(file_mtime "$state_file") ))
+        else
+          held=-1
+        fi
+        if (( held >= 0 && held < cooldown )); then
+          echo "[$(ts)] MATCH [$name] $target — detect-only, holding (${held}s of ${cooldown}s)"
+          return 0
+        fi
+        # Either first sighting (start the clock) or the cooldown elapsed (restart
+        # it). Both re-stamp the marker; the difference is that a first sighting
+        # holds and an elapsed one falls through to retry.
+        $DRY_RUN || { mkdir -p "$STATE_DIR"; : > "$state_file"; }
+        if (( held < 0 )); then
+          echo "[$(ts)] MATCH [$name] $target — detect-only, first sighting, holding ${DETECT_COOLDOWN_HOURS}h"
+          return 0
+        fi
+        echo "[$(ts)] MATCH [$name] $target — detect-only cooldown elapsed (${held}s), retrying via action rows"
+        continue
+      fi
       if $DRY_RUN; then
-        echo "[$(ts)] MATCH [$name] $target — would send: ${send:-<detect-only>} (dry-run)"
-      elif [[ -z "$send" ]]; then
-        echo "[$(ts)] MATCH [$name] $target — detect-only (no send configured)"
+        echo "[$(ts)] MATCH [$name] $target — would send: $send (dry-run)"
       else
         echo "[$(ts)] MATCH [$name] $target — sending: $send"
         local steps step

--- a/deploy.sh
+++ b/deploy.sh
@@ -97,6 +97,12 @@ COMPONENTS:
                       menu is the script's only prompt; everything after it
                       already runs with safe defaults (git conflicts keep
                       existing values).
+    --allow-worktree-deploy
+                      Deploy even though this copy of the script lives in a git
+                      worktree. Refused by default: DOT_DIR follows the script,
+                      so global symlinks (~/.claude, ~/.codex, ...) would be
+                      repointed at an ephemeral worktree. ~/.claude would lose
+                      its credentials and session backlog in the process.
 
 EXAMPLES:
     ./deploy.sh                           # Use defaults from config.sh
@@ -110,6 +116,47 @@ EOF
 
 # Parse CLI arguments (overrides config.sh)
 parse_args "$@"
+
+# ─── Worktree guard ───────────────────────────────────────────────────────────
+# DOT_DIR is derived from this script's own location (see top of file), and most
+# components symlink GLOBAL config at "$DOT_DIR/<thing>" — ~/.claude, ~/.codex,
+# ~/.serena, ~/.config/zed, and so on. Run from a git worktree, that repoints
+# global config at a directory that is ephemeral by design.
+#
+# The ~/.claude case is the damaging one. The `-L` branch of the Claude
+# component rm's the existing symlink and relinks it, and unlike the `-d`
+# branch it restores NO runtime files — so the new target starts with an empty
+# projects/, jobs/, and no .credentials.json. That reads as a logout, and the
+# entire session backlog goes invisible until the symlink is pointed back.
+# Observed 2026-07-27: ~/.claude repointed at a worktree, credentials gone,
+# 163 jobs replaced by 7.
+#
+# Override with --allow-worktree-deploy (or ALLOW_WORKTREE_DEPLOY=1) when you
+# genuinely mean to deploy from a worktree.
+if [[ "${ALLOW_WORKTREE_DEPLOY:-${DEPLOY_ALLOW_WORKTREE_DEPLOY:-false}}" != "true" \
+   && "${ALLOW_WORKTREE_DEPLOY:-0}" != "1" ]]; then
+    _git_dir="$(git -C "$DOT_DIR" rev-parse --git-dir 2>/dev/null || true)"
+    if [[ "$_git_dir" == */worktrees/* || "$DOT_DIR" == */.claude/worktrees/* ]]; then
+        _main_dir="$(git -C "$DOT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+        _main_dir="${_main_dir:+$(dirname "$_main_dir")/deploy.sh}"
+        cat >&2 <<EOF
+Error: refusing to deploy from a git worktree.
+
+  DOT_DIR: $DOT_DIR
+
+Deploying from here would repoint global config (~/.claude, ~/.codex, ~/.serena,
+...) at this worktree. ~/.claude in particular would lose its credentials and
+its whole session backlog, which presents as being logged out.
+
+Run the main checkout's copy instead:
+  ${_main_dir:-<main-checkout>/deploy.sh} $*
+
+Or, if this is deliberate:
+  ./deploy.sh --allow-worktree-deploy $*
+EOF
+        exit 1
+    fi
+fi
 
 # Make custom_bins (claude-tools) discoverable, then fetch a prebuilt
 # claude-tools matching this platform so the component menu works before the

--- a/scripts/shared/helpers.sh
+++ b/scripts/shared/helpers.sh
@@ -1759,6 +1759,13 @@ parse_args() {
                 NON_INTERACTIVE=true
                 export NON_INTERACTIVE
                 ;;
+            --allow-worktree-deploy)
+                # Opt out of deploy.sh's worktree guard. Not a component, so it
+                # needs its own case — the --* catch-all below would both mangle
+                # it into a DEPLOY_* variable and collide with --only.
+                ALLOW_WORKTREE_DEPLOY=true
+                export ALLOW_WORKTREE_DEPLOY
+                ;;
             --no-*)
                 if [[ "$_only_mode" == true ]]; then
                     echo "Error: --only cannot be mixed with profile or component flags" >&2

--- a/scripts/tests/test-tmux-resume.sh
+++ b/scripts/tests/test-tmux-resume.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Functional test for tmux-resume's detect-only cooldown state machine and the
+# send-sequence parser. Self-contained: builds its own fixtures under a temp dir.
+#
+#   bash scripts/tests/test-tmux-resume.sh
+#
+# Exits non-zero on the first failed assertion.
+#
+# WHY THIS EXISTS: config/tmux-resume-patterns.conf says the ACTION half of each
+# row is fragile and must be re-verified after CLI upgrades. That check is only
+# cheap if the harness is checked in, so it is.
+#
+# WHAT IT CANNOT COVER: whether the keystrokes actually drive a live rate-limit
+# prompt. That needs `tmux-resume --dry-run` against a real rate-limited pane.
+# This tests the machinery around the keystrokes, not the keystrokes' effect.
+#
+# TWO ACCOMMODATIONS, both harness-side, neither touching the logic under test:
+#
+# 1. A sandboxed session cannot socket(AF_UNIX), so no real tmux server socket
+#    can exist and discover_sockets() would find nothing. We build a copy of
+#    tmux-resume with ONE added line: a second discover_sockets() definition
+#    (later definition wins in bash) echoing a fixed fake path.
+# 2. tmux-resume deliberately re-exports PATH with system dirs FIRST (cron gives
+#    a minimal PATH), so a stub earlier in the caller's PATH loses to
+#    /usr/bin/tmux. The first entry it prepends is "$HOME/.local/bin", so we
+#    point HOME at a test dir and install the stub there — the stub wins by the
+#    script's own ordering rather than by editing the script.
+#
+# Everything under test — pattern parsing, first-match ordering, the cooldown
+# state machine, dry-run guarding, the send loop — runs unmodified.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# $TMPDIR is not reliably writable — under Claude Code's sandbox it points at
+# /run/user/$UID, which is read-only. Take the first base that actually works.
+T=""
+for base in "${TMPDIR:-}" /tmp/claude /tmp; do
+  [[ -n "$base" && -d "$base" && -w "$base" ]] || continue
+  T="$(mktemp -d "$base/tmux-resume-test.XXXXXX" 2>/dev/null)" && break
+done
+[[ -n "$T" ]] || { echo "no writable temp dir (tried \$TMPDIR, /tmp/claude, /tmp)"; exit 1; }
+trap 'rm -rf "$T"' EXIT
+
+FAILED=0
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1"; FAILED=1; }
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"
+  else fail "$1"; printf '       expected: %q\n       actual:   %q\n' "$2" "$3"; fi
+}
+
+mkdir -p "$T/state" "$T/home/.local/bin"
+
+cat > "$T/home/.local/bin/tmux" <<'STUB'
+#!/usr/bin/env bash
+# Stub tmux. Drops the leading "-S <socket>" that tmux-resume always passes.
+shift 2
+case "$1" in
+  list-panes)   echo "fake:0.0" ;;
+  capture-pane) cat "$FAKE_CAPTURE" ;;
+  send-keys)    shift; echo "SEND: $*" >> "$FAKE_SENDLOG" ;;
+esac
+STUB
+chmod +x "$T/home/.local/bin/tmux"
+
+python3 - "$REPO/custom_bins/tmux-resume" "$T/tmux-resume-test" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+text = open(src).read()
+anchor = "resume_pane() {"
+assert text.count(anchor) == 1, "anchor 'resume_pane() {' not found exactly once"
+open(dst, "w").write(text.replace(anchor, 'discover_sockets() { echo "/fake/tmux-socket"; }\n\n' + anchor))
+PY
+chmod +x "$T/tmux-resume-test"
+
+# Real captured wording (2026-07-27), the case the rows are tuned for.
+printf '%s\n' \
+  'Usage limit reached' \
+  "You've hit your weekly limit · resets Jul 29, 3pm (UTC)" \
+  > "$T/capture.txt"
+# A pane that must NOT match: both strings are near-misses the guards exclude.
+printf '%s\n' \
+  'git reset HEAD~1' \
+  'rate limiter configured with limit=500' \
+  > "$T/benign.txt"
+
+export HOME="$T/home"
+export TMUX_RESUME_PATTERNS="$REPO/config/tmux-resume-patterns.conf"
+export TMUX_RESUME_STATE_DIR="$T/state"
+export FAKE_CAPTURE="$T/capture.txt"
+export FAKE_SENDLOG="$T/sends.log"
+: > "$T/sends.log"
+
+run() { "$T/tmux-resume-test" "$@" 2>&1 | sed 's/^\[[^]]*\] //'; }
+sends() { cat "$T/sends.log"; }
+reset_state() { rm -f "$T"/state/* 2>/dev/null; : > "$T/sends.log"; }
+
+# The exact keystroke decomposition the config's action row must produce.
+# `-l` on the middle line is load-bearing: it disables tmux key-name lookup, so
+# the `-` in `wrap-up` cannot be read as a modifier separator.
+EXPECTED_SEND='SEND: -t fake:0.0 1 Enter
+SEND: -t fake:0.0 -l /wrap-up
+SEND: -t fake:0.0 Enter Enter'
+
+echo "== detect-only cooldown =="
+out="$(run)"
+assert_eq "first sighting holds, does not send" "yes" \
+  "$([[ "$out" == *"first sighting, holding"* && ! -s "$T/sends.log" ]] && echo yes || echo no)"
+
+out="$(run)"
+assert_eq "second sighting still holds" "yes" \
+  "$([[ "$out" == *"holding ("* && ! -s "$T/sends.log" ]] && echo yes || echo no)"
+
+assert_eq "exactly one marker file" "1" "$(find "$T/state" -type f | wc -l | tr -d ' ')"
+
+echo "== fall-through after cooldown =="
+# Backdate the marker's mtime, which is the cooldown clock. NOT `touch -d '7 hours
+# ago'` — relative -d is GNU-only and this file is meant to be re-run on macOS too,
+# where BSD touch takes -t [[CC]YY]MMDDhhmm instead. python3 is already a
+# dependency of this harness, so use it and stay portable.
+python3 -c 'import os,sys,time; t=time.time()-7*3600; [os.utime(p,(t,t)) for p in sys.argv[1:]]' "$T"/state/*
+out="$(run)"
+assert_eq "cooldown elapsed -> falls through to action row" "yes" \
+  "$([[ "$out" == *"cooldown elapsed"* && "$out" == *"sending:"* ]] && echo yes || echo no)"
+assert_eq "keystrokes sent verbatim" "$EXPECTED_SEND" "$(sends)"
+
+out="$(run)"
+assert_eq "clock restarts after fall-through" "yes" \
+  "$([[ "$out" == *"holding ("* ]] && echo yes || echo no)"
+assert_eq "no second burst" "$EXPECTED_SEND" "$(sends)"
+
+echo "== dry-run is inert =="
+reset_state
+run --dry-run > /dev/null
+assert_eq "dry-run writes no marker" "0" "$(find "$T/state" -type f | wc -l | tr -d ' ')"
+assert_eq "dry-run sends nothing" "" "$(sends)"
+
+echo "== cooldown escape hatch =="
+reset_state
+out="$(TMUX_RESUME_DETECT_COOLDOWN_HOURS=0 "$T/tmux-resume-test" 2>&1)"
+assert_eq "cooldown 0 -> immediate fall-through" "yes" \
+  "$([[ "$out" == *"cooldown 0"* ]] && echo yes || echo no)"
+assert_eq "cooldown 0 sends keystrokes" "$EXPECTED_SEND" "$(sends)"
+
+echo "== false-positive guards =="
+reset_state
+out="$(FAKE_CAPTURE="$T/benign.txt" "$T/tmux-resume-test" 2>&1)"
+assert_eq "benign pane does not match" "yes" \
+  "$([[ "$out" != *MATCH* ]] && echo yes || echo no)"
+assert_eq "benign pane receives nothing" "" "$(sends)"
+
+echo
+if [[ $FAILED -eq 0 ]]; then echo "all checks passed"; else echo "FAILURES — see above"; fi
+exit $FAILED


### PR DESCRIPTION
The hourly `tmux-resume` nudge sends a bare `continue` to rate-limited Claude/Codex panes. `continue` has no exit branch, so a nudged session resumes forever and never ends. This PR gives it one.

## What

| Change | Where |
|---|---|
| New `/wrap-up` skill. Classifies the session, then takes one of three **terminating** branches: land the work as a draft PR, state the blocker and exit, or take exactly one step and re-classify next tick (never twice in a row) | `claude/skills/wrap-up/SKILL.md` |
| The nudge now sends `/wrap-up` instead of `continue` | `config/tmux-resume-patterns.conf` |
| `send_sequence` steps can carry quoted literal text — `"/wrap-up"` routes through `send-keys -l`; unquoted steps still go through tmux key-name lookup, which would read the `-` as a modifier | `custom_bins/tmux-resume` |
| Detect-only rows (weekly limit, credit exhaustion) expire after a cooldown, default 6h, instead of shadowing the action row forever | `custom_bins/tmux-resume` |
| Global rule: in a background job every decision point goes through `AskUserQuestion`, never prose | `claude/rules/background-job-questions.md` |
| `deploy.sh` aborts when run from a git worktree | `deploy.sh` |

## Why

Measured on this machine 2026-07-28, across 161 job records: **100 were hourly `continue` nudges** and **46 sat blocked** on a decision that was never surfaced — against **2** actually active. Background-job prose does not notify, so a blocked session is indistinguishable from a stall, and the decision it was owed is never delivered.

The `deploy.sh` guard came out of the same measurement: `DOT_DIR` is derived from the script's own path, so a run from a worktree repointed `~/.claude` at an ephemeral directory. **163 jobs and 68 project dirs read as 7 and 5** for seven minutes on 2026-07-27. No data was lost (checked message-by-message across all 21 transcript fragments: 0 message uuids exist only in the worktree copy), but the guard makes it unrepeatable.

## How it was tested

`scripts/tests/test-tmux-resume.sh`, self-contained with real assertions and a non-zero exit on failure — all passing. It covers pattern parsing and first-match ordering, the cooldown state machine (hold → hold → fall through once the marker is backdated → re-hold, confirming the clock restarts), `--dry-run` inertness, the false-positive guards (`git reset HEAD~1`, `rate limiter configured with limit=500`), and the exact send decomposition: `1 Enter` / `-l /wrap-up` / `Enter Enter`.

Detection is verified against three prompt wordings captured from real rate-limited panes, including one with its header scrolled out of the 12-line capture window.

## Not verified

Two keystroke guesses, both flagged in-file, both settled by the same check:

- whether `1 Enter` matches the live wait-menu (numbering changes between releases)
- whether one `Enter` submits a slash command, or the picker needs a second

A sandboxed session cannot open a tmux socket, so **one `tmux-resume --dry-run` against a real rate-limited pane is owed before trusting the scheduled job.** Merging makes this live on the next `:05` tick.

**Scoping is prompt-level, not mechanical.** The trial is limited to `dotfiles` by the skill's Step 0; the script itself matches every pane it can see. Out-of-scope panes announce and resume the prior task, so behaviour outside `dotfiles` is unchanged — but that limit is enforced by a prompt rather than by the script.
