### PR TITLE
fix(cache): reap abandoned temp_git_* plugin clones

### DIFF
--- a/custom_bins/claude-cache-clean
+++ b/custom_bins/claude-cache-clean
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# claude-cache-clean — Remove stale plugin cache versions.
+# claude-cache-clean — Remove stale plugin cache versions and abandoned clones.
 #
 # The plugin cache at ~/.claude/plugins/cache/ accumulates old versions.
 # This script identifies and removes non-current versions, keeping only the
 # versions referenced in installed_plugins.json.
+#
+# It also reaps abandoned temp_git_* directories. Plugin install/update clones
+# a marketplace into cache/temp_git_<epoch_ms>_<rand>/, copies the files out,
+# and leaves the bare .git behind. These were invisible to the version walk
+# below: they sit at marketplace depth and hold only a dotfile, so the "*/"
+# globs never match anything inside them. 37 had accumulated (50MB, 26% of
+# the cache) over 9 days before this pass was added on 2026-07-26.
 #
 # Usage:
 #   claude-cache-clean           # Dry run — show what would be removed
@@ -52,6 +59,36 @@ kept_count=0
 echo -e "${YELLOW}Scanning plugin cache...${NC}"
 echo ""
 
+# Reap abandoned temp_git_* clones. All three guards must hold: the name
+# matches, nothing but .git is inside, and it is older than the age floor —
+# so a clone still in flight is never touched.
+TEMP_MIN_AGE_MIN="${CLAUDE_CACHE_TEMP_AGE_MIN:-60}"
+temp_count=0
+temp_size=0
+temp_skipped=0
+
+while IFS= read -r temp_dir; do
+    [[ -n "$temp_dir" ]] || continue
+
+    extra=$(find "$temp_dir" -mindepth 1 -maxdepth 1 ! -name '.git' -print -quit 2>/dev/null)
+    if [[ -n "$extra" ]]; then
+        echo -e "  ${YELLOW}SKIP${NC} $(basename "$temp_dir") — holds more than .git"
+        temp_skipped=$((temp_skipped + 1))
+        continue
+    fi
+
+    size=$(du -sk "$temp_dir" 2>/dev/null | cut -f1)
+    temp_size=$((temp_size + size))
+    temp_count=$((temp_count + 1))
+
+    if $DRY_RUN; then
+        echo -e "  ${RED}ABANDONED${NC} $(basename "$temp_dir") (${size}KB)"
+    else
+        echo -e "  ${RED}REMOVING${NC} $(basename "$temp_dir") (${size}KB)"
+        rm -rf "$temp_dir"
+    fi
+done < <(find "$CACHE_DIR" -maxdepth 1 -type d -name 'temp_git_*' -mmin "+${TEMP_MIN_AGE_MIN}" 2>/dev/null | sort)
+
 # Walk marketplace dirs
 for marketplace_dir in "$CACHE_DIR"/*/; do
     [[ -d "$marketplace_dir" ]] || continue
@@ -86,8 +123,12 @@ done
 echo ""
 echo -e "${GREEN}Current versions: ${kept_count}${NC}"
 echo -e "${RED}Stale versions: ${stale_count}${NC} (~$((stale_size / 1024))MB)"
+echo -e "${RED}Abandoned clones: ${temp_count}${NC} (~$((temp_size / 1024))MB)"
+if [[ $temp_skipped -gt 0 ]]; then
+    echo -e "${YELLOW}Skipped (not empty): ${temp_skipped}${NC}"
+fi
 
-if $DRY_RUN && [[ $stale_count -gt 0 ]]; then
+if $DRY_RUN && [[ $((stale_count + temp_count)) -gt 0 ]]; then
     echo ""
-    echo -e "${YELLOW}Run 'claude-cache-clean --apply' to remove stale versions${NC}"
+    echo -e "${YELLOW}Run 'claude-cache-clean --apply' to remove them${NC}"
 fi


### PR DESCRIPTION
Plugin install/update clones a marketplace into `cache/temp_git_<epoch_ms>_<rand>/`, copies the files out, and abandons the bare `.git`. **41 had accumulated — 54MB, 27% of a 198MB cache, at ~4/day.** Nothing references them.

They were invisible to `claude-cache-clean` for a structural reason: it walks `cache/<marketplace>/<plugin>/<version>/`, but a `temp_git_*` dir sits at *marketplace* depth holding nothing but a dotfile, so the `*/` globs never match anything inside it and the inner loops never iterate.

## The new pass

Three guards, all must hold:
- name matches `temp_git_*`
- older than `CLAUDE_CACHE_TEMP_AGE_MIN` (default 60 min) — an in-flight clone is never destroyed
- contains nothing but `.git` — anything else is reported as SKIP, not removed

Respects the existing dry-run default; abandoned-clone counts are reported separately from stale-version counts.

## Not newly scheduled

`deploy.sh --claude` already invokes `claude-cache-clean --apply`, so deploy-time coverage now works. A dedicated cron entry was deliberately left undone: every job in `scripts/cleanup/` passes a bare binary, and `schedule_daily` embeds its command as a single launchd `ProgramArguments` string — a command with arguments would break on macOS. Wiring one up needs a no-arg wrapper first.

## Verification

- `shellcheck` clean
- **`--apply` run against the real cache on this box (Linux, 2026-07-26)** — cache went **198MB → 91MB, ~107MB reclaimed**: 41 abandoned clones (~54MB) and 27 stale versions (~53MB) removed, 0 skipped by the shape guard.
- **Integrity check passed**: the version walk reported **33 current versions both before and after**. That count is derived by matching each directory against `installed_plugins.json`, so 33 → 33 means every referenced install path survived. A follow-up dry run reports 0 stale, 0 abandoned.
- The growth rate is the argument for the pass existing rather than being a one-off cleanup: clones went 37 → 41 in the few hours between the first dry run and the apply.

https://claude.ai/code/session_011Xenbe8xzeF9yyzFYuG22x
