### PR TITLE
spec: persistent ssh-agent so sandboxed git push works

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -916,8 +916,6 @@
         "/tmp/claude",
         "/tmp/tmux-*",
         "/tmp/tmux-*/*",
-        "/tmp/ssh-*",
-        "/tmp/ssh-*/agent.*",
         "/private/tmp/com.apple.launchd.*/Listeners",
         "/var/folders/*/*/T",
         "/var/folders/*/*/T/claude",


### PR DESCRIPTION
**Spec-first.** The implementation is paused pending review of the design below.

**What this PR actually changes:** one commit, two deleted lines — the part of the design that is correct no matter which requirements you approve.

```diff
-        "/tmp/ssh-*",
-        "/tmp/ssh-*/agent.*",
         "/private/tmp/com.apple.launchd.*/Listeners",
```

Those entries widened the sandbox for a socket that provably cannot appear on this box (see *Background*). Deleting them is a strict **narrowing**. The macOS launchd entry stays.

Verified before staging: `jq empty` clean, `statusLine`/`hooks`/`permissions` all present (per `.claude/rules/dotfiles-settings.md`), `~/.ssh/id_*` still in `denyRead`.

Not reviewed by `codex-companion` — this is a spec awaiting human review, and that path needs `dangerouslyDisableSandbox` and exceeds the 600s foreground timeout.

Local copy of the spec below: `specs/2026-07-27-ssh-agent-sandbox.md` (gitignored — public repo).

---

## Overview

`git push` over SSH fails inside the Claude Code sandbox, and the only workaround today is `dangerouslyDisableSandbox: true` — which bypasses far more than the one rule actually in the way. Give the box a persistent ssh-agent at a **stable socket path** and allowlist that path, so ssh authenticates over the agent (signing happens inside the agent process; the key file is never opened) while `~/.ssh/id_*` stays deny-read.

## Background: why the first attempt was wrong

Commit `0ffae36` allowlisted `/tmp/ssh-*` and `/tmp/ssh-*/agent.*`. That path shape is what **agent forwarding** produces — a socket created by `sshd`, randomly named per session, destroyed when the session ends. Claude Code here runs as a background job with no attached session, so there is no forwarded agent to inherit, by construction.

Verified on this box (read-only commands, 2026-07-27):

| Check | Result |
|---|---|
| `pgrep -a ssh-agent` | empty — **no agent process at all** |
| `$SSH_AUTH_SOCK` | `/tmp/ssh-lpIEipm2i3/agent.3278074` — points at a socket that does not exist |
| `ssh-add ~/.ssh/id_ed25519` (user ran it) | `Error connecting to agent: No such file or directory` |
| `who`, `$SSH_CONNECTION`, `$SSH_TTY` | empty / unset |
| `/run/user/1000/systemd` | exists — systemd user manager available |

So the allowlist alone was never going to work: there was nothing to allowlist. The three commonplace Linux setups are (1) desktop session/keyring starts one, (2) agent forwarding from a laptop, (3) a systemd user unit at a fixed socket. This box has none; (3) is the documented Arch Wiki recipe and the one that fits a headless box with background jobs.

## Requirements

Approve/reject row by row.

| # | Requirement | Notes |
|---|---|---|
| **R1** | MUST add `config/systemd-user/ssh-agent.service` with `Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket`, `ExecStart=<abs path>/ssh-agent -D -a $SSH_AUTH_SOCK`, `[Install] WantedBy=default.target` | `%t` = `$XDG_RUNTIME_DIR` → `/run/user/1000`. Absolute `ExecStart` templated by `sed`, same as `pueued.service` |
| **R2** | MUST deploy + `systemctl --user enable --now` it on Linux, gated on its **own** flag, **not** on `--pueue` | The existing systemd block (`deploy.sh:882`) is inside `if [[ "$DEPLOY_PUEUE" == "true" ]]`. ssh-agent is independent of resource management — nesting it there means `--no-pueue` silently breaks pushes |
| **R3a** | MUST register `"ssh-agent\|Persistent ssh-agent (systemd user unit)\|linux\|true\|Linux"` in `DEPLOY_REGISTRY` (`config.sh:47`) | Verified registry-driven: the arg parser's generic `--*` / `--no-*` arms (`helpers.sh:1867`, `1859`) mean `--ssh-agent` / `--no-ssh-agent` need no case; `--only` validates against the registry (`helpers.sh:1894`) and the `minimal` profile derives from it (`config.sh:283`), so both need the entry and neither needs a manual edit |
| **R3b** | MUST add a `--ssh-agent` line to the `COMPONENTS:` help block (`deploy.sh:60`+) | The **one** part that is not registry-driven — that block is hand-written. CLAUDE.md § Adding New Features says "update help text"; that half is still accurate, the "add flag parsing in `while` loop" half is now stale |
| **R4** | MUST set `DEPLOY_SSH_AGENT=false` in the `server` and `cloud` profiles | A remote box should use **forwarding** from the laptop, not hold its own copy of a key. Lean, not certain — see Q3 |
| **R5** | MUST export `SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent.socket"` from `config/zshrc.sh`, Linux-only, guarded on the socket existing | Without this the shell keeps inheriting the dead `/tmp/ssh-*` value. Guard so a box without the unit isn't given a broken value |
| **R6** | MUST swap the sandbox allowlist in `claude/settings.json`: remove `/tmp/ssh-*` and `/tmp/ssh-*/agent.*`, add `/run/user/*/ssh-agent.socket` | Reuses the existing `/run/user/*/pueue*.socket` precedent. Keep `/private/tmp/com.apple.launchd.*/Listeners` (macOS has no systemd) |
| **R7** | MUST leave `~/.ssh/id_*` in `denyRead`, untouched | Non-negotiable. The entire point is that the key file stays unreadable |
| **R8** | MUST update the `deploy.sh` "Next steps" hint to reflect the unit, and keep the single `ssh-add ~/.ssh/id_ed25519` as **Yulong's to run** | Explicitly requested. Deploy never loads a key itself |
| **R9** | MUST capture `ssh-add` status with `\|\| status=$?`, never run it bare | `set -euo pipefail` at `deploy.sh:15`; `ssh-add -l` returns non-zero as *signalling*, so a bare call aborts an otherwise-complete deploy |
| **R10** | MUST NOT introduce HTTPS + a `gh` token as a fallback | Relocates the credential from a guarded path (`~/.ssh/id_*`, deny-read) to an unguarded one (`~/.config/gh/hosts.yml`) — trades a real boundary for convenience |
| **R11** | SHOULD leave macOS behaviour unchanged | launchd-managed agent + Keychain (`UseKeychain yes`, `AddKeysToAgent yes` already in `~/.ssh/config`) already works there |

## Acceptance Criteria

Someone else can verify "done" by running these.

| # | Check | Expected |
|---|---|---|
| **AC1** | `systemctl --user is-enabled ssh-agent` | `enabled` |
| **AC2** | `ls -l /run/user/$(id -u)/ssh-agent.socket` | socket exists, mode `srw-------`, owned by the user |
| **AC3** | New login shell: `echo $SSH_AUTH_SOCK` | `/run/user/1000/ssh-agent.socket` (not a `/tmp/ssh-*` path) |
| **AC4** | `ssh-add ~/.ssh/id_ed25519` then `ssh-add -l` | lists the key, exit 0 |
| **AC5** | After reboot, before any interactive login: socket exists | Linger is already enabled (`/var/lib/systemd/linger/yulong`, 22 Jun), so this should hold with no extra step |
| **AC6** | **Inside a restarted sandboxed Claude Code session**: `ssh-add -l` | lists the key. Today it returns `Error connecting to agent: Operation not permitted` (exit 2) |
| **AC7** | **Inside the sandbox**, `git push` with **no** `dangerouslyDisableSandbox` | succeeds |
| **AC8** | `jq -r '.sandbox.filesystem.denyRead[]' claude/settings.json` | still contains `~/.ssh/id_*` |
| **AC9** | `zsh -n deploy.sh && zsh -n config/zshrc.sh && jq empty claude/settings.json` | all clean (`shellcheck` can't read zsh — SC1071) |
| **AC10** | `./deploy.sh --only ssh-agent` **run from `/home/yulong/code/dotfiles`** (the main checkout, never a worktree) on a box that already has it | idempotent, exit 0, no duplicate units. The working directory matters: running `deploy.sh` from a worktree is what clobbered `~/.claude` auth before, and `guard_not_worktree` now hard-aborts it |

AC6 and AC7 cannot be checked until the branch is merged **and** Claude Code restarts — the sandbox config is read at session start.

## Open Questions

**Q1 — linger. Resolved, nothing needed from you.** For the agent to survive with no login session, linger must be on. `loginctl show-user` can't answer this from inside the sandbox (`Failed to connect to bus: Operation not permitted` — D-Bus is blocked, the same reason `systemctl --user` doesn't work here), but the on-disk marker is readable: `/var/lib/systemd/linger/yulong` exists, dated 22 Jun — consistent with the pueue setup that documents it as a prerequisite. Linger is on; AC5 should pass with no extra step.

**Q2 — the public key.** `~/.ssh/id_ed25519.pub` is covered by the same `id_*` deny glob. Expected to be irrelevant (the agent offers keys itself, ssh doesn't need the `.pub` file when using an agent), but untested. If AC7 fails with the agent working, this is the next suspect — the fix would be narrowing the glob to `id_ed25519` / `id_rsa` rather than `id_*`.

**Q3 — server/cloud profile default (R4).** My lean is off-by-default there, on the reasoning that a remote box shouldn't hold a key. But you do `ssh-add` on RunPod boxes today. If you want pushes to work from a sandboxed Claude Code session *on a cloud box*, R4 should flip to `true`.

## Out of Scope

- macOS parity beyond the already-committed `/private/tmp/com.apple.launchd.*/Listeners` entry. A manually-started agent on macOS lands under `/var/folders/.../ssh-*/agent.*` and stays uncovered; this box is Linux, so nothing depends on it.
- Agent forwarding configuration. Structurally can't help here (a forwarded socket dies with the session; background jobs have none).
- The `~/.claude` symlink / dirty-`settings.json` merge hazard — a merge-mechanics problem, recorded under *Merging* below, not a requirement of this design.

## Merging

`~/.claude` symlinks to the **main checkout's** `claude/`, and Claude Code dual-writes `settings.json` at runtime, so that working copy is chronically dirty relative to `HEAD`. Git refuses a merge that would modify a dirty file — this is what to expect, not a conflict with this branch.

**It is not a content conflict.** This branch touches only the `allowWrite` array (~line 917). The drifted keys are elsewhere and this branch doesn't touch them, so merging cannot revert them.

Current drift in the main checkout:

| Key | main checkout (live) | committed in git |
|---|---|---|
| `permissions.defaultMode` | `auto` | `acceptEdits` |
| `model` | *(absent)* | `opusplan` |
| `plansDirectory` | `~/vault/specs` | `plans` |
| `mcpServers.things-cloud` | later in block | earlier in block |

**Recommendation: commit the live state on main, then merge.** It is what Claude Code actually runs today, and `plansDirectory: ~/vault/specs` matches the vault convention in `workflow-defaults.md`. The one row worth your glance is `model` — history shows a deliberate `opusplan` → `sonnet` change, so confirm that dropping the key entirely is intended.

## Current Branch State

| Commit | What it did | Status under this spec |
|---|---|---|
| `0ffae36` (merged, #45) | +3 allowlist lines: `/tmp/ssh-*`, `/tmp/ssh-*/agent.*`, `/private/tmp/com.apple.launchd.*/Listeners` | 2 of 3 lines already **removed** by `aae8ebf`; the macOS line stays |
| `c1fcd62` (merged, #45) | +15 lines: conditional `ssh-add -l` hint in `deploy.sh`'s "Next steps", tested at exit 0/1/2 and absent-from-PATH | **Kept**, to be reworded by R8 |
| `aae8ebf` (PR #46) | −2 lines: removes the two dead `/tmp/ssh-*` entries | The half of R6 that is correct regardless of which requirements you approve — a strict **narrowing** of the sandbox |

R1–R5, R3b and the *additive* half of R6 (`/run/user/*/ssh-agent.socket`) are **not implemented** — they await approval.

https://claude.ai/code/session_01HuBmkQKHpFkwi8Yp9NmK2H
