### PR TITLE
feat(hooks): nudge simplify to promote reused scratch scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,5 @@ This repo is **public** — and a branch in a public repo is public too, so pers
 ## Learnings
 
 Project-specific bugs, quirks, decisions and current state. Timestamp `- description (YYYY-MM-DD)`, keep under 20, prune past two weeks — retired entries move to [`docs/tooling-and-packages.md`](docs/tooling-and-packages.md) § Past Learnings.
+
+- The simplify nudge now has a second signal: `simplify_track_reuse.py` counts *runs* of scratch scripts (not writes — writes are iteration) and the Stop hook suggests promoting any that ran 3× with at least one run unchanged. Rules for where a promoted script lands: `claude/rules/reusable-component-promotion.md` (2026-08-01)

--- a/claude/hooks/README.md
+++ b/claude/hooks/README.md
@@ -62,7 +62,8 @@ Hooks for automating task and agent management workflows.
 
 **Behavior:**
 - `simplify_mark_dirty.sh` (`PostToolUse`, `Write|Edit`) touches a per-session marker when a code file changes → "run a quality pass".
-- `simplify_track_reuse.py` (`PostToolUse`, `Bash`) tallies *executions* of throwaway scripts (paths under `tmp/`/`scratch/`, or `tmp_`-prefixed names) in a per-session JSON state file. A run whose file is unchanged since the previous run counts as "stable", so edit-run-edit-run debugging never accumulates.
+- `simplify_track_reuse.py` (`PostToolUse`, `Bash`) tallies *executions* of throwaway scripts in a per-session JSON state file (under a 0700 per-user dir in `TMPDIR` — its contents reach the user as a message). A run whose file is unchanged since the previous run counts as "stable", so edit-run-edit-run debugging never accumulates, and a path that can't be stat'ed is never stable.
+- Scratch-ness is judged *relative to the enclosing repo*: `tmp_probe.py` or anything under a `tmp/`/`scratch/` segment qualifies, but a repo or worktree checked out under `/tmp` doesn't turn its own `tests/` into scratch. Commands are followed through `cd`, glued operators, interpreter flags and `uv run`; redirect targets and huge inline programs are skipped.
 - `simplify_nudge.sh` (`Stop`) fires when a script hit `CLAUDE_SIMPLIFY_REUSE_RUNS` (default 3) runs with at least one stable run → "promote it into a permanent component" (criteria and destinations: `rules/reusable-component-promotion.md`). Each candidate is nudged once per session.
 
 **Tests:** `test_simplify_reuse.sh`.

--- a/claude/hooks/README.md
+++ b/claude/hooks/README.md
@@ -56,6 +56,17 @@ Hooks for automating task and agent management workflows.
 - Blocks tool call when `AUTO_AGENT_DEPTH >= AUTO_AGENT_MAX_DEPTH`.
 - Intended to cap recursive delegation chains.
 
+### simplify_mark_dirty.sh / simplify_track_reuse.py / simplify_nudge.sh
+
+**Purpose:** Suggest a `/simplify` pass when the session produced work worth one. Two independent signals feed one `Stop` message; both are soft nudges (`systemMessage`) that never continue the turn.
+
+**Behavior:**
+- `simplify_mark_dirty.sh` (`PostToolUse`, `Write|Edit`) touches a per-session marker when a code file changes → "run a quality pass".
+- `simplify_track_reuse.py` (`PostToolUse`, `Bash`) tallies *executions* of throwaway scripts (paths under `tmp/`/`scratch/`, or `tmp_`-prefixed names) in a per-session JSON state file. A run whose file is unchanged since the previous run counts as "stable", so edit-run-edit-run debugging never accumulates.
+- `simplify_nudge.sh` (`Stop`) fires when a script hit `CLAUDE_SIMPLIFY_REUSE_RUNS` (default 3) runs with at least one stable run → "promote it into a permanent component" (criteria and destinations: `rules/reusable-component-promotion.md`). Each candidate is nudged once per session.
+
+**Tests:** `test_simplify_reuse.sh`.
+
 ## Runtime Policy
 
 Shared config is in `config/ai_automation.sh` (optionally overridden by `~/.claude/ai_automation.local.sh`).

--- a/claude/hooks/simplify_nudge.sh
+++ b/claude/hooks/simplify_nudge.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-# Stop hook: if a code file changed this turn (marked by
-# simplify_mark_dirty.sh), surface a systemMessage suggesting a simplify pass.
+# Stop hook: surface a simplify suggestion when this session produced work a
+# quality pass would improve. Two independent signals, one message:
+#
+#   1. a code file changed this turn (marked by simplify_mark_dirty.sh);
+#   2. a throwaway script has been run enough times to deserve a permanent home
+#      (tallied by simplify_track_reuse.py) — the reuse/promotion signal, which
+#      fires whether or not anything was edited this turn.
+#
 # Soft nudge only — never blocks the stop.
 #
 # systemMessage, not additionalContext, and deliberately so. additionalContext
@@ -20,13 +26,48 @@ INPUT=$(cat)
 SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || exit 0
 [ -z "$SESSION_ID" ] && exit 0
 
-MARKER="${TMPDIR:-/tmp}/claude-simplify-dirty-${SESSION_ID}"
-[ -f "$MARKER" ] || exit 0
-rm -f "$MARKER" 2>/dev/null || true
+TMP="${TMPDIR:-/tmp}"
+MARKER="$TMP/claude-simplify-dirty-${SESSION_ID}"
+REUSE_STATE="$TMP/claude-simplify-reuse-${SESSION_ID}.json"
 
