### PR TITLE
feat(tmux-resume): gate sends behind a per-window opt-in

### DIFF
--- a/claude/skills/wrap-up/SKILL.md
+++ b/claude/skills/wrap-up/SKILL.md
@@ -18,25 +18,25 @@ You have been woken by the hourly `tmux-resume` nudge, not by a human. Something
 
 The hourly nudge in `config/tmux-resume-patterns.conf` used to send a bare `continue`. `continue` has no exit branch, so sessions resume hourly forever and accumulate: 101 of 157 jobs on this machine were hourly `continue` nudges, and 56 sessions sat blocked on a human decision that was never surfaced. Fixing the inflow means the nudge must be able to *end* a session — so the nudge now types `/wrap-up` instead.
 
-**Status: the nudge is wired, the keystrokes are not yet confirmed.** Detection anchors on rate-limit wordings captured from real prompts, but the *action* — `1 Enter`, then `/wrap-up`, then two `Enter`s — has never been fired at a live prompt, because a sandboxed session cannot open a tmux socket. Both guesses are marked as such in the pattern file and are settled by one `tmux-resume --dry-run` against a real rate-limited pane.
+**Status: the nudge is wired, gated on opt-in, and its keystrokes are unconfirmed.** `tmux-resume` types `/wrap-up` only into panes whose tmux window name starts with `auto-` (`config/tmux-resume-patterns.conf`; toggle with `tauto` / `tnoauto`). So you are reading this because a human named this window that way — reaching this skill is itself evidence someone wanted this session wrapped up. Detection anchors on rate-limit wordings captured from real prompts, but the *action* — `1 Enter`, then `/wrap-up`, then two `Enter`s — has never been fired at a live prompt, because a sandboxed session cannot open a tmux socket. Both guesses are marked as such in the pattern file and are settled by one `tmux-resume --dry-run` against a real rate-limited pane.
 
 **`disable-model-invocation: true` stays on regardless.** It makes this skill reachable only by someone typing `/wrap-up` — and the nudge sending those keystrokes *is* that invocation, so wiring the nudge is not a reason to drop the flag. Omitting it would instead make the skill model-invoked (see `claude/skills/writing-great-skills/SKILL.md` § Invocation), letting any matching dotfiles prompt fire an autonomous commit-and-push path with no nudge involved at all. That is a different and much wider trigger surface than the one being trialled here. Discovery during the trial is via `claude/skills/catalog/SKILL.md`.
 
 ## Step 0: Scope guard (required first)
 
-This skill is being trialled on `dotfiles` only. Before anything else:
+Writing to git unattended — staging, committing, pushing, opening a PR — is trialled on `dotfiles` only. Before anything else:
 
 ```bash
 basename "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")"
 ```
 
-**If that basename is not `dotfiles`**, do none of the steps below. Print one line — `wrap-up: out of trial scope (<repo>), resuming prior task` — and then **carry on with whatever the session was already doing**, exactly as a bare `continue` would have. Do not do the wrap-up work "just this once."
+**If that basename is not `dotfiles`**, Step 2 is closed: stage nothing, commit nothing, push nothing. Still classify (Step 1), then take the **blocked** branch (Step 3) — say where the work stands, name what is left uncommitted and in which checkout, and rename the session (Step 5). Then end your turn.
 
-That fall-back is deliberate and load-bearing. The nudge in `config/tmux-resume-patterns.conf` no longer sends `continue` — it sends `/wrap-up` — so this branch is what every rate-limited pane *outside* dotfiles now lands on. Stopping dead here would strand those panes mid-work with no PR, no blocker stated, and no rename; and because a resumed pane stops displaying a rate-limit banner, no row would match on the next hourly scan to retry. That is strictly worse than the `continue` it replaced, and it is the same shape as the detect-only regression this PR already had to fix once. A trial scoped to `dotfiles` must not change behaviour outside `dotfiles`.
+**Out of scope terminates; it does not resume.** An earlier version of this guard announced out-of-scope and then carried on with the prior task, exactly as a bare `continue` would. That was right while the nudge fired at every pane the scheduler could see: stopping dead would have stranded unrelated panes with no PR and no blocker stated, and since a resumed pane stops displaying a rate-limit banner, nothing would have matched on the next scan to retry. Opt-in removed that premise. The nudge now reaches only windows a human named `auto-…`, so there are no bystander panes to strand, and resuming would rebuild the endless-`continue` pump this entire change exists to remove. The trial scope governs *who may write to git*, not *whether the session may stop*.
 
 Use `--git-common-dir`, not `--show-toplevel`. In a linked worktree (`cw`, `claude --worktree`) `--show-toplevel` returns the *worktree* path, whose basename is the worktree's name — `agent-sprawl-spec`, not `dotfiles` — so a `show-toplevel` test excludes every branch worktree, which is where most sessions actually live. `--git-common-dir` resolves to the owning repo's `.git` in both a worktree and the root checkout, so its parent's basename is the repo name either way. Worktrees are in scope: they are the intended home for a wrap-up commit, since Step 2 forbids committing on `main`.
 
-This guard exists because the nudge fires against every pane the scheduler can see, and the pattern file has no per-repo field. The skill is the only place scoping can live right now.
+The opt-in prefix in `config/tmux-resume-patterns.conf` is the primary scope, and it lives in the sender, where it belongs — by the time this guard runs the keystrokes have already landed, so a check here can never prevent an unwanted interruption. This guard is defence-in-depth for the git-writing branch only.
 
 ## Step 1: Classify honestly
 
@@ -76,7 +76,17 @@ What you may do about it depends on which checkout you are in, because a branch 
 3. **Verify before committing — read the content, not just the names.** `git diff --cached --name-only` must match your list exactly, nothing extra. That is necessary but *not sufficient*: a path is not an ownership boundary. In a shared checkout, another actor can have edited a different hunk of a file you also touched, and `git add <path>` stages their hunk alongside yours while the name-only check still passes cleanly. So also read `git diff --cached` and confirm every hunk is one you recognise. If a hunk is not yours, `git restore --staged <path>` and leave that file out. Anything modified that you cannot attribute to this session stays unstaged; name it in the PR body so the owner knows it is there. If you cannot attribute the changes at all, stop and go to Step 3 — an unattributable diff is a decision for the owner, not a commit.
 4. Commit with a real message that says *why*, not just what. No heredocs — write to `/tmp/claude/<job>-msg.txt` and `git commit -F`.
 5. **If the branch is ahead of `main`, push and open a draft PR — a dirty tree does not excuse skipping this.** the staging rule above deliberately leaves unattributable edits unstaged, so a dirty tree is the *expected* end state, not an error; gating the push on cleanliness would mean the common case commits locally, exits "done", and leaves the work invisible on a machine nobody looks at. Push the commit; mention the leftover unstaged paths in the PR body. Never push to `main`, never force-push, never merge.
-6. **The PR command must be non-interactive.** `gh pr create --draft` alone prompts for title and body, and an unattended job has no way to answer — it hangs or dies before it can terminate, which is the exact failure this skill exists to prevent. Always supply both: `gh pr create --draft --title "<subject>" --body-file /tmp/claude/<job>-pr.md`. (`--fill` works too, but it derives the body from commit messages and loses the leftover-paths note.)
+6. **The PR command must be non-interactive.** `gh pr create --draft` alone prompts for title and body, and an unattended job has no way to answer — it hangs or dies before it can terminate, which is the exact failure this skill exists to prevent. Always supply both: `gh pr create --draft --title "<subject>" --body-file /tmp/claude/<job>-pr.md`. Do **not** use `--fill`: it derives the body from commit messages, which cannot carry the three sections below.
+
+   **The body is the state of the work, in three headed sections, under ~250 words total.** Write it to that file before calling `gh`:
+
+   | Section | Contents |
+   |---|---|
+   | **What's done** | What now works that did not before. Not a file list — `gh pr diff` already shows files. |
+   | **What's left** | Known gaps, deferred decisions, and any paths left unstaged because you could not attribute them to this session. "Nothing" is a valid answer — say it explicitly rather than dropping the section. |
+   | **How it was tested** | The command you ran and what it returned. If the suite failed, or you did not run one, say that here; per item 0 a failing suite does not block a draft PR, it blocks claiming the work is finished. Never write "tested" without naming what was run. |
+
+   The word ceiling is load-bearing, not politeness. This PR is read cold by someone deciding whether to look further, and the session that produced it cannot answer follow-up questions. A wall of narration gets skipped exactly the way a 157-entry job list does — the sections exist so a reviewer can reconstruct the state in one screen.
 7. If push or PR creation fails — no remote, auth expired, a protected branch — do **not** exit as done. The commit exists but nobody can see it, which is indistinguishable from the pile-up this skill was written to stop. Classify as **blocked** (Step 3), name the failure, and say where the commit is.
 8. Rename the session (Step 5), then **end your turn.**
 
@@ -122,7 +132,8 @@ Keep `<topic>` to two or three words. If `tmux rename-window` fails (no tmux, de
 |---|---|
 | "I'll just keep going, I'm close" | That is what `continue` did 101 times. Classify and terminate. |
 | "I'll pick the sensible option and note it" | Step 3 exists precisely to stop this. Surface it. |
-| "This repo isn't dotfiles but the work is obviously fine" | Step 0 is a hard stop *on the wrap-up steps*. The trial scope is the point. Announce out-of-scope, resume the prior task, and do none of the steps below it. |
+| "This repo isn't dotfiles but the work is obviously fine" | Step 0 closes Step 2 only. Say where the work stands, name the uncommitted paths and their checkout, rename the session, and end the turn. Do **not** resume — out of scope means "do not write to git", never "keep going". |
+| "The PR body should explain everything I did" | Under ~250 words, three sections, no narration. `gh pr diff` shows the files; the body says what works, what does not, and what was run. |
 | "I'll commit everything to be safe" | Stage the paths you touched, by name. `git add -u` commits other people's work; `git add -A` also stages sandbox char-device masks. |
 | "I'm on `main` but the change is small" | Step 2's precondition is a hard stop. Unattended commits onto `main` are exactly what the draft-PR flow exists to prevent. |
 | "I'll just switch the checkout to a branch first" | Only in a linked worktree. In the root checkout that moves HEAD for every other pane and cron job pointed at it. |

--- a/config/aliases/tmux.sh
+++ b/config/aliases/tmux.sh
@@ -31,8 +31,7 @@ alias tdel="tmux kill-session -t"
 # tauto [topic] — opt this window in. Defaults to prefixing the current name.
 tauto () {
   [ -n "$TMUX" ] || { echo "tauto: not inside tmux" >&2; return 1; }
-  local cur; cur="$(tmux display-message -p '#{window_name}')"
-  local topic="${1:-$cur}"
+  local topic="${1:-$(tmux display-message -p '#{window_name}')}"
   case "$topic" in auto-*) ;; *) topic="auto-$topic" ;; esac
   tmux rename-window "$topic" && echo "opted in: $topic"
 }

--- a/config/aliases/tmux.sh
+++ b/config/aliases/tmux.sh
@@ -17,6 +17,47 @@ alias tdel="tmux kill-session -t"
 # ls/tree aliases → config/modern_tools.sh (single source of truth)
 
 #-------------------------------------------------------------
+# tmux-resume opt-in
+#-------------------------------------------------------------
+# tmux-resume (hourly) only sends keystrokes into windows whose name starts with
+# `auto-`. Everything else is detected, logged, and left alone to stop at the
+# rate limit. These helpers toggle that opt-in on the CURRENT window, which is
+# the common case: you decide a session should run unattended after starting it,
+# not before. Config + rationale: config/tmux-resume-patterns.conf
+#
+# `rename-window` also disables tmux's automatic-rename for the window, so the
+# name sticks instead of being overwritten by the running command.
+
+# tauto [topic] — opt this window in. Defaults to prefixing the current name.
+tauto () {
+  [ -n "$TMUX" ] || { echo "tauto: not inside tmux" >&2; return 1; }
+  local cur; cur="$(tmux display-message -p '#{window_name}')"
+  local topic="${1:-$cur}"
+  case "$topic" in auto-*) ;; *) topic="auto-$topic" ;; esac
+  tmux rename-window "$topic" && echo "opted in: $topic"
+}
+
+# tnoauto — opt this window back out.
+tnoauto () {
+  [ -n "$TMUX" ] || { echo "tnoauto: not inside tmux" >&2; return 1; }
+  local cur; cur="$(tmux display-message -p '#{window_name}')"
+  case "$cur" in
+    auto-*) tmux rename-window "${cur#auto-}" && echo "opted out: ${cur#auto-}" ;;
+    *) echo "already opted out: $cur" ;;
+  esac
+}
+
+# tautols — every window that will be auto-resumed, across all sessions.
+tautols () {
+  local out
+  # Tab-delimited so names containing spaces stay one field, as tmux-resume reads them.
+  # awk, not `grep -P '\tauto-'` — BSD grep on macOS has no -P.
+  out="$(tmux list-windows -a -F '#{session_name}:#{window_index}	#{window_name}' 2>/dev/null \
+    | awk -F'\t' '$2 ~ /^auto-/' || true)"
+  if [ -z "$out" ]; then echo "(no windows opted in)"; else printf '%s\n' "$out"; fi
+}
+
+#-------------------------------------------------------------
 # chmod
 #-------------------------------------------------------------
 

--- a/config/aliases/tmux.sh
+++ b/config/aliases/tmux.sh
@@ -20,39 +20,56 @@ alias tdel="tmux kill-session -t"
 # tmux-resume opt-in
 #-------------------------------------------------------------
 # tmux-resume (hourly) only sends keystrokes into windows whose name starts with
-# `auto-`. Everything else is detected, logged, and left alone to stop at the
-# rate limit. These helpers toggle that opt-in on the CURRENT window, which is
-# the common case: you decide a session should run unattended after starting it,
-# not before. Config + rationale: config/tmux-resume-patterns.conf
+# the opt-in prefix (default `auto-`). Everything else is detected, logged, and
+# left alone to stop at the rate limit. These helpers toggle that opt-in on the
+# CURRENT window, which is the common case: you decide a session should run
+# unattended after starting it, not before. Config + rationale:
+# config/tmux-resume-patterns.conf
 #
 # `rename-window` also disables tmux's automatic-rename for the window, so the
 # name sticks instead of being overwritten by the running command.
 
+# The prefix is configurable (env var or a patterns-file directive), so ask
+# tmux-resume for the resolved value rather than assuming `auto-`. Hard-coding it
+# here would rename windows to a prefix the gate rejects — the helper would report
+# success while leaving the pane opted out. Empty means sending is disabled.
+_tmux_resume_prefix () {
+  command -v tmux-resume >/dev/null 2>&1 || { echo "tmux-resume not on PATH" >&2; return 1; }
+  local p; p="$(tmux-resume --print-optin-prefix 2>/dev/null)"
+  [ -n "$p" ] || { echo "opt-in prefix is empty — sending is disabled" >&2; return 1; }
+  printf '%s' "$p"
+}
+
 # tauto [topic] — opt this window in. Defaults to prefixing the current name.
 tauto () {
   [ -n "$TMUX" ] || { echo "tauto: not inside tmux" >&2; return 1; }
+  local prefix; prefix="$(_tmux_resume_prefix)" || return 1
   local topic="${1:-$(tmux display-message -p '#{window_name}')}"
-  case "$topic" in auto-*) ;; *) topic="auto-$topic" ;; esac
+  # Prefix quoted in the pattern so it is matched literally, not as a glob.
+  case "$topic" in "$prefix"*) ;; *) topic="$prefix$topic" ;; esac
   tmux rename-window "$topic" && echo "opted in: $topic"
 }
 
 # tnoauto — opt this window back out.
 tnoauto () {
   [ -n "$TMUX" ] || { echo "tnoauto: not inside tmux" >&2; return 1; }
+  local prefix; prefix="$(_tmux_resume_prefix)" || return 1
   local cur; cur="$(tmux display-message -p '#{window_name}')"
   case "$cur" in
-    auto-*) tmux rename-window "${cur#auto-}" && echo "opted out: ${cur#auto-}" ;;
+    "$prefix"*) tmux rename-window "${cur#"$prefix"}" && echo "opted out: ${cur#"$prefix"}" ;;
     *) echo "already opted out: $cur" ;;
   esac
 }
 
 # tautols — every window that will be auto-resumed, across all sessions.
 tautols () {
+  local prefix; prefix="$(_tmux_resume_prefix)" || return 1
   local out
   # Tab-delimited so names containing spaces stay one field, as tmux-resume reads them.
-  # awk, not `grep -P '\tauto-'` — BSD grep on macOS has no -P.
+  # awk, not `grep -P '\tauto-'` — BSD grep on macOS has no -P. The prefix is passed
+  # as an awk var and matched with index(), so regex metacharacters stay literal.
   out="$(tmux list-windows -a -F '#{session_name}:#{window_index}	#{window_name}' 2>/dev/null \
-    | awk -F'\t' '$2 ~ /^auto-/' || true)"
+    | awk -F'\t' -v p="$prefix" 'index($2, p) == 1' || true)"
   if [ -z "$out" ]; then echo "(no windows opted in)"; else printf '%s\n' "$out"; fi
 }
 

--- a/config/tmux-resume-patterns.conf
+++ b/config/tmux-resume-patterns.conf
@@ -59,16 +59,24 @@
 # second guess in this row — confirm it in the same dry-run as `1 Enter`, and if
 # a single Enter submits, drop the extra.
 #
-# SCOPE: the skill is trialled on `dotfiles` only and enforces that itself in its
-# Step 0 guard, which is why this row does not need a per-repo field (it has none
-# to give). Outside dotfiles that guard does NOT stop dead — it announces
-# out-of-scope and then resumes the prior task, exactly as the bare `continue`
-# this row used to send. That fall-back is what makes global wiring safe. Without
-# it, every rate-limited pane outside dotfiles would be parked mid-work with no
-# PR and no blocker stated, and would never retry: a resumed pane stops showing a
-# rate-limit banner, so nothing here matches on the next scan. If you ever edit
-# Step 0, keep the fall-back — a trial scoped to dotfiles must not change
-# behaviour outside dotfiles.
+# SCOPE IS ENFORCED AT THE SENDER, NOT IN THE SKILL. tmux-resume only sends into
+# panes whose tmux window name starts with TMUX_RESUME_OPTIN_PREFIX (below), so a
+# session receives keystrokes only if a human named its window that way at launch.
+# Everything else detects and logs, and stops when it hits the limit.
+#
+# This replaced an earlier design that wired the nudge globally and relied on the
+# skill's Step 0 repo guard to bow out. Two reasons it was wrong. First, the
+# keystrokes have already landed by the time Step 0 runs — the interruption is the
+# annoyance, and a guard downstream of it cannot undo it. Second, "which repo" is
+# a poor proxy for "I meant this to keep running": most dotfiles sessions are
+# ordinary interactive ones that should simply stop.
+#
+# The Step 0 repo guard stays as defence-in-depth. It is no longer load-bearing,
+# so its out-of-scope branch no longer has to fall back to resuming the prior
+# task in order to keep global wiring safe — there is no global wiring left.
+#
+# Opting in is deliberately visible: `tmux ls` shows exactly which sessions will
+# resume. Prefer renaming a window you already have over launching a special one.
 #
 # VERIFIED WORDINGS (captured from real prompts 2026-07-27). These drive the rows
 # below; anything not on this list is a guess and must be dry-run before adding:
@@ -93,6 +101,15 @@
 #     grep on macOS does not reliably support `\b` in ERE; the class spells out
 #     both cases rather than relying on `-i` to fold a NEGATED class, which is
 #     the one construct where BSD and GNU grep are most likely to differ.
+
+# DIRECTIVE. `KEY=value`, not a pattern row — the row parser skips any line
+# starting `TMUX_RESUME_`. $TMUX_RESUME_OPTIN_PREFIX in the environment overrides
+# this. Setting it EMPTY disables sending entirely (fail closed); it does not mean
+# "every window". Detection is unaffected either way and always logs.
+#
+# `auto-` must not be a command you run: tmux auto-names a window after its
+# running command, so a window running `auto-something` would opt itself in.
+TMUX_RESUME_OPTIN_PREFIX=auto-
 
 # DETECT-ONLY ROW (third field omitted — not left blank; the splitter needs ` | `
 # with spaces BOTH sides, so a trailing pipe would land inside the regex as an

--- a/custom_bins/tmux-resume
+++ b/custom_bins/tmux-resume
@@ -91,6 +91,15 @@ fi
 # behaviour this gate exists to prevent.
 optin_ok() { [[ -n "$OPTIN_PREFIX" && "$1" == "$OPTIN_PREFIX"* ]]; }
 
+# Publish the resolved prefix so the shell helpers (tauto/tnoauto/tautols) read it
+# from here instead of hard-coding "auto-". Without this they rename windows to a
+# prefix the gate may no longer accept, silently opting the pane out of the thing
+# the human just asked for. Empty output means sending is disabled.
+if [[ "${1:-}" == "--print-optin-prefix" ]]; then
+  printf '%s\n' "$OPTIN_PREFIX"
+  exit 0
+fi
+
 # Discover all tmux server sockets for this user. tmux uses $TMUX_TMPDIR else
 # $TMPDIR else /tmp, plus /tmux-<uid>/. launchd/cron may hand us a different
 # TMPDIR than the interactive shell, so probe every plausible base dir +
@@ -155,7 +164,17 @@ resume_pane() {
         # Either first sighting (start the clock) or the cooldown elapsed (restart
         # it). Both re-stamp the marker; the difference is that a first sighting
         # holds and an elapsed one falls through to retry.
-        $DRY_RUN || { mkdir -p "$STATE_DIR"; : > "$state_file"; }
+        #
+        # If the marker cannot be persisted the clock never starts, so every scan
+        # sees held<0 and reports a fresh "first sighting" forever. Keep holding —
+        # falling through would send into a weekly-limit pane every hour, the exact
+        # behaviour this gate exists to stop — but name the cause, because the
+        # "first sighting" line repeating hourly is what made this undiagnosable.
+        # resume_pane runs under `|| true`, so errexit will not catch this.
+        if ! $DRY_RUN && ! { mkdir -p "$STATE_DIR" && : > "$state_file"; } 2>/dev/null; then
+          echo "[$(ts)] MATCH [$name] $target — detect-only, marker unwritable ($state_file), holding"
+          return 0
+        fi
         if (( held < 0 )); then
           echo "[$(ts)] MATCH [$name] $target — detect-only, first sighting, holding ${DETECT_COOLDOWN_HOURS}h"
           return 0

--- a/custom_bins/tmux-resume
+++ b/custom_bins/tmux-resume
@@ -3,6 +3,24 @@
 # auto-resume them by sending configured keystrokes. Scheduled hourly.
 #   --dry-run : detect and log only, send nothing (use this to verify patterns).
 # Patterns: config/tmux-resume-patterns.conf (override via $TMUX_RESUME_PATTERNS).
+#
+# OPT-IN SCOPING: keystrokes are only sent into panes whose tmux *window name*
+# starts with $TMUX_RESUME_OPTIN_PREFIX (default "auto-"). Detection is never
+# scoped and always logs; only the *send* is gated. Set the prefix via the env
+# var or a `TMUX_RESUME_OPTIN_PREFIX=auto-` directive line in the patterns file
+# (env wins). An empty prefix disables sending entirely rather than matching
+# every window — fail closed, never blanket.
+#
+# WHY opt-in rather than "resume everything": the rate limit is the only
+# involuntary stopping point an unattended session has. Resuming every pane
+# deletes that stopping point, so nothing terminates and sessions/worktrees
+# accumulate. Requiring the human to name a window `auto-<topic>` at launch
+# means resumption only happens where it was actually intended, and `tmux ls`
+# shows you exactly which sessions will resume.
+#
+# CAVEAT: tmux auto-names windows after the running command, so a window
+# running a command that itself begins with the prefix would match by accident.
+# Pick a prefix you do not run as a command.
 set -euo pipefail
 
 # cron/launchd give a minimal PATH.
@@ -12,6 +30,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PATTERNS_FILE="${TMUX_RESUME_PATTERNS:-$DOT_DIR/config/tmux-resume-patterns.conf}"
 CAPTURE_LINES="${TMUX_RESUME_LINES:-12}"
+
+# Tab-delimited so window names containing spaces or colons survive the split.
+PANE_FMT=$'#{session_name}:#{window_index}.#{pane_index}\t#{window_name}'
 
 # Detect-only rows are throttled, not permanent. A pane sitting on a rate-limit
 # banner produces no new output, so the banner never leaves the capture window —
@@ -39,6 +60,37 @@ file_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || ech
 command -v tmux &>/dev/null || { echo "[$(ts)] tmux-resume: tmux not found" >&2; exit 0; }
 [[ -f "$PATTERNS_FILE" ]] || { echo "[$(ts)] tmux-resume: patterns file missing: $PATTERNS_FILE" >&2; exit 0; }
 
+# Read a `KEY=value` directive from the patterns file (last occurrence wins).
+# Directives share the patterns file so the whole policy lives in one place;
+# the row parser skips any TMUX_RESUME_*= line so they cannot be read as rows.
+conf_directive() {
+  local key="$1" val
+  val="$(grep -E "^[[:space:]]*$key=" "$PATTERNS_FILE" 2>/dev/null | tail -1)"
+  [[ -z "$val" ]] && return 1
+  val="$(printf '%s' "${val#*=}" | trim)"
+  val="${val%\"}"; val="${val#\"}"
+  val="${val%\'}"; val="${val#\'}"
+  printf '%s' "$val"
+}
+
+# Resolution order: env (if SET, even to empty) > file directive (if PRESENT, even
+# empty) > built-in default. The distinction between set-but-empty and unset is
+# load-bearing: an empty prefix means "send to nothing", so it has to be
+# expressible. `${VAR:-default}` cannot express it — it treats empty as unset and
+# would silently restore `auto-`, i.e. keep sending after you asked it to stop.
+if [[ -n "${TMUX_RESUME_OPTIN_PREFIX+set}" ]]; then
+  OPTIN_PREFIX="$TMUX_RESUME_OPTIN_PREFIX"
+elif OPTIN_PREFIX="$(conf_directive TMUX_RESUME_OPTIN_PREFIX)"; then
+  : # Directive present. An empty value there is honoured as "disable", not defaulted.
+else
+  OPTIN_PREFIX="auto-"
+fi
+
+# Only opted-in windows receive keystrokes. An empty prefix matches nothing
+# (fail closed) — deliberately NOT "match everything", which is the blanket
+# behaviour this gate exists to prevent.
+optin_ok() { [[ -n "$OPTIN_PREFIX" && "$1" == "$OPTIN_PREFIX"* ]]; }
+
 # Discover all tmux server sockets for this user. tmux uses $TMUX_TMPDIR else
 # $TMPDIR else /tmp, plus /tmux-<uid>/. launchd/cron may hand us a different
 # TMPDIR than the interactive shell, so probe every plausible base dir +
@@ -59,11 +111,13 @@ discover_sockets() {
 }
 
 resume_pane() {
-  local socket="$1" target="$2" captured="$3"
+  local socket="$1" target="$2" captured="$3" window="$4"
   local line name after_name regex send state_file cooldown held
   while IFS= read -r line; do
     line="$(printf '%s' "$line" | trim)"
     [[ -z "$line" || "$line" == \#* ]] && continue
+    # Directive lines configure policy, they are not pattern rows.
+    [[ "$line" == TMUX_RESUME_*=* ]] && continue
     # Split on " | " (space-pipe-space) so bare `|` inside ERE patterns is preserved.
     # Format: "name | trigger_regex | send_sequence"
     name="${line%% | *}"
@@ -109,6 +163,13 @@ resume_pane() {
         echo "[$(ts)] MATCH [$name] $target — detect-only cooldown elapsed (${held}s), retrying via action rows"
         continue
       fi
+      # Action row matched, but this window did not opt in: log and stop. The
+      # row still "won" the first-match race, so no later row fires — the log
+      # line above is the detection record for this pane.
+      if ! optin_ok "$window"; then
+        echo "[$(ts)] MATCH [$name] $target — window '$window' not opted in (prefix '${OPTIN_PREFIX:-<none>}'), sending nothing"
+        return 0
+      fi
       if $DRY_RUN; then
         echo "[$(ts)] MATCH [$name] $target — would send: $send (dry-run)"
       else
@@ -146,10 +207,10 @@ fi
 
 while IFS= read -r socket; do
   [[ -z "$socket" ]] && continue
-  while IFS= read -r target; do
+  while IFS=$'\t' read -r target window; do
     [[ -z "$target" ]] && continue
     captured="$(tmux -S "$socket" capture-pane -p -t "$target" -S -"$CAPTURE_LINES" 2>/dev/null || true)"
     [[ -z "$captured" ]] && continue
-    resume_pane "$socket" "$target" "$captured" || true
-  done < <(tmux -S "$socket" list-panes -a -F '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)
+    resume_pane "$socket" "$target" "$captured" "$window" || true
+  done < <(tmux -S "$socket" list-panes -a -F "$PANE_FMT" 2>/dev/null || true)
 done <<< "$sockets"

--- a/scripts/tests/test-tmux-resume.sh
+++ b/scripts/tests/test-tmux-resume.sh
@@ -199,6 +199,31 @@ assert_eq "benign pane does not match" "yes" \
   "$([[ "$out" != *MATCH* ]] && echo yes || echo no)"
 assert_eq "benign pane receives nothing" "" "$(sends)"
 
+echo "== resolved prefix is published for the shell helpers =="
+# tauto/tnoauto/tautols read the prefix from here instead of hard-coding `auto-`.
+# If this stops agreeing with the gate, those helpers rename windows to a prefix
+# the gate rejects and silently leave the pane opted out.
+assert_eq "prints the file directive's prefix" "auto-" \
+  "$("$T/tmux-resume-test" --print-optin-prefix)"
+assert_eq "prints the env override" "ci-" \
+  "$(TMUX_RESUME_OPTIN_PREFIX="ci-" "$T/tmux-resume-test" --print-optin-prefix)"
+assert_eq "prints nothing when sending is disabled" "" \
+  "$(TMUX_RESUME_OPTIN_PREFIX="" "$T/tmux-resume-test" --print-optin-prefix)"
+assert_eq "printing the prefix sends nothing" "" "$(sends)"
+
+echo "== unwritable marker holds, and says why =="
+# resume_pane runs under `|| true`, so a failed marker write does not trip
+# errexit. Without the explicit check, held stays -1 and every hourly scan
+# reports a fresh "first sighting" — holding forever while claiming otherwise.
+reset_state
+: > "$T/blocked"   # a regular file, so mkdir -p "$T/blocked/state" cannot succeed
+out="$(TMUX_RESUME_STATE_DIR="$T/blocked/state" run)"
+assert_eq "unwritable marker names the cause" "yes" \
+  "$([[ "$out" == *"marker unwritable"* ]] && echo yes || echo no)"
+assert_eq "unwritable marker does not claim a first sighting" "yes" \
+  "$([[ "$out" != *"first sighting"* ]] && echo yes || echo no)"
+assert_eq "unwritable marker still sends nothing" "" "$(sends)"
+
 echo
 if [[ $FAILED -eq 0 ]]; then echo "all checks passed"; else echo "FAILURES — see above"; fi
 exit $FAILED

--- a/scripts/tests/test-tmux-resume.sh
+++ b/scripts/tests/test-tmux-resume.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Functional test for tmux-resume's detect-only cooldown state machine and the
-# send-sequence parser. Self-contained: builds its own fixtures under a temp dir.
+# Functional test for tmux-resume's detect-only cooldown state machine, its
+# opt-in send gate, and the send-sequence parser. Self-contained: builds its own
+# fixtures under a temp dir.
 #
 #   bash scripts/tests/test-tmux-resume.sh
 #
@@ -58,7 +59,10 @@ cat > "$T/home/.local/bin/tmux" <<'STUB'
 # Stub tmux. Drops the leading "-S <socket>" that tmux-resume always passes.
 shift 2
 case "$1" in
-  list-panes)   echo "fake:0.0" ;;
+  # tmux-resume asks for "target<TAB>window_name". Emit both, tab-separated —
+  # a single field would leave the window name empty, which the opt-in gate
+  # reads as "not opted in" and every send assertion below would fail.
+  list-panes)   printf '%s\t%s\n' "${FAKE_TARGET:-fake:0.0}" "${FAKE_WINDOW:-auto-test}" ;;
   capture-pane) cat "$FAKE_CAPTURE" ;;
   send-keys)    shift; echo "SEND: $*" >> "$FAKE_SENDLOG" ;;
 esac
@@ -91,6 +95,9 @@ export TMUX_RESUME_PATTERNS="$REPO/config/tmux-resume-patterns.conf"
 export TMUX_RESUME_STATE_DIR="$T/state"
 export FAKE_CAPTURE="$T/capture.txt"
 export FAKE_SENDLOG="$T/sends.log"
+# Opted in by default so the cooldown/parser cases below exercise the send path.
+# The gate itself is tested explicitly further down, both ways.
+export FAKE_WINDOW="auto-test"
 : > "$T/sends.log"
 
 run() { "$T/tmux-resume-test" "$@" 2>&1 | sed 's/^\[[^]]*\] //'; }
@@ -143,6 +150,47 @@ out="$(TMUX_RESUME_DETECT_COOLDOWN_HOURS=0 "$T/tmux-resume-test" 2>&1)"
 assert_eq "cooldown 0 -> immediate fall-through" "yes" \
   "$([[ "$out" == *"cooldown 0"* ]] && echo yes || echo no)"
 assert_eq "cooldown 0 sends keystrokes" "$EXPECTED_SEND" "$(sends)"
+
+echo "== opt-in gate =="
+# All of these use cooldown 0 so the detect-only row falls straight through and
+# the action row — the only row that can send — is the one under test.
+gated() { reset_state; TMUX_RESUME_DETECT_COOLDOWN_HOURS=0 "$T/tmux-resume-test" 2>&1; }
+
+out="$(FAKE_WINDOW="dotfiles" gated)"
+assert_eq "un-opted window still detected" "yes" \
+  "$([[ "$out" == *MATCH* ]] && echo yes || echo no)"
+assert_eq "un-opted window says why it sent nothing" "yes" \
+  "$([[ "$out" == *"not opted in"* ]] && echo yes || echo no)"
+assert_eq "un-opted window receives nothing" "" "$(sends)"
+
+out="$(FAKE_WINDOW="auto-overnight" gated)"
+assert_eq "opted-in window receives keystrokes" "$EXPECTED_SEND" "$(sends)"
+
+# Window names can contain spaces; the pane list is tab-delimited so they survive.
+out="$(FAKE_WINDOW="auto-two words" gated)"
+assert_eq "opted-in name with a space still opts in" "$EXPECTED_SEND" "$(sends)"
+
+# Env overrides the file directive, so a different prefix can opt a window in.
+out="$(FAKE_WINDOW="ci-run" TMUX_RESUME_OPTIN_PREFIX="ci-" gated)"
+assert_eq "env prefix overrides the file directive" "$EXPECTED_SEND" "$(sends)"
+
+# Set-but-empty must FAIL CLOSED. `${VAR:-default}` would treat it as unset and
+# silently restore `auto-`, i.e. keep sending after being told to stop.
+out="$(FAKE_WINDOW="auto-test" TMUX_RESUME_OPTIN_PREFIX="" gated)"
+assert_eq "empty prefix disables sending, does not match everything" "" "$(sends)"
+assert_eq "empty prefix reports no prefix" "yes" \
+  "$([[ "$out" == *"<none>"* ]] && echo yes || echo no)"
+
+echo "== directive lines are not pattern rows =="
+# A directive has no " | ", so the row parser would read the whole line as both
+# name and regex — turning any pane that displays the directive text into a
+# match. It is skipped instead; this pane must stay untouched.
+reset_state
+printf '%s\n' 'TMUX_RESUME_OPTIN_PREFIX=auto-' > "$T/directive.txt"
+out="$(FAKE_CAPTURE="$T/directive.txt" TMUX_RESUME_DETECT_COOLDOWN_HOURS=0 "$T/tmux-resume-test" 2>&1)"
+assert_eq "directive text in a pane does not match" "yes" \
+  "$([[ "$out" != *MATCH* ]] && echo yes || echo no)"
+assert_eq "directive text in a pane sends nothing" "" "$(sends)"
 
 echo "== false-positive guards =="
 reset_state


### PR DESCRIPTION
Stacked on #41 — base is `worktree-agent-sprawl-spec`, not `main`. Both files it touches are modified on top of #41's versions, so a diff against `main` would be incoherent. Merge #41 first.

#41 closes with the caveat that *scoping is prompt-level, not mechanical*: the trial limit to `dotfiles` lives in the `/wrap-up` skill's Step 0 prose, while the script matches every pane it can see. This makes the limit mechanical.

## What's done

Sends are restricted to panes whose window name starts with `TMUX_RESUME_OPTIN_PREFIX` (default `auto-`). Detection is deliberately **not** scoped and still logs every match, so `~/.tmux-resume.log` stays a complete record of what fired — only the keystroke send is gated. An explicitly empty prefix disables sending rather than matching everything; `${VAR+set}` distinguishes set-but-empty from unset, which `${VAR:-default}` cannot.

Plus `tauto` / `tnoauto` / `tautols` to opt a window in or out, and `/wrap-up`'s landing branch now specifies a ~250-word PR body via `--body-file` (never `--fill`) — this PR body is the format.

## What's left

`tauto` / `tnoauto` / `tautols` have never run against a real tmux server; a sandboxed session cannot open the socket. They are three `tmux rename-window` wrappers, so the risk is low, but it is untested.

The two keystroke guesses inherited from #41 are unchanged and still owed one `tmux-resume --dry-run` against a real rate-limited pane.

## How it was tested

8 new assertions in `scripts/tests/test-tmux-resume.sh`: un-opted window is detected but receives nothing and says why, opted-in window receives keystrokes, names containing spaces still opt in, env var overrides the file directive, and an empty prefix sends nothing rather than matching every window. Full suite passes, non-zero exit on failure.
