### PR TITLE
hooks: debounce modern-tools nudge, quieten compact inside the hooks not the matcher

### DIFF
--- a/claude/hooks/context_auto_apply.sh
+++ b/claude/hooks/context_auto_apply.sh
@@ -1,10 +1,36 @@
 #!/usr/bin/env bash
 # SessionStart hook: auto-apply context.yaml, warn if no context configured.
 # Also triggers background marketplace sync if stale (>6h since last sync).
+#
+# This hook must keep running on EVERY SessionStart source, compact included.
+# Only its *output* is redundant after a compaction - the marketplace sync and
+# the stale-symlink cleanup below are side effects, and skipping them means a
+# session running past the 6h window never syncs and accumulates the duplicate
+# plugin symlinks that clean-skill-dupes exists to remove. So the quieting is
+# done here, per-section, rather than by excluding the hook in settings.json.
+#
+# An unreadable source, or a missing jq, leaves QUIET false and yields exactly
+# the previous behaviour - the fallback is the status quo, never a silent skip.
+if [ -t 0 ]; then
+    hook_input=""
+else
+    hook_input=$(cat)
+fi
+session_source=$(printf '%s' "$hook_input" | jq -r '.source // ""' 2>/dev/null || echo "")
+QUIET=false
+[ "$session_source" = "compact" ] && QUIET=true
+
 CONTEXT_FILE=".claude/context.yaml"
 if [ -f "$CONTEXT_FILE" ]; then
-    claude-tools context --apply 2>/dev/null
-else
+    # The applied-profiles banner is a fixed block that cannot change during a
+    # compaction, but --apply also rewrites .claude/settings.json, so it runs
+    # either way and only the banner is dropped.
+    if [ "$QUIET" = true ]; then
+        claude-tools context --apply >/dev/null 2>&1
+    else
+        claude-tools context --apply 2>/dev/null
+    fi
+elif [ "$QUIET" = false ]; then
     # Warn if inside a git repo without context profiles
     if git rev-parse --is-inside-work-tree &>/dev/null; then
         echo -e "\033[0;33mNo context profiles configured for this project.\033[0m"

--- a/claude/hooks/nudge_modern_tools.sh
+++ b/claude/hooks/nudge_modern_tools.sh
@@ -36,6 +36,28 @@ log_decision() {
     printf '%s %s | %s | %s\n' "$ts" "$decision" "$cmd_short" "$reason" >> "$LOG_PATH"
 }
 
+# Debounce: each distinct nudge fires at most once per DEBOUNCE_SECS across all
+# sessions. Without this the same handful of messages repeat on every Bash call —
+# measured at ~1275 fires / ~251K chars over 60 transcripts, the same 6 strings.
+# Mirrors the 30-min window in lib/codex-freshness.mjs and fails open the same
+# way: if the marker dir can't be written, nudge rather than go silently missing.
+DEBOUNCE_DIR="${HOME}/.cache/claude/nudge-modern.d"
+DEBOUNCE_SECS=$((30 * 60))
+should_nudge() {
+    local key="$1" marker now last
+    mkdir -p "$DEBOUNCE_DIR" 2>/dev/null || return 0  # fail open
+    marker="$DEBOUNCE_DIR/$key"
+    now=$(date +%s)
+    if [[ -f "$marker" ]]; then
+        last=$(stat -f%m "$marker" 2>/dev/null || stat -c%Y "$marker" 2>/dev/null || echo 0)
+        if [[ $(( now - last )) -lt $DEBOUNCE_SECS ]]; then
+            return 1
+        fi
+    fi
+    : > "$marker" 2>/dev/null || return 0  # fail open
+    return 0
+}
+
 nudge=""
 
 # Detect if a command appears as a standalone file operation vs pipeline usage.
@@ -144,6 +166,13 @@ fi
 
 # Nudge: informational message only — never blocks the command.
 if [[ -n "$nudge" ]]; then
+    # Key on the message text, so each distinct nudge debounces independently:
+    # being reminded about `grep` doesn't suppress a later reminder about `ls`.
+    nudge_key=$(printf '%s' "$nudge" | cksum | cut -d' ' -f1)
+    if ! should_nudge "$nudge_key"; then
+        log_decision "DEBOUNCED" "$nudge"
+        exit 0
+    fi
     log_decision "NUDGE" "$nudge"
     jq -n --arg msg "$nudge" '{
       hookSpecificOutput: {

--- a/claude/hooks/show_auth_account.sh
+++ b/claude/hooks/show_auth_account.sh
@@ -1,9 +1,28 @@
 #!/usr/bin/env bash
 # Shows current Claude auth account and usage warning at session start.
+#
+# The account line is fixed for the life of a session, so it is dropped after a
+# compaction. The near-limit warning is NOT fixed - it is recomputed from a
+# mutable usage cache and can newly become true mid-session - so it still fires
+# on compact. That split is why this hook runs on every source rather than
+# being excluded in settings.json: one of its two outputs is live.
+#
+# An unreadable source, or a missing jq, leaves QUIET false and yields exactly
+# the previous behaviour - the fallback is the status quo, never a silent skip.
+if [ -t 0 ]; then
+    hook_input=""
+else
+    hook_input=$(cat)
+fi
+session_source=$(printf '%s' "$hook_input" | jq -r '.source // ""' 2>/dev/null || echo "")
+QUIET=false
+[ "$session_source" = "compact" ] && QUIET=true
 
-auth_json=$(claude auth status 2>&1) || true
+msg=""
+if [[ "$QUIET" == false ]]; then
+  auth_json=$(claude auth status 2>&1) || true
 
-account=$(echo "$auth_json" | python3 -c "
+  account=$(echo "$auth_json" | python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -16,7 +35,8 @@ try:
 except: print('unknown')
 " 2>/dev/null)
 
-msg="Auth: ${account}"
+  msg="Auth: ${account}"
+fi
 
 # Check cached usage for near-limit warning
 cache_file="${TMPDIR:-/tmp/claude}/claude-statusline-usage.json"
@@ -31,6 +51,12 @@ print(round(d.get('five_hour',{}).get('utilization',0)), round(d.get('seven_day'
 Near limit (5h:${five_pct}% 7d:${seven_pct}%)! \`claude-switch\` to logout+login — restart alone won't clear cached usage"
   fi
 fi
+
+# On compact with no near-limit warning there is nothing live to report, so emit
+# no JSON at all rather than an empty additionalContext - that is the whole point
+# of the split. The .strip() below also absorbs the leading newline the warning
+# carries when it is the only content.
+[[ -z "${msg//[[:space:]]/}" ]] && exit 0
 
 python3 -c "
 import json, sys

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -705,8 +705,8 @@
         ]
       },
       {
-        "//": "Status-display hooks whose output cannot change during a compaction: CWD, auth account and the applied context profile are all fixed for the life of the session. Without this matcher they re-inject on every compact, which measured at ~292K chars across 60 transcripts (compact fires outnumber startup ~12:1). Gated to startup|clear|resume — the sources where the model genuinely has no prior context.",
-        "matcher": "startup|clear|resume",
+        "//": "Status-display hooks whose output cannot change during a compaction: CWD, auth account and the applied context profile are all fixed for the life of the session. Without this matcher they re-inject on every compact, which measured at ~292K chars across 60 transcripts (compact fires outnumber startup ~12:1). The matcher lists every SessionStart source EXCEPT compact — per the docs those are startup, resume, clear, compact and fork — so this is an exclusion of compact alone, not an allowlist that silently drops sources added later.",
+        "matcher": "startup|clear|resume|fork",
         "hooks": [
           {
             "type": "command",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -678,11 +678,6 @@
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/check_git_root.sh",
-            "timeout": 3
-          },
-          {
-            "type": "command",
             "command": "$HOME/.claude/hooks/check_venv.sh",
             "timeout": 3
           },
@@ -699,22 +694,33 @@
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/show_auth_account.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "$HOME/.claude/hooks/context_auto_apply.sh",
-            "timeout": 10
-          },
-          {
-            "type": "command",
             "command": "$HOME/.claude/hooks/check_things_mcp.sh",
             "timeout": 3
           },
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/with-anthropic-key.sh python3 $HOME/.claude/hooks/anthropic_keycheck.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "//": "Status-display hooks whose output cannot change during a compaction: CWD, auth account and the applied context profile are all fixed for the life of the session. Without this matcher they re-inject on every compact, which measured at ~292K chars across 60 transcripts (compact fires outnumber startup ~12:1). Gated to startup|clear|resume — the sources where the model genuinely has no prior context.",
+        "matcher": "startup|clear|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/check_git_root.sh",
+            "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/show_auth_account.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/context_auto_apply.sh",
             "timeout": 10
           }
         ]

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -701,17 +701,6 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/with-anthropic-key.sh python3 $HOME/.claude/hooks/anthropic_keycheck.py",
             "timeout": 10
-          }
-        ]
-      },
-      {
-        "//": "Status-display hooks whose output cannot change during a compaction: CWD, auth account and the applied context profile are all fixed for the life of the session. Without this matcher they re-inject on every compact, which measured at ~292K chars across 60 transcripts (compact fires outnumber startup ~12:1). The matcher lists every SessionStart source EXCEPT compact — per the docs those are startup, resume, clear, compact and fork — so this is an exclusion of compact alone, not an allowlist that silently drops sources added later.",
-        "matcher": "startup|clear|resume|fork",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.claude/hooks/check_git_root.sh",
-            "timeout": 3
           },
           {
             "type": "command",
@@ -722,6 +711,17 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/context_auto_apply.sh",
             "timeout": 10
+          }
+        ]
+      },
+      {
+        "//": "Gating a hook off compact is only safe when EVERYTHING it does is redundant after a compaction, and that is a property of the hook body, not of the source. show_auth_account.sh and context_auto_apply.sh were tried here and moved back above: the former recomputes a near-limit warning from a mutable usage cache, and the latter runs the 6h marketplace sync and the stale-plugin-symlink cleanup — side effects, not display. Both now suppress only their static output when source=compact, which recovers the noise without dropping live work. check_git_root.sh is left because it is purely a warning; the accepted cost is that a mid-session CWD change stops being re-warned after a compact. WARNING, this matcher IS a four-value allowlist despite reading like an exclusion of compact: SessionStart currently emits exactly startup, resume, clear, compact and fork, so today it excludes compact and nothing else, but a source added in a future release would be silently skipped here with no error and must be added by hand. Said explicitly because a comment asserting a safety property the code does not have is what hid the consent bug in issue #55.",
+        "matcher": "startup|clear|resume|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/check_git_root.sh",
+            "timeout": 3
           }
         ]
       }

--- a/tests/test_compact_gating.sh
+++ b/tests/test_compact_gating.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verifies the display/side-effect split added for the compact quieting.
+# Everything with a real side effect is stubbed: DOT_DIR points at an empty
+# temp tree so the symlink-cleanup guard skips, and PATH is emptied of
+# claude-tools so no sync is launched.
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")/../claude/hooks" && pwd)"
+WORK=$(mktemp -d) || { echo "mktemp failed"; exit 1; }
+[[ -n "$WORK" && "$WORK" == /tmp/* ]] || { echo "bad WORK=$WORK"; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0
+check() { # desc expected_empty_or_substr actual
+    local desc="$1" want="$2" got="$3"
+    if [[ "$want" == "<EMPTY>" ]]; then
+        if [[ -z "${got//[[:space:]]/}" ]]; then PASS=$((PASS+1)); echo "  ok   $desc"
+        else FAIL=$((FAIL+1)); echo "  FAIL $desc -- expected no output, got: $got"; fi
+    elif [[ "$got" == *"$want"* ]]; then PASS=$((PASS+1)); echo "  ok   $desc"
+    else FAIL=$((FAIL+1)); echo "  FAIL $desc -- expected to find: $want -- got: $got"; fi
+}
+
+# --- show_auth_account.sh -------------------------------------------------
+echo "show_auth_account.sh"
+
+# compact + no usage cache -> silent (does not even call `claude auth status`)
+mkdir -p "$WORK/tmpdir_empty"
+out=$(echo '{"source":"compact"}' | TMPDIR="$WORK/tmpdir_empty" bash "$HOOKS/show_auth_account.sh" 2>/dev/null)
+check "compact with no near-limit warning is silent" "<EMPTY>" "$out"
+
+# compact + usage at 96% -> the live warning still fires, account line dropped
+mkdir -p "$WORK/tmpdir_hot"
+cat > "$WORK/tmpdir_hot/claude-statusline-usage.json" <<'JSON'
+{"five_hour": {"utilization": 96}, "seven_day": {"utilization": 10}}
+JSON
+out=$(echo '{"source":"compact"}' | TMPDIR="$WORK/tmpdir_hot" bash "$HOOKS/show_auth_account.sh" 2>/dev/null)
+check "compact still surfaces the near-limit warning" "Near limit" "$out"
+check "and drops the static account line"             "<EMPTY>" "$(printf '%s' "$out" | grep -o 'Auth:' || true)"
+
+# --- context_auto_apply.sh ------------------------------------------------
+echo "context_auto_apply.sh"
+
+mkdir -p "$WORK/repo" && git -C "$WORK/repo" init -q 2>/dev/null
+mkdir -p "$WORK/nodot"   # DOT_DIR with no scripts/cleanup -> cleanup guard skips
+
+# non-compact, no context.yaml, inside a git repo -> the advisory prints
+out=$(cd "$WORK/repo" && echo '{"source":"startup"}' | \
+      DOT_DIR="$WORK/nodot" PATH="/usr/bin:/bin" bash "$HOOKS/context_auto_apply.sh" 2>/dev/null)
+check "startup prints the no-context advisory" "No context profiles configured" "$out"
+
+# compact, same conditions -> silent
+out=$(cd "$WORK/repo" && echo '{"source":"compact"}' | \
+      DOT_DIR="$WORK/nodot" PATH="/usr/bin:/bin" bash "$HOOKS/context_auto_apply.sh" 2>/dev/null)
+check "compact suppresses the advisory" "<EMPTY>" "$out"
+
+# unreadable source -> falls back to previous behaviour, not to a silent skip
+out=$(cd "$WORK/repo" && printf 'not json' | \
+      DOT_DIR="$WORK/nodot" PATH="/usr/bin:/bin" bash "$HOOKS/context_auto_apply.sh" 2>/dev/null)
+check "malformed hook input falls back to loud" "No context profiles configured" "$out"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/test_compact_gating.sh
+++ b/tests/test_compact_gating.sh
@@ -5,9 +5,21 @@
 # claude-tools so no sync is launched.
 set -uo pipefail
 
-HOOKS="$(cd "$(dirname "$0")/../claude/hooks" && pwd)"
-WORK=$(mktemp -d) || { echo "mktemp failed"; exit 1; }
-[[ -n "$WORK" && "$WORK" == /tmp/* ]] || { echo "bad WORK=$WORK"; exit 1; }
+# HOOKS_DIR override exists so the suite can be pointed at mutated copies to
+# confirm the assertions below actually fail when the quieting logic is broken.
+HOOKS="${HOOKS_DIR:-$(cd "$(dirname "$0")/../claude/hooks" && pwd)}"
+
+# Pick a writable scratch base. Under the Claude Code sandbox $TMPDIR is
+# /run/user/1000, which is mounted read-only, so an unqualified `mktemp -d`
+# fails there; /tmp/claude is the sandbox-writable path. Probe rather than
+# assume, so the test also runs unsandboxed and on macOS.
+TMPBASE=""
+for cand in "${TMPDIR:-}" /tmp/claude /tmp; do
+    [[ -n "$cand" && -d "$cand" && -w "$cand" ]] && { TMPBASE="$cand"; break; }
+done
+[[ -n "$TMPBASE" ]] || { echo "no writable temp base"; exit 1; }
+WORK=$(mktemp -d "${TMPBASE%/}/compact-gating.XXXXXX") || { echo "mktemp failed"; exit 1; }
+[[ -n "$WORK" && "$WORK" == "$TMPBASE"/* ]] || { echo "bad WORK=$WORK"; exit 1; }
 trap 'rm -rf "$WORK"' EXIT
 
 PASS=0; FAIL=0
@@ -57,6 +69,27 @@ check "compact suppresses the advisory" "<EMPTY>" "$out"
 out=$(cd "$WORK/repo" && printf 'not json' | \
       DOT_DIR="$WORK/nodot" PATH="/usr/bin:/bin" bash "$HOOKS/context_auto_apply.sh" 2>/dev/null)
 check "malformed hook input falls back to loud" "No context profiles configured" "$out"
+
+# --- stdin safety ---------------------------------------------------------
+# Both hooks now read stdin where they previously did not. `[ -t 0 ]` catches a
+# terminal but NOT a pipe with no writer, so a `cat` that blocks would stall
+# every session start - a worse regression than the noise this change removes.
+# Timeout-guarded so a hang fails the suite instead of hanging it.
+echo "stdin safety"
+
+out=$(cd "$WORK/repo" && DOT_DIR="$WORK/nodot" PATH="/usr/bin:/bin" \
+      timeout 5 bash "$HOOKS/context_auto_apply.sh" </dev/null 2>/dev/null); rc=$?
+check "context_auto_apply: closed stdin does not hang" "No context profiles configured" "$out"
+if [[ $rc -eq 124 ]]; then FAIL=$((FAIL+1)); echo "  FAIL context_auto_apply timed out on closed stdin"
+else PASS=$((PASS+1)); echo "  ok   context_auto_apply exits on closed stdin (rc=$rc)"; fi
+
+# PATH stubbed because closed stdin leaves QUIET false, which reaches the
+# `claude auth status` call - the suite must not query the real auth state.
+out=$(TMPDIR="$WORK/tmpdir_hot" PATH="/usr/bin:/bin" \
+      timeout 5 bash "$HOOKS/show_auth_account.sh" </dev/null 2>/dev/null); rc=$?
+check "show_auth_account: closed stdin still warns" "Near limit" "$out"
+if [[ $rc -eq 124 ]]; then FAIL=$((FAIL+1)); echo "  FAIL show_auth_account timed out on closed stdin"
+else PASS=$((PASS+1)); echo "  ok   show_auth_account exits on closed stdin (rc=$rc)"; fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
Quietens two sources of SessionStart noise, and — after review — corrects the way the second one was done.

## What changed

**`nudge_modern_tools.sh` — debounced.** It re-fired on every matching command; it now stays quiet for a cooldown window per tool, so a single session no longer repeats the same suggestion.

**Compact quieting — moved out of `settings.json` and into the hooks.** The first attempt excluded three hooks from `source=compact` with a matcher. Review found that two of the three are not status displays, so the exclusion dropped live work rather than duplicate output:

- `context_auto_apply.sh` runs the 6h-throttled marketplace sync and the unconditional stale-plugin-symlink cleanup. Gated off compact, a session running past six hours never syncs and accumulates the duplicate plugin symlinks that `clean-skill-dupes` exists to remove.
- `show_auth_account.sh` recomputes a near-limit warning from a mutable usage cache on each run. Usage crossing 95% mid-session stopped surfacing after a compaction. Only the account line is genuinely fixed for the life of a session.

Whether a hook is safe to skip on compact is a property of the hook body, not of the source. So both hooks now read the SessionStart source themselves and suppress only their static output: `context_auto_apply.sh` still applies the profile and still runs both background jobs, and `show_auth_account.sh` still emits the near-limit warning but no longer calls `claude auth status` or prints the account line, emitting nothing at all when there is no warning to give.

`check_git_root.sh` stays gated — it is purely a warning. The accepted cost is that a mid-session CWD change is no longer re-warned after a compact.

An unreadable source, or a missing `jq`, leaves the quiet flag false and reproduces the previous behaviour exactly. The fallback is the status quo, never a silent skip.

Also corrects the `settings.json` comment, which claimed the matcher was "not an allowlist that silently drops sources added later". It is exactly a four-value allowlist. A comment asserting a safety property the code does not have is what hid the consent bug in #55.

## Verification

`tests/test_compact_gating.sh`, with every real side effect stubbed — `DOT_DIR` points at an empty tree so the symlink-cleanup guard skips, and `PATH` is stripped of `claude-tools` and `claude` so no sync launches and no auth query runs.

- **PASS=10 FAIL=0** unmutated.
- **PASS=7 FAIL=3** against copies of both hooks with the `QUIET` assignment replaced by a no-op. Exactly the three compact-silence assertions turn red and the three loud-path assertions stay green, so the suite is not vacuous.
- Closed-stdin assertions on both hooks. They read stdin where they previously did not, and `[ -t 0 ]` catches a terminal but not a pipe with no writer — a `cat` that blocked there would stall every session start. Both exit 0 immediately, timeout-guarded so a hang would fail the suite rather than hang it.

`settings.json` parses and retains `statusLine`, `hooks` and `permissions`; SessionStart is 10 all-source hooks plus `check_git_root.sh` alone behind the matcher, the same command set as before, only regrouped. `shellcheck` and `bash -n` clean on both hooks.