-cat <<'HOOK_EOF'
-{
-  "systemMessage": "Code changed this turn — `/simplify` will run a quality pass over the changed files if it's worth one."
-}
-HOOK_EOF
+# Runs of the same script needed before it counts as reusable. At least one of
+# them must be a "stable" run (file unchanged since the previous run) so that
+# edit-run-edit-run debugging never trips the nudge — see simplify_track_reuse.py.
+THRESHOLD="${CLAUDE_SIMPLIFY_REUSE_RUNS:-3}"
+[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || THRESHOLD=3
+
+PARTS=()
+
+if [ -f "$MARKER" ]; then
+  rm -f "$MARKER" 2>/dev/null || true
+  PARTS+=("Code changed this turn — \`/simplify\` will run a quality pass over the changed files if it's worth one.")
+fi
+
+if [ -f "$REUSE_STATE" ]; then
+  SELECT="(.value.runs // 0) >= \$t and (.value.stable // 0) >= 1 and (.value.notified // false) != true"
+  CANDIDATES=$(jq -r --argjson t "$THRESHOLD" \
+    "to_entries | map(select($SELECT)) | .[] | \"- \\(.key) (ran \\(.value.runs)×)\"" \
+    "$REUSE_STATE" 2>/dev/null) || CANDIDATES=""
+
+  if [ -n "$CANDIDATES" ]; then
+    PARTS+=("Scratch scripts reused this session:
+$CANDIDATES
+
+\`/simplify\` can promote them into permanent, reusable components — a real script on PATH, a shared function, or a skill.")
+
+    # Mark them notified so the nudge doesn't repeat every turn for the rest of
+    # the session. Failure here just means a duplicate nudge later — never fatal.
+    if OUT=$(jq --argjson t "$THRESHOLD" \
+        "with_entries(if $SELECT then .value.notified = true else . end)" \
+        "$REUSE_STATE" 2>/dev/null); then
+      printf '%s\n' "$OUT" > "$REUSE_STATE.tmp" 2>/dev/null &&
+        mv -f "$REUSE_STATE.tmp" "$REUSE_STATE" 2>/dev/null || true
+    fi
+  fi
+fi
+
+[ ${#PARTS[@]} -eq 0 ] && exit 0
+
+MSG=$(printf '%s\n\n' "${PARTS[@]}")
+jq -n --arg msg "${MSG%$'\n\n'}" '{systemMessage: $msg}'
 exit 0

--- a/claude/hooks/simplify_nudge.sh
+++ b/claude/hooks/simplify_nudge.sh
@@ -28,13 +28,19 @@ SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) ||
 
 TMP="${TMPDIR:-/tmp}"
 MARKER="$TMP/claude-simplify-dirty-${SESSION_ID}"
-REUSE_STATE="$TMP/claude-simplify-reuse-${SESSION_ID}.json"
+# Must match state_path() in simplify_track_reuse.py. The 0700 per-user
+# directory matters because these contents are echoed back to the user as a
+# systemMessage — another local account must not be able to write them.
+STATE_DIR="$TMP/claude-simplify-$(id -u)"
+REUSE_STATE="$STATE_DIR/reuse-${SESSION_ID}.json"
+[ -d "$STATE_DIR" ] && [ -O "$STATE_DIR" ] || REUSE_STATE=""
 
 # Runs of the same script needed before it counts as reusable. At least one of
 # them must be a "stable" run (file unchanged since the previous run) so that
 # edit-run-edit-run debugging never trips the nudge — see simplify_track_reuse.py.
+# Leading zeros are rejected too: --argjson would choke on `007`.
 THRESHOLD="${CLAUDE_SIMPLIFY_REUSE_RUNS:-3}"
-[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || THRESHOLD=3
+[[ "$THRESHOLD" =~ ^[1-9][0-9]*$ ]] || THRESHOLD=3
 
 PARTS=()
 
@@ -43,8 +49,11 @@ if [ -f "$MARKER" ]; then
   PARTS+=("Code changed this turn — \`/simplify\` will run a quality pass over the changed files if it's worth one.")
 fi
 
-if [ -f "$REUSE_STATE" ]; then
-  SELECT="(.value.runs // 0) >= \$t and (.value.stable // 0) >= 1 and (.value.notified // false) != true"
+if [ -n "$REUSE_STATE" ] && [ -f "$REUSE_STATE" ]; then
+  # The type guard keeps one corrupt entry from erroring the whole program out
+  # and suppressing every valid candidate alongside it.
+  SELECT="(.value | type) == \"object\" and ((.value.runs // 0) | tonumber? // 0) >= \$t \
+and ((.value.stable // 0) | tonumber? // 0) >= 1 and (.value.notified // false) != true"
   CANDIDATES=$(jq -r --argjson t "$THRESHOLD" \
     "to_entries | map(select($SELECT)) | .[] | \"- \\(.key) (ran \\(.value.runs)×)\"" \
     "$REUSE_STATE" 2>/dev/null) || CANDIDATES=""
@@ -68,6 +77,7 @@ fi
 
 [ ${#PARTS[@]} -eq 0 ] && exit 0
 
+# Command substitution strips the trailing blank line between parts for us.
 MSG=$(printf '%s\n\n' "${PARTS[@]}")
-jq -n --arg msg "${MSG%$'\n\n'}" '{systemMessage: $msg}'
+jq -n --arg msg "$MSG" '{systemMessage: $msg}'
 exit 0

--- a/claude/hooks/simplify_track_reuse.py
+++ b/claude/hooks/simplify_track_reuse.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""PostToolUse(Bash) hook: tally repeat runs of throwaway scripts.
+
+Pairs with simplify_nudge.sh (Stop), which turns the tally into a suggestion to
+promote a scratch script into a permanent, reusable component. The signal we
+want is "this throwaway earned its keep", not "a script exists":
+
+  * only executions count — writing and editing a script is iteration, not reuse
+    (that's what the simplify_mark_dirty.sh / simplify_nudge.sh pair covers);
+  * a run whose file is byte-identical (same mtime) to the previous run is a
+    "stable" run. Edit-run-edit-run debugging loops produce runs but no stable
+    runs, so they never reach the promotion threshold.
+
+State lives in a per-session JSON file under TMPDIR, same convention as the
+dirty marker. Per-session (not per-user) keeps cleanup free and avoids nudging
+about a script someone abandoned last week. Concurrent Bash calls can race on
+the read-modify-write; the loser silently loses one increment, which is a fine
+outcome for a nudge and not worth a lock file.
+
+Always exits 0 and never blocks — a tracking hook must not break a Bash call.
+"""
+
+import json
+import os
+import re
+import shlex
+import sys
+
+SCRIPT_RE = re.compile(r"\.(py|sh|bash|zsh|js|mjs|cjs|ts|rb|pl|R)$")
+
+# Throwaway *locations*: a tmp/scratch path segment anywhere, or macOS's
+# /var/folders TMPDIR. Includes the agent scratchpad (/tmp/claude-*/…).
+SCRATCH_DIR_RE = re.compile(r"(^|/)(tmp|temp|scratch|scratchpad|\.tmp|var/folders)(/|$)")
+# Throwaway *names*: tmp_foo.py, scratch-check.sh, oneoff_backfill.py.
+SCRATCH_NAME_RE = re.compile(r"^(tmp|temp|scratch|throwaway|oneoff|one_off)[-_.]")
+# Vendored trees hold plenty of tmp/ paths that are nobody's scratch work.
+VENDOR_RE = re.compile(r"/(node_modules|site-packages|\.venv|venv|\.git|dist|build)/")
+# A script whose own directory is a permanent home already lives where a
+# promotion would put it. Matters because repos and worktrees get checked out
+# under /tmp, which would otherwise make every script in them look scratch.
+PERMANENT_PARENTS = {"bin", "sbin", "custom_bins", "tools", "scripts", "libexec"}
+
+# A candidate path only counts when something actually ran it: an interpreter
+# in front of it, or the path itself in command position (./tmp/x.sh).
+INTERPRETERS = {
+    "python", "python3", "uv", "uvx", "run", "bash", "sh", "zsh", "fish",
+    "node", "bun", "deno", "tsx", "ts-node", "ruby", "perl", "Rscript",
+    "pytest", "poetry", "pdm", "source", ".",
+}
+# Tokens after which the next word starts a fresh command.
+CMD_START_AFTER = {
+    "&&", "||", ";", "|", "|&", "&", "(", ")", "{", "}",
+    "then", "else", "do", "time", "nohup", "env", "exec", "xargs", "command",
+}
+
+
+def is_scratch(path: str) -> bool:
+    if not SCRIPT_RE.search(path) or VENDOR_RE.search(path):
+        return False
+    parent = os.path.dirname(path)
+    if os.path.basename(parent) in PERMANENT_PARENTS:
+        return False
+    if SCRATCH_DIR_RE.search(parent):
+        return True
+    return bool(SCRATCH_NAME_RE.match(os.path.basename(path)))
+
+
+def scripts_run(command: str, cwd: str) -> list:
+    """Absolute paths of scratch scripts this command executes (deduped)."""
+    try:
+        tokens = shlex.split(command, comments=True)
+    except ValueError:
+        # Unbalanced quotes (heredocs, mostly) — a dumb split still finds paths.
+        tokens = command.split()
+
+    found, at_cmd_start = [], True
+    for i, token in enumerate(tokens):
+        if token in CMD_START_AFTER:
+            at_cmd_start = True
+            continue
+        prev = tokens[i - 1] if i else ""
+        executed = at_cmd_start or os.path.basename(prev) in INTERPRETERS
+        at_cmd_start = False
+        if executed and is_scratch(token):
+            resolved = os.path.normpath(os.path.join(cwd, os.path.expanduser(token)))
+            if resolved not in found:
+                found.append(resolved)
+    return found
+
+
+def state_path(session_id: str) -> str:
+    tmp = os.environ.get("TMPDIR") or "/tmp"
+    return os.path.join(tmp, f"claude-simplify-reuse-{session_id}.json")
+
+
+def load_state(path: str) -> dict:
+    try:
+        with open(path) as fh:
+            state = json.load(fh)
+        return state if isinstance(state, dict) else {}
+    except Exception:
+        return {}
+
+
+def save_state(path: str, state: dict) -> None:
+    tmp_path = f"{path}.{os.getpid()}.tmp"
+    try:
+        with open(tmp_path, "w") as fh:
+            json.dump(state, fh)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def record(state: dict, script: str) -> None:
+    try:
+        mtime = os.path.getmtime(script)
+    except OSError:
+        mtime = 0.0  # deleted or never on disk — still counts as a run
+
+    entry = state.get(script)
+    if not isinstance(entry, dict):
+        entry = {"runs": 0, "stable": 0, "mtime": None, "notified": False}
+    entry["runs"] = int(entry.get("runs") or 0) + 1
+    if entry.get("mtime") == mtime:
+        entry["stable"] = int(entry.get("stable") or 0) + 1
+    entry["mtime"] = mtime
+    state[script] = entry
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return
+    if not isinstance(payload, dict):
+        return
+
+    session_id = payload.get("session_id") or ""
+    tool_input = payload.get("tool_input")
+    if not session_id or not isinstance(tool_input, dict):
+        return
+
+    command = tool_input.get("command") or ""
+    if not isinstance(command, str) or not command:
+        return
+
+    cwd = payload.get("cwd") or os.getcwd()
+    scripts = scripts_run(command, cwd if isinstance(cwd, str) else os.getcwd())
+    if not scripts:
+        return
+
+    path = state_path(session_id)
+    state = load_state(path)
+    for script in scripts:
+        record(state, script)
+    save_state(path, state)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass
+    sys.exit(0)

--- a/claude/hooks/simplify_track_reuse.py
+++ b/claude/hooks/simplify_track_reuse.py
@@ -9,13 +9,17 @@ want is "this throwaway earned its keep", not "a script exists":
     (that's what the simplify_mark_dirty.sh / simplify_nudge.sh pair covers);
   * a run whose file is byte-identical (same mtime) to the previous run is a
     "stable" run. Edit-run-edit-run debugging loops produce runs but no stable
-    runs, so they never reach the promotion threshold.
+    runs, so they never reach the promotion threshold. A path we can't stat is
+    never stable — an unresolvable path is the least verified thing here, and
+    counting it would nudge about scripts that don't exist.
 
-State lives in a per-session JSON file under TMPDIR, same convention as the
-dirty marker. Per-session (not per-user) keeps cleanup free and avoids nudging
-about a script someone abandoned last week. Concurrent Bash calls can race on
-the read-modify-write; the loser silently loses one increment, which is a fine
-outcome for a nudge and not worth a lock file.
+Scratch-ness is judged *relative to the enclosing repo* when there is one, so a
+repo or worktree checked out under /tmp doesn't make its whole test suite look
+like scratch work, while a repo-local `tmp/` still does.
+
+State lives in a per-user 0700 directory under TMPDIR. Concurrent Bash calls can
+race on the read-modify-write; the loser silently loses one increment, which is
+a fine outcome for a nudge and not worth a lock file.
 
 Always exits 0 and never blocks — a tracking hook must not break a Bash call.
 """
@@ -27,70 +31,178 @@ import shlex
 import sys
 
 SCRIPT_RE = re.compile(r"\.(py|sh|bash|zsh|js|mjs|cjs|ts|rb|pl|R)$")
+# Cheap pre-filter so the overwhelming majority of Bash calls never reach the
+# tokenizer: no script extension anywhere in the command, nothing to track.
+SCRIPT_HINT_RE = re.compile(r"\.(py|sh|bash|zsh|js|mjs|cjs|ts|rb|pl|R)\b")
+# shlex.split is quadratic in the length of a single token, and a giant token is
+# exactly what `python3 -c '<program>'` or an inline base64 blob looks like. No
+# scratch-script invocation is this long; refusing to tokenize keeps the hook
+# far inside its timeout instead of stalling every large Bash call.
+MAX_COMMAND_LEN = 20_000
 
-# Throwaway *locations*: a tmp/scratch path segment anywhere, or macOS's
-# /var/folders TMPDIR. Includes the agent scratchpad (/tmp/claude-*/…).
+# Throwaway *locations*: a tmp/scratch path segment, or macOS's /var/folders
+# TMPDIR. Includes the agent scratchpad (/tmp/claude-*/…).
 SCRATCH_DIR_RE = re.compile(r"(^|/)(tmp|temp|scratch|scratchpad|\.tmp|var/folders)(/|$)")
 # Throwaway *names*: tmp_foo.py, scratch-check.sh, oneoff_backfill.py.
 SCRATCH_NAME_RE = re.compile(r"^(tmp|temp|scratch|throwaway|oneoff|one_off)[-_.]")
 # Vendored trees hold plenty of tmp/ paths that are nobody's scratch work.
 VENDOR_RE = re.compile(r"/(node_modules|site-packages|\.venv|venv|\.git|dist|build)/")
-# A script whose own directory is a permanent home already lives where a
-# promotion would put it. Matters because repos and worktrees get checked out
-# under /tmp, which would otherwise make every script in them look scratch.
+# Directories that already are a permanent home — a script sitting in one has
+# nowhere to be promoted to.
 PERMANENT_PARENTS = {"bin", "sbin", "custom_bins", "tools", "scripts", "libexec"}
 
-# A candidate path only counts when something actually ran it: an interpreter
-# in front of it, or the path itself in command position (./tmp/x.sh).
+# A candidate path only counts when something ran it: an interpreter earlier in
+# the same command segment, or the path itself in command position (./tmp/x.sh).
 INTERPRETERS = {
-    "python", "python3", "uv", "uvx", "run", "bash", "sh", "zsh", "fish",
+    "python", "python3", "uv", "uvx", "bash", "sh", "zsh", "fish",
     "node", "bun", "deno", "tsx", "ts-node", "ruby", "perl", "Rscript",
     "pytest", "poetry", "pdm", "source", ".",
 }
-# Tokens after which the next word starts a fresh command.
-CMD_START_AFTER = {
+# Tokens after which the next word starts a fresh command. Glued operators
+# (`x.py; echo`) are split into these by tokenize().
+SEPARATORS = {
     "&&", "||", ";", "|", "|&", "&", "(", ")", "{", "}",
-    "then", "else", "do", "time", "nohup", "env", "exec", "xargs", "command",
+    "then", "else", "do", "done", "fi", "time", "nohup", "env", "exec",
+    "xargs", "command",
 }
+SEPARATOR_RE = re.compile(r"[;|&()]+")
+REDIRECTS = {">", ">>", "<", "<<", "2>", "2>>", "&>", "1>", ">|"}
+ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
-def is_scratch(path: str) -> bool:
+def tokenize(command: str) -> list:
+    """Shell-ish tokens, with glued operators promoted to their own tokens."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        # Unbalanced quotes (heredocs, mostly) — a dumb split still finds paths.
+        tokens = command.split()
+
+    flat = []
+    for token in tokens:
+        if not SEPARATOR_RE.search(token):
+            flat.append(token)
+            continue
+        for i, part in enumerate(SEPARATOR_RE.split(token)):
+            if i:
+                flat.append(";")
+            if part:
+                flat.append(part)
+    return flat
+
+
+def resolve(token: str, cwd: str):
+    """Absolute path for a command token, or None if it isn't literal enough."""
+    if not token or "$" in token or "*" in token or "?" in token:
+        return None
+    return os.path.normpath(os.path.join(cwd, os.path.expanduser(token)))
+
+
+def repo_root(directory: str, cache: dict):
+    """Nearest ancestor holding a .git, or None. Memoized per directory."""
+    if directory in cache:
+        return cache[directory]
+
+    seen, current = [], directory
+    root = None
+    for _ in range(64):  # bounded: never walk a pathological path forever
+        if current in cache:
+            root = cache[current]
+            break
+        seen.append(current)
+        if os.path.exists(os.path.join(current, ".git")):
+            root = current
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    for path in seen:
+        cache[path] = root
+    return root
+
+
+def is_scratch(path: str, cache: dict) -> bool:
+    """Does this look like a throwaway script rather than a real component?"""
     if not SCRIPT_RE.search(path) or VENDOR_RE.search(path):
         return False
-    parent = os.path.dirname(path)
-    if os.path.basename(parent) in PERMANENT_PARENTS:
+
+    directory = os.path.dirname(path)
+    # Inside a repo, judge the path by where it sits *in the repo*: a checkout
+    # under /tmp is a checkout, not scratch — but its own tmp/ dir still is.
+    root = repo_root(directory, cache)
+    relative = os.path.relpath(directory, root) if root else directory
+    if relative == ".":
+        relative = ""
+
+    if PERMANENT_PARENTS & set(relative.split(os.sep)):
         return False
-    if SCRATCH_DIR_RE.search(parent):
+    if SCRATCH_DIR_RE.search(relative):
         return True
     return bool(SCRATCH_NAME_RE.match(os.path.basename(path)))
 
 
 def scripts_run(command: str, cwd: str) -> list:
     """Absolute paths of scratch scripts this command executes (deduped)."""
-    try:
-        tokens = shlex.split(command, comments=True)
-    except ValueError:
-        # Unbalanced quotes (heredocs, mostly) — a dumb split still finds paths.
-        tokens = command.split()
+    if len(command) > MAX_COMMAND_LEN or not SCRIPT_HINT_RE.search(command):
+        return []
 
-    found, at_cmd_start = [], True
+    tokens = tokenize(command)
+    found, cache = [], {}
+    at_cmd_start, saw_interpreter, prev = True, False, ""
+
     for i, token in enumerate(tokens):
-        if token in CMD_START_AFTER:
-            at_cmd_start = True
+        if token in SEPARATORS:
+            at_cmd_start, saw_interpreter, prev = True, False, ""
             continue
-        prev = tokens[i - 1] if i else ""
-        executed = at_cmd_start or os.path.basename(prev) in INTERPRETERS
+        if prev in REDIRECTS:  # a redirect target was written, not run
+            prev = token
+            continue
+        prev = token
+        if ASSIGN_RE.match(token) or token.startswith("-"):
+            continue  # env assignment or flag: neither starts nor ends a command
+
+        # `cd /tmp/work && ./probe.sh` — follow the cwd or the path resolves
+        # against the wrong directory and we nudge about a file that isn't there.
+        if at_cmd_start and token == "cd" and i + 1 < len(tokens):
+            target = resolve(tokens[i + 1], cwd)
+            if target and os.path.isdir(target):
+                cwd = target
+            continue
+
+        if os.path.basename(token) in INTERPRETERS:
+            saw_interpreter = True
+            at_cmd_start = False
+            continue
+
+        executed = at_cmd_start or saw_interpreter
         at_cmd_start = False
-        if executed and is_scratch(token):
-            resolved = os.path.normpath(os.path.join(cwd, os.path.expanduser(token)))
-            if resolved not in found:
-                found.append(resolved)
+        if not executed:
+            continue
+
+        path = resolve(token, cwd)
+        if path and path not in found and is_scratch(path, cache):
+            found.append(path)
     return found
 
 
-def state_path(session_id: str) -> str:
+def state_path(session_id: str):
+    """Per-session state file inside a private per-user directory, or None.
+
+    0700 and ownership-checked: the file's contents reach the user as a
+    systemMessage, so another local account must not be able to write it.
+    """
     tmp = os.environ.get("TMPDIR") or "/tmp"
-    return os.path.join(tmp, f"claude-simplify-reuse-{session_id}.json")
+    directory = os.path.join(tmp, f"claude-simplify-{os.geteuid()}")
+    try:
+        os.makedirs(directory, mode=0o700, exist_ok=True)
+        info = os.stat(directory)
+    except OSError:
+        return None
+    if info.st_uid != os.geteuid() or info.st_mode & 0o077:
+        return None
+    return os.path.join(directory, f"reuse-{session_id}.json")
 
 
 def load_state(path: str) -> dict:
@@ -115,19 +227,30 @@ def save_state(path: str, state: dict) -> None:
             pass
 
 
+def count(value) -> int:
+    """Coerce a tally that a corrupt state file may have turned into anything."""
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def record(state: dict, script: str) -> None:
     try:
         mtime = os.path.getmtime(script)
     except OSError:
-        mtime = 0.0  # deleted or never on disk — still counts as a run
+        mtime = None  # unresolvable path: counts as a run, never as stable
 
     entry = state.get(script)
     if not isinstance(entry, dict):
         entry = {"runs": 0, "stable": 0, "mtime": None, "notified": False}
-    entry["runs"] = int(entry.get("runs") or 0) + 1
-    if entry.get("mtime") == mtime:
-        entry["stable"] = int(entry.get("stable") or 0) + 1
+    entry["runs"] = count(entry.get("runs")) + 1
+    if mtime is not None and entry.get("mtime") == mtime:
+        entry["stable"] = count(entry.get("stable")) + 1
+    else:
+        entry["stable"] = count(entry.get("stable"))
     entry["mtime"] = mtime
+    entry["notified"] = bool(entry.get("notified"))
     state[script] = entry
 
 
@@ -141,19 +264,24 @@ def main() -> None:
 
     session_id = payload.get("session_id") or ""
     tool_input = payload.get("tool_input")
-    if not session_id or not isinstance(tool_input, dict):
+    if not session_id or "/" in session_id or not isinstance(tool_input, dict):
         return
 
     command = tool_input.get("command") or ""
     if not isinstance(command, str) or not command:
         return
 
-    cwd = payload.get("cwd") or os.getcwd()
-    scripts = scripts_run(command, cwd if isinstance(cwd, str) else os.getcwd())
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        cwd = os.getcwd()
+
+    scripts = scripts_run(command, cwd)
     if not scripts:
         return
 
     path = state_path(session_id)
+    if not path:
+        return
     state = load_state(path)
     for script in scripts:
         record(state, script)

--- a/claude/hooks/test_simplify_reuse.sh
+++ b/claude/hooks/test_simplify_reuse.sh
@@ -24,6 +24,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 # Hooks keep their state under TMPDIR — point them at the sandbox.
 export TMPDIR="$TMP"
+STATE_DIR="$TMP/claude-simplify-$(id -u)"
+state_file() { printf '%s/reuse-%s.json' "$STATE_DIR" "$1"; }
 
 ok()   { PASS=$((PASS + 1)); }
 bad()  { FAIL=$((FAIL + 1)); printf 'FAIL: %s\n' "$1"; }
@@ -60,6 +62,13 @@ expect() {
     case "$out" in *systemMessage*) got=fire ;; esac
     if [ "$got" != "$want" ]; then
         bad "$desc (expected $want, got $got)"
+        return
+    fi
+    # Half the output contract is that stdout is a single valid JSON object
+    # with a systemMessage key — a substring check alone would miss a message
+    # broken by a quote or newline in a script path.
+    if [ "$got" = fire ] && ! printf '%s' "$out" | jq -e '.systemMessage | strings' >/dev/null 2>&1; then
+        bad "$desc (stdout is not a JSON object with a string systemMessage)"
         return
     fi
     if [ -n "$needle" ] && [[ "$out" != *"$needle"* ]]; then
@@ -131,6 +140,97 @@ for i in 1 2 3 4; do
 done
 expect "edited between every run stays silent" "$(nudge "$S")" silent
 
+# --- scratch-ness is judged relative to the enclosing repo ------------------
+# Repos and worktrees get checked out under /tmp; without this, running a test
+# file three times would nudge you to "promote" your test suite.
+echo "=== repo-relative detection ==="
+
+mkdir -p "$TMP/myrepo/.git" "$TMP/myrepo/tests" "$TMP/myrepo/src" "$TMP/myrepo/tmp"
+printf 'x = 1\n' > "$TMP/myrepo/tests/test_auth.py"
+printf 'x = 1\n' > "$TMP/myrepo/src/utils.py"
+printf 'x = 1\n' > "$TMP/myrepo/tmp/probe.py"
+
+S=repo-tests
+runs 3 "$S" "$TMP" "pytest $TMP/myrepo/tests/test_auth.py -x"
+expect "test file in a repo under /tmp ignored" "$(nudge "$S")" silent
+
+S=repo-src
+runs 3 "$S" "$TMP" "python3 $TMP/myrepo/src/utils.py"
+expect "source file in a repo under /tmp ignored" "$(nudge "$S")" silent
+
+S=repo-tmp
+runs 3 "$S" "$TMP" "python3 $TMP/myrepo/tmp/probe.py"
+expect "repo-local tmp/ is still scratch" "$(nudge "$S")" fire "myrepo/tmp/probe.py"
+
+# --- path resolution: never nudge about a file that isn't there -------------
+echo "=== path resolution ==="
+
+S=cd-prefix
+runs 3 "$S" "/home/user" "cd $TMP && bash scratch/probe.sh"
+OUT=$(nudge "$S")
+expect "cd prefix resolves the real path" "$OUT" fire "$TMP/scratch/probe.sh"
+case "$OUT" in *"/home/user/scratch/probe.sh"*) bad "cd prefix leaked the pre-cd cwd" ;; *) ok ;; esac
+
+S=ghost
+runs 4 "$S" "$TMP" "python3 $TMP/scratch/ghost.py"
+expect "nonexistent script never goes stable" "$(nudge "$S")" silent
+
+S=unexpanded
+runs 4 "$S" "$TMP" 'python3 $TMPDIR/tmp_probe.py'
+expect "unexpanded variable is not a path" "$(nudge "$S")" silent
+
+S=redirect-target
+printf 'x = 1\n' > "$TMP/bin/gen.py"
+runs 3 "$S" "$TMP" "python3 $TMP/bin/gen.py > $TMP/scratch/out.py"
+expect "redirect target is written, not run" "$(nudge "$S")" silent
+
+# --- command shapes that must still count ----------------------------------
+echo "=== command shapes ==="
+
+S=glued
+runs 3 "$S" "$TMP" "python3 $TMP/scratch/probe.py; echo done"
+expect "glued semicolon still counts" "$(nudge "$S")" fire "probe.py"
+
+S=loop
+runs 3 "$S" "$TMP" "for i in 1 2; do python3 $TMP/scratch/probe.py; done"
+expect "for-loop body still counts" "$(nudge "$S")" fire "probe.py"
+
+S=flags
+runs 3 "$S" "$TMP" "python3 -u $TMP/scratch/probe.py"
+expect "interpreter flags don't hide the script" "$(nudge "$S")" fire "probe.py"
+
+S=uv-with
+runs 3 "$S" "$TMP" "uv run --with requests $TMP/scratch/probe.py"
+expect "uv run with flag arguments counts" "$(nudge "$S")" fire "probe.py"
+
+S=bare
+runs 3 "$S" "$TMP/scratch" "python3 probe.py"
+expect "bare name inside a scratch cwd counts" "$(nudge "$S")" fire "$TMP/scratch/probe.py"
+
+S=hash
+printf 'x = 1\n' > "$TMP/scratch/tmp_v#1.py"
+runs 3 "$S" "$TMP" "python3 $TMP/scratch/tmp_v#1.py"
+expect "# in a filename is not a comment" "$(nudge "$S")" fire 'tmp_v#1.py'
+
+# A single huge token is the shape that makes shlex.split quadratic — the hook
+# must bail out, not burn its whole timeout on every large Bash call.
+S=huge
+python3 - "$TMP" > "$TMP/huge.json" <<'PY'
+import json, sys
+# One 400 KB token — an inline program or base64 blob — with a .py mention so
+# the cheap pre-filter doesn't skip it for the wrong reason.
+command = "python3 -c 'x = \"" + "a" * 400_000 + "\"  # probe.py'"
+print(json.dumps({"session_id": "huge", "cwd": sys.argv[1], "tool_name": "Bash",
+                  "tool_input": {"command": command}}))
+PY
+START=$SECONDS
+rc=0
+python3 "$DIR/simplify_track_reuse.py" < "$TMP/huge.json" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 0 ] || bad "tracker exited $rc on a huge command"
+ELAPSED=$((SECONDS - START))
+if [ "$ELAPSED" -lt 3 ]; then ok; else bad "huge command took ${ELAPSED}s (must bail out fast)"; fi
+expect "huge command tracked nothing" "$(nudge "$S")" silent
+
 # --- nudge: message composition and repeat suppression ----------------------
 echo "=== nudge behaviour ==="
 
@@ -169,10 +269,37 @@ done
 
 # A corrupt state file must degrade to "no candidates", not to an error.
 S=corrupt
-printf 'not json at all' > "$TMP/claude-simplify-reuse-${S}.json"
+mkdir -p "$STATE_DIR" && chmod 700 "$STATE_DIR"
+printf 'not json at all' > "$(state_file "$S")"
 expect "corrupt state file silent" "$(nudge "$S")" silent
 track "$S" "$TMP" "python3 $TMP/scratch/probe.py"
 ok  # tracker survived a corrupt state file (bad() already fired if it didn't)
+
+# One hostile entry must not suppress the valid candidates beside it, and must
+# not freeze tracking for the rest of the session.
+S=hostile
+runs 3 "$S" "$TMP" "python3 $TMP/scratch/probe.py"
+python3 - "$(state_file "$S")" <<'PY'
+import json, sys
+path = sys.argv[1]
+state = json.load(open(path))
+state["/tmp/scratch/tampered.py"] = 7
+state["/tmp/scratch/typed.py"] = {"runs": "abc", "stable": None}
+json.dump(state, open(path, "w"))
+PY
+expect "hostile state entries don't suppress candidates" "$(nudge "$S")" fire "probe.py"
+track "$S" "$TMP" "python3 $TMP/scratch/probe.py"
+if jq -e '."/tmp/scratch/probe.py"' "$(state_file "$S")" >/dev/null 2>&1 ||
+   jq -e 'to_entries | map(select(.value | type == "object")) | length >= 1' \
+        "$(state_file "$S")" >/dev/null 2>&1; then ok
+else bad "tracking froze after a hostile state entry"; fi
+
+# Session ids are used to build a filename — a traversal attempt is dropped.
+S="../../escape"
+rc=0
+bash_event "$S" "$TMP" "python3 $TMP/scratch/probe.py" |
+    python3 "$DIR/simplify_track_reuse.py" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 0 ] && [ ! -e "$TMP/../../escape" ] && ok || bad "session id traversal not rejected"
 
 echo
 TOTAL=$((PASS + FAIL))

--- a/claude/hooks/test_simplify_reuse.sh
+++ b/claude/hooks/test_simplify_reuse.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Tests for the scratch-script reuse nudge: simplify_track_reuse.py (counts
+# repeat runs) and simplify_nudge.sh (turns the tally into a promotion nudge).
+#
+# Same contract as test_convention_nudges.sh: each hook must (a) fire a
+# systemMessage on a positive case, (b) stay silent on negatives, and
+# (c) NEVER exit non-zero.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+TMP=""
+for cand in "${TMPDIR:-}" /tmp/claude /tmp .; do
+    [ -n "$cand" ] || continue
+    if mkdir -p "$cand/simplify-reuse-tests.$$" 2>/dev/null; then
+        TMP="$cand/simplify-reuse-tests.$$"
+        break
+    fi
+done
+[ -n "$TMP" ] || { echo "no writable temp dir found" >&2; exit 1; }
+trap 'rm -rf "$TMP"' EXIT
+
+# Hooks keep their state under TMPDIR — point them at the sandbox.
+export TMPDIR="$TMP"
+
+ok()   { PASS=$((PASS + 1)); }
+bad()  { FAIL=$((FAIL + 1)); printf 'FAIL: %s\n' "$1"; }
+
+# bash_event <session> <cwd> <command>
+bash_event() {
+    python3 -c "
+import json, sys
+session, cwd, command = sys.argv[1:4]
+print(json.dumps({'session_id': session, 'cwd': cwd, 'tool_name': 'Bash',
+                  'tool_input': {'command': command}}))
+" "$1" "$2" "$3"
+}
+
+# track <session> <cwd> <command> — one run through the PostToolUse tracker.
+track() {
+    local rc=0
+    bash_event "$1" "$2" "$3" | python3 "$DIR/simplify_track_reuse.py" >/dev/null 2>&1 || rc=$?
+    [ "$rc" -eq 0 ] || bad "tracker exited $rc on: $3"
+}
+
+# nudge <session> — run the Stop hook, echo its stdout.
+nudge() {
+    local rc=0 out
+    out=$(printf '{"session_id":"%s"}' "$1" | bash "$DIR/simplify_nudge.sh" 2>/dev/null) || rc=$?
+    [ "$rc" -eq 0 ] || bad "nudge hook exited $rc"
+    printf '%s' "$out"
+}
+
+# expect <desc> <output> <fire|silent> [needle]
+expect() {
+    local desc="$1" out="$2" want="$3" needle="${4:-}"
+    local got=silent
+    case "$out" in *systemMessage*) got=fire ;; esac
+    if [ "$got" != "$want" ]; then
+        bad "$desc (expected $want, got $got)"
+        return
+    fi
+    if [ -n "$needle" ] && [[ "$out" != *"$needle"* ]]; then
+        bad "$desc (missing '$needle' in message)"
+        return
+    fi
+    ok
+}
+
+runs() { local n=$1; shift; while [ "$n" -gt 0 ]; do track "$@"; n=$((n - 1)); done; }
+
+# --- tracker: what counts as a run of a scratch script ----------------------
+echo "=== reuse tracking ==="
+
+mkdir -p "$TMP/scratch" "$TMP/bin" "$TMP/node_modules/pkg/tmp"
+printf 'print("hi")\n' > "$TMP/scratch/probe.py"
+printf 'echo hi\n'     > "$TMP/scratch/probe.sh"
+printf 'echo hi\n'     > "$TMP/bin/deploy.sh"
+printf 'x = 1\n'       > "$TMP/tmp_backfill.py"
+printf 'x = 1\n'       > "$TMP/node_modules/pkg/tmp/setup.py"
+
+S=count-py
+runs 3 "$S" "$TMP" "python3 $TMP/scratch/probe.py --limit 3"
+expect "3 runs of a scratch script fires" "$(nudge "$S")" fire "probe.py"
+
+S=count-uv
+runs 3 "$S" "$TMP" "uv run $TMP/scratch/probe.py"
+expect "uv run counts as execution" "$(nudge "$S")" fire "probe.py"
+
+S=count-direct
+runs 3 "$S" "$TMP" "$TMP/scratch/probe.sh"
+expect "direct invocation counts" "$(nudge "$S")" fire "probe.sh"
+
+S=count-relative
+runs 3 "$S" "$TMP" "bash scratch/probe.sh"
+expect "relative path resolves against cwd" "$(nudge "$S")" fire "$TMP/scratch/probe.sh"
+
+S=count-name
+runs 3 "$S" "$TMP" "python3 $TMP/tmp_backfill.py"
+expect "tmp_-prefixed name counts as scratch" "$(nudge "$S")" fire "tmp_backfill.py"
+
+S=below
+runs 2 "$S" "$TMP" "python3 $TMP/scratch/probe.py"
+expect "2 runs stays below threshold" "$(nudge "$S")" silent
+
+S=permanent
+runs 5 "$S" "$TMP" "bash $TMP/bin/deploy.sh"
+expect "script in a permanent home ignored" "$(nudge "$S")" silent
+
+S=vendored
+runs 5 "$S" "$TMP" "python3 $TMP/node_modules/pkg/tmp/setup.py"
+expect "vendored tmp/ path ignored" "$(nudge "$S")" silent
+
+S=notrun
+runs 5 "$S" "$TMP" "cat $TMP/scratch/probe.py"
+expect "reading a script is not running it" "$(nudge "$S")" silent
+
+S=redirect
+runs 5 "$S" "$TMP" "echo 'print(1)' > $TMP/scratch/probe.py"
+expect "writing a script is not running it" "$(nudge "$S")" silent
+
+# Edit-run-edit-run debugging: every run sees a different mtime, so no run is
+# "stable" and the script never reaches promotion.
+S=churn
+for i in 1 2 3 4; do
+    printf 'print(%d)\n' "$i" > "$TMP/scratch/churn.py"
+    touch -t "0101010${i}00" "$TMP/scratch/churn.py"
+    track "$S" "$TMP" "python3 $TMP/scratch/churn.py"
+done
+expect "edited between every run stays silent" "$(nudge "$S")" silent
+
+# --- nudge: message composition and repeat suppression ----------------------
+echo "=== nudge behaviour ==="
+
+S=once
+runs 3 "$S" "$TMP" "python3 $TMP/scratch/probe.py"
+expect "first stop nudges" "$(nudge "$S")" fire "probe.py"
+expect "second stop stays quiet" "$(nudge "$S")" silent
+track "$S" "$TMP" "python3 $TMP/scratch/probe.py"
+expect "already-promoted script stays quiet" "$(nudge "$S")" silent
+
+S=dirty
+touch "$TMP/claude-simplify-dirty-${S}"
+expect "dirty marker alone still nudges" "$(nudge "$S")" fire "quality pass"
+
+S=both
+touch "$TMP/claude-simplify-dirty-${S}"
+runs 3 "$S" "$TMP" "python3 $TMP/scratch/probe.py"
+OUT=$(nudge "$S")
+expect "both signals: quality pass" "$OUT" fire "quality pass"
+expect "both signals: promotion"    "$OUT" fire "probe.py"
+
+expect "clean session silent" "$(nudge no-such-session)" silent
+
+# --- robustness: hooks must never fail the tool call ------------------------
+echo "=== robustness ==="
+
+for payload in '' 'not json' '[]' '{}' '{"session_id":"x"}' \
+               '{"session_id":"x","tool_input":{"command":"python3 \"unbalanced}'; do
+    rc=0
+    printf '%s' "$payload" | python3 "$DIR/simplify_track_reuse.py" >/dev/null 2>&1 || rc=$?
+    [ "$rc" -eq 0 ] && ok || bad "tracker exited $rc on payload: $payload"
+    rc=0
+    printf '%s' "$payload" | bash "$DIR/simplify_nudge.sh" >/dev/null 2>&1 || rc=$?
+    [ "$rc" -eq 0 ] && ok || bad "nudge exited $rc on payload: $payload"
+done
+
+# A corrupt state file must degrade to "no candidates", not to an error.
+S=corrupt
+printf 'not json at all' > "$TMP/claude-simplify-reuse-${S}.json"
+expect "corrupt state file silent" "$(nudge "$S")" silent
+track "$S" "$TMP" "python3 $TMP/scratch/probe.py"
+ok  # tracker survived a corrupt state file (bad() already fired if it didn't)
+
+echo
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS passed, $FAIL failed (total $TOTAL)"
+[ "$FAIL" -eq 0 ] && echo "All tests passed!"
+[ "$FAIL" -eq 0 ]

--- a/claude/rules/reusable-component-promotion.md
+++ b/claude/rules/reusable-component-promotion.md
@@ -1,0 +1,25 @@
+# Reusable Component Promotion
+
+Part of a `/simplify` pass: throwaway scripts that got used repeatedly are refactored into permanent components, not left in `/tmp`. The `simplify_track_reuse.py` hook flags candidates at the third run; the same judgement applies whenever you notice a scratch script earning its keep.
+
+## Promote when
+
+Ran three or more times, at least once unchanged (it works — you're using it, not still writing it), and the next use is foreseeable. A script that ran twice while being debugged and then never again is doing its job as a throwaway; leave it.
+
+## Where it goes
+
+| Shape | Home |
+|---|---|
+| Command you'd want on PATH anywhere | `custom_bins/<name>` (`chmod +x`, no extension) |
+| Repo-specific task | that repo's `scripts/` or `justfile` recipe |
+| Shell one-liner or wrapper | `config/aliases/<topic>.sh` |
+| Python helper importable by other code | the owning package, not a loose script |
+| Multi-step procedure Claude reruns | a skill under `claude/skills/` |
+
+## What promotion means
+
+Copy-with-a-new-name is not promotion. Give it argument parsing instead of edit-the-constant-at-the-top, a `--help`, real exit codes, and no hardcoded absolute paths from the machine it was born on. Python past ~50 lines of shell (`coding-conventions.md`); `shellcheck` clean if it stays shell. Delete the scratch original once the permanent one works, and say where it went.
+
+## Don't
+
+Don't promote something the repo already has — search first; the point is fewer components, not more. Don't promote secrets or a session-specific path along with the logic. Don't build configuration for uses nobody has asked for yet: port what the script does today.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -426,6 +426,11 @@
             "command": "$HOME/.claude/hooks/mark_failed_sync.sh",
             "if": "Bash(git *)",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/simplify_track_reuse.py",
+            "timeout": 5
           }
         ]
       },


### PR DESCRIPTION
The simplify nudge only ever asked for a quality pass over files edited this turn. The other half of a simplify pass — a throwaway script that keeps getting re-run should graduate into something permanent — had nothing watching for it.

## Changes

**`claude/hooks/simplify_track_reuse.py`** (new, `PostToolUse` / `Bash`) — tallies *executions* of scripts living in tmp/scratch paths (or named `tmp_*`, `scratch-*`, …) into a per-session JSON state file under `TMPDIR`.

- Writes and edits deliberately don't count: those are iteration, and counting them would flag every script that took two tries to work.
- A run whose file is unchanged (same mtime) since the previous run is recorded as *stable*, so an edit-run-edit-run debugging loop never reaches the threshold — only a script that ran repeatedly while standing still.
- Skips vendored trees, and skips scripts whose own directory is already a permanent home (`bin/`, `custom_bins/`, `tools/`, `scripts/`, …) — repos and worktrees do get checked out under `/tmp`.

**`claude/hooks/simplify_nudge.sh`** — composes both signals into one `Stop` message, and fires on the reuse signal even when nothing was edited this turn. A candidate is nudged once per session; threshold is `CLAUDE_SIMPLIFY_REUSE_RUNS` (default 3 runs, ≥1 stable). Still `systemMessage`-only — it never continues the turn.

**`claude/rules/reusable-component-promotion.md`** (new) — what makes the nudge actionable: when a script has earned promotion, where each shape of script lands (PATH binary vs. repo `scripts/` vs. alias vs. skill), and what promotion means beyond copy-with-a-new-name.

**`claude/settings.json`** — registers the tracker under the existing `PostToolUse`/`Bash` matcher. Verified `statusLine` / `hooks` / `permissions` are intact per `.claude/rules/dotfiles-settings.md`.

Plus README and CLAUDE.md Learnings entries.

## Testing

`claude/hooks/test_simplify_reuse.sh` (new) — 32 cases, all passing: threshold behaviour, `uv run` / interpreter / direct / relative-path invocation, name- and directory-based scratch detection, negatives (permanent home, vendored path, `cat`-ing or writing a script instead of running it, edit-between-every-run churn), message composition for each signal, once-per-session suppression, and the fail-open contract (garbage payloads and a corrupt state file must exit 0 and stay silent).

Also verified end-to-end against a real scratchpad layout: three `uv run scratchpad/probe.py` invocations produce a promotion nudge naming the script; a fourth produces nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015qp9XrMkuDiNDX5XgwX1YD)_