### PR TITLE
Audit memory tier + hooks against current Opus 5 guidance

### DIFF
--- a/claude/hooks/simplify_nudge.sh
+++ b/claude/hooks/simplify_nudge.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # Stop hook: if a code file changed this turn (marked by
-# simplify_mark_dirty.sh), nudge Claude via additionalContext to run the
-# simplify skill before finishing. Soft nudge only — never blocks the stop.
+# simplify_mark_dirty.sh), surface a systemMessage suggesting a simplify pass.
+# Soft nudge only — never blocks the stop.
 #
-# stop_hook_active guard: additionalContext keeps the conversation going
-# through the same loop protections as decision:block, so without this guard
-# a simplify pass that itself edits code would re-mark the session dirty and
-# re-trigger the nudge on the next Stop check.
+# systemMessage, not additionalContext, and deliberately so. additionalContext
+# forces the turn to continue, which made every code-writing turn pay for an
+# extra pass whether or not the code needed one — the "harness scaffolding that
+# adds a separate pass" pattern current models are explicitly worse off for.
+# A systemMessage puts the suggestion in front of the user and stops there.
+#
+# Because nothing continues the turn, the stop_hook_active guard this hook used
+# to carry is moot: a simplify pass can no longer re-mark the session dirty and
+# re-trigger itself on the next Stop check. Don't reinstate it with the message
+# type as-is.
 set -euo pipefail
 
 INPUT=$(cat)
@@ -18,15 +24,9 @@ MARKER="${TMPDIR:-/tmp}/claude-simplify-dirty-${SESSION_ID}"
 [ -f "$MARKER" ] || exit 0
 rm -f "$MARKER" 2>/dev/null || true
 
-STOP_HOOK_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null) || exit 0
-[[ "$STOP_HOOK_ACTIVE" == "true" ]] && exit 0
-
 cat <<'HOOK_EOF'
 {
-  "hookSpecificOutput": {
-    "hookEventName": "Stop",
-    "additionalContext": "Code was written this turn — consider running the simplify skill (Skill tool, skill: \"simplify\") on the changed files before finishing."
-  }
+  "systemMessage": "Code changed this turn — `/simplify` will run a quality pass over the changed files if it's worth one."
 }
 HOOK_EOF
 exit 0

--- a/claude/rules/agents-and-delegation.md
+++ b/claude/rules/agents-and-delegation.md
@@ -1,5 +1,11 @@
 # Agents & Delegation
 
+## Spawn Fewer Than You Want To
+
+Current models reach for delegation more readily than the work justifies, so the default is a cap, not an invitation. Delegate for large, genuinely independent, parallelisable tracks — a wide multi-file investigation, several unrelated subsystems. Don't delegate what you can finish in a handful of tool calls yourself, and when one agent can do the job, send one rather than a fleet.
+
+**Never spawn an agent to verify or double-check your own work.** Self-correction already happens without being asked; a verifier agent on top of it burns tokens and latency without buying accuracy. A second opinion is a different thing — that means a different model family and it has its own rule (`rules/second-opinions.md`).
+
 ## Never Run Detached Long-Jobs Inside a Subagent
 
 When a subagent's turn ends, any process it backgrounded or detached is orphaned: nothing re-notifies the parent, the job dies or runs to no effect, and the agent reports `completed` anyway. (Real failure, 2026-06-15: `core:codex` backgrounded `codex exec` — burned hours, wrote nothing.) A subagent is not a durable host for background work. Launch long-running jobs from a harness-tracked mechanism that survives the launching context: `codex-companion` via the Monitor tool for Codex work, Bash `run_in_background` from *main* context, or tmux.

--- a/claude/rules/context-management.md
+++ b/claude/rules/context-management.md
@@ -1,7 +1,8 @@
 # Context Management
 
+- **Delegate on breadth, not on file size.** A wide sweep — many files, unknown location, several naming conventions — is worth a subagent (`Explore` / `efficient-explorer`): you keep the conclusion, not the file dumps. Reading one file whose path you already know is not, however long it is. (The line-count thresholds this rule used to carry assumed a much smaller window — don't reinstate them.)
+- **Read with `offset`/`limit` when you know which part you need**, and Grep first when you are still locating it. That is a speed and signal-to-noise habit, not a context-safety one — don't escalate it into a delegation.
 - **PDFs: bound the read or delegate.** Read's `pages` parameter (max 20/request, required past 10 pages) makes a targeted PDF read safe inline. An unbounded read of a large PDF can still consume the whole window — hand those to a subagent.
-- **Files >500 lines: never Read without `offset`/`limit`** — delegate to a subagent if you need the whole file. The 500-line bar is our convention, not a harness setting.
-- **200-500 lines:** Grep first, then targeted Read.
-- **Multi-file comparison or broad exploration: delegate.** Spawn a subagent (`Explore` / `efficient-explorer`) and keep only its findings in main context — larger windows raise the ceiling, but pollution still degrades long sessions.
 - **Verbose or long-running commands** (builds, `pytest -v`, experiments): `run_in_background` — it detaches, survives across turns, and re-invokes on exit. Reserve tmux for work that must outlive the session itself. Never run them synchronously in main context.
+
+Delegation limits: `rules/agents-and-delegation.md`.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1008,17 +1008,15 @@
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "latest",
   "plansDirectory": "plans",
-  "autoMemoryDirectory": "memory",
   "showThinkingSummaries": true,
   "skipDangerousModePermissionPrompt": true,
   "skipWorkflowUsageWarning": true,
   "claudeMdExcludes": [
-    "node_modules",
-    "vendor",
-    ".venv",
-    "target",
-    "cache",
-    ".cache"
+    "**/node_modules/**",
+    "**/vendor/**",
+    "**/.venv/**",
+    "**/target/**",
+    "**/.cache/**"
   ],
   "theme": "auto",
   "verbose": false,


### PR DESCRIPTION
Audited `CLAUDE.md`, `claude/rules/*`, `claude/hooks/*` and `claude/settings.json` against Anthropic's current published guidance for Opus 5 / Claude 5-generation models.

Headline: after PR #49's trim, the memory tier is already in good shape. Most of what the guidance asks for is either already true here or already shipped in the Claude Code system prompt (scope discipline, correction narration, conciseness), so adding it to `CLAUDE.md` would only duplicate context. Four things were genuinely stale, and they are what this PR changes.

## Changed

**`claude/rules/context-management.md` — delegation was gated on file size.** The rule said "Files >500 lines: never Read without `offset`/`limit` — delegate to a subagent if you need the whole file", explicitly flagged as "our convention, not a harness setting". That bar assumed a much smaller context window. Current models hold instruction-following across the whole window, so the rule was paying spawn latency to avoid tokens that no longer cost anything. Re-gated on breadth: a wide sweep across unknown locations earns a subagent; a file whose path you already know does not. The `offset`/`limit` habit survives as a signal-to-noise practice rather than a delegation trigger.

**`claude/rules/agents-and-delegation.md` — nothing capped delegation.** The file covered failure modes of delegation but never said when *not* to delegate, while `context-management.md` was actively encouraging it. Current models over-delegate by default, so the guidance recommends an explicit cap. Added one, including the specific "never spawn an agent to verify or double-check your own work" — flagged in the guidance as cost with no accuracy gain. Cross-referenced `second-opinions.md` so the different-model-family case stays distinct from a verifier agent.

**`claude/hooks/simplify_nudge.sh` — forced an extra pass on every code-writing turn.** The hook emitted `additionalContext`, which continues the turn, so every turn that touched code paid for a simplify pass whether it needed one or not. That is the "separate pass bolted on by the harness" shape the guidance singles out. Switched to a top-level `systemMessage`: same trigger, same once-per-dirty-marking behaviour, suggestion still reaches the user, but nothing forces a continuation. The `stop_hook_active` guard went with it — its only job was breaking the `additionalContext` self-retrigger loop, which no longer exists; a comment records that so it isn't reinstated by reflex.

**`claude/settings.json` — two keys were silently inert.**
- `autoMemoryDirectory` was `"memory"`, a relative path. The setting requires an absolute or `~/`-prefixed value, so it was doing nothing. Had it resolved, it would have pointed auto-memory at a directory inside this **public** repo, and `memory/` is not in `.gitignore` — which the "Personal Content" rule forbids. Dropped the key; the default (`~/.claude/projects/<project>/memory/`) is already per-repo, worktree-shared and machine-local, which is what was wanted.
- `claudeMdExcludes` held bare directory names (`node_modules`, `vendor`, …). Patterns are globbed against **absolute** paths, so none of them could ever match. Rewritten as `**/node_modules/**` etc.

## Deliberately not changed

- **The `CLAUDE.md` verification-planning rule stays.** The guidance targets *post-hoc* verification scaffolding ("include a final verification step", "use a subagent to verify"). This rule is the opposite: design the verification approach before starting, for research reproducibility. Different mechanism, not the thing being warned about.
- **`effortLevel: "high"`** is the documented default, not carried-over 4.8 config. The guidance suggests re-running an effort sweep and using low/medium liberally where quality holds — a measurement task on real workloads, not an edit.
- **`alwaysThinkingEnabled: true`** is now redundant (thinking is on by default) but harmless, and still meaningful for the `fable` fallback.
- **`codex_code_review_reminder.mjs`** only fires on an explicitly-invoked `code-review` skill and dedupes per workspace — user-initiated, not automatic over-verification.

## Verification

`tests/test_memory_tier_budget.py` and `tests/test_validate_claude_settings.py`: 22 passed. The 3 failures in `test_memory_tier_budget.py` are pre-existing in this environment — they resolve the `pretrim-memory-2026-07-29` tag, which is absent from a shallow clone. The byte-ceiling and aggregate-budget assertions all pass; both edited rule files are outside that budget.

`simplify_nudge.sh` exercised directly against the four cases that matter: clean turn stays silent; dirty turn emits valid JSON whose only key is `systemMessage`; the marker is consumed so it cannot repeat; `stop_hook_active=true` still fires and cannot loop. `bash -n` clean.

No CI runs on this PR — the repo's only workflow (`build-claude-tools.yml`) triggers on push-to-`main` under `tools/claude-tools/**` and has no `pull_request` trigger.