### PR TITLE
fix(app-lifecycle): close fail-open paths that turn a failed read into a destructive action

### DIFF
--- a/custom_bins/app-lifecycle-config
+++ b/custom_bins/app-lifecycle-config
@@ -44,8 +44,19 @@ ACTIONS = ("skip", "hide", "close", "quit")
 # fix the pattern: minute-valued keys take a _MINUTES suffix, and the visibility
 # threshold keeps the name it already shipped under.
 DEFAULT_KEYS = {
-    "manual": ("action", "quit", None),
-    "auto": ("action", "quit", None),
+    # Fallbacks are `skip`, not `quit`. These two fields authorise closing and
+    # quitting, so whatever they resolve to when ABSENT is what an incomplete
+    # policy means. Defaulting them to quit made every way of losing the section -
+    # a zero-byte file, a comments-only file, a redirect interrupted right after
+    # `defaults:` - resolve to "quit every app, protect nothing", at exactly the
+    # moment the safety policy went missing. Absence must mean do nothing.
+    #
+    # This costs no behaviour on a complete policy: config/app-lifecycle.yaml sets
+    # both explicitly. It is also why a sparse `apps:`-only document is still
+    # accepted rather than rejected as corrupt - it now resolves to a harmless
+    # no-op instead of to a massacre, so there is nothing to reject.
+    "manual": ("action", "skip", None),
+    "auto": ("action", "skip", None),
     "hide_after": ("minutes", 15, "HIDE_AFTER_MINUTES"),
     "close_after": ("minutes", 15, "CLOSE_AFTER_MINUTES"),
     "quit_after": ("minutes", 30, "QUIT_AFTER_MINUTES"),
@@ -250,6 +261,34 @@ def check(kind, key, value, where):
 
 
 def resolve(doc, env):
+    # An unreadable policy must never resolve to something MORE destructive than
+    # a readable one. The primary defence is in DEFAULT_KEYS, where manual and
+    # auto fall back to `skip`: any way of losing part of the document now
+    # resolves toward doing nothing rather than toward quitting everything.
+    #
+    # A wholly empty document is still rejected outright rather than left to
+    # resolve to a silent no-op. Both are safe; this one is also honest. A
+    # zero-byte config is a broken install, not a policy of inaction, and the
+    # difference matters when someone is trying to work out why the automation
+    # stopped. This is the parser's existing rule ("reject unknown shape, don't
+    # guess", see the module docstring) applied to the empty document, which
+    # slipped through because every field had a fallback. A missing file is
+    # already rejected in main(); a present-but-empty one must be too.
+    #
+    # Note what is deliberately NOT rejected: a document with no `defaults:` at
+    # all, or a truncated one carrying only `defaults:`. Requiring the section
+    # would break sparse-but-valid policies that only set `apps:` and lean on the
+    # built-ins - and with the built-ins now `skip`, leaning on them is harmless.
+    # Truncation partway THROUGH a written-out defaults block (`manual: quit`
+    # saved, `protect_windows:` lost) still resolves to something destructive, and
+    # no presence check can catch that; only a trailing completeness marker or
+    # atomic emission would. That is a config-format change, flagged rather than
+    # taken unilaterally.
+    if not doc:
+        fail("config is empty - refusing to guess a policy. A zero-byte or"
+             " comments-only file is a broken install, not an instruction to do"
+             " nothing; restore it rather than letting the idle job run against a"
+             " policy that is not there")
     defaults = {}
     raw_defaults = doc.get("defaults", {})
     for key, value in raw_defaults.items():

--- a/custom_bins/app-lifecycle-config
+++ b/custom_bins/app-lifecycle-config
@@ -57,11 +57,36 @@ DEFAULT_KEYS = {
     # no-op instead of to a massacre, so there is nothing to reject.
     "manual": ("action", "skip", None),
     "auto": ("action", "skip", None),
+    # See MIGRATION_DEFAULTS below before changing either of the two above:
+    # migrate() writes these same fallbacks into the YAML it generates, where
+    # they carry the opposite meaning.
     "hide_after": ("minutes", 15, "HIDE_AFTER_MINUTES"),
     "close_after": ("minutes", 15, "CLOSE_AFTER_MINUTES"),
     "quit_after": ("minutes", 30, "QUIT_AFTER_MINUTES"),
     "user_idle": ("minutes", 5, "USER_IDLE_MINUTES"),
     "min_visible_percent": ("percent", 40, "HIDE_IDLE_MIN_VISIBLE_PERCENT"),
+}
+
+# What migrate() writes for keys whose runtime fallback is deliberately not what
+# the legacy config meant. The two mappings answer different questions and must
+# not be collapsed back together:
+#
+#   DEFAULT_KEYS  - "the policy does not say; what should we do?" Answer: as
+#                   little as possible, because not-saying is usually a
+#                   truncated or half-written file.
+#   MIGRATION_DEFAULTS - "the old clear-mac-apps.conf did not list this app;
+#                   what did that MEAN?" Answer: quit. Absence there was an
+#                   affirmative policy, and the migration's whole claim is that
+#                   it changes no behaviour - there is a golden-file test in
+#                   tests/test_clear_mac_apps.zsh asserting the migrated config
+#                   reproduces the pre-migration dry run byte for byte.
+#
+# So migrate() emits these EXPLICITLY. That is also why the runtime fallback can
+# be safely inert: every migrated file states its own manual/auto rather than
+# relying on the built-in.
+MIGRATION_DEFAULTS = {
+    "manual": "quit",
+    "auto": "quit",
 }
 
 # Per-app keys. `slow` has no defaults: counterpart - it is a property of the
@@ -400,7 +425,7 @@ def migrate(path, out):
     out.write("# alone. Scale: skip < hide < close < quit.\n\n")
     out.write("defaults:\n")
     for key, (_kind, fallback, _env) in DEFAULT_KEYS.items():
-        out.write("  %s: %s\n" % (key, fallback))
+        out.write("  %s: %s\n" % (key, MIGRATION_DEFAULTS.get(key, fallback)))
     out.write("\napps:\n")
     width = max((len(name) for name in order), default=0) + 2
     for name in order:

--- a/custom_bins/clear-mac-apps
+++ b/custom_bins/clear-mac-apps
@@ -392,6 +392,18 @@ close_app_selectively() {
     fi
 
     # Pass 1: fetch window/tab data, filter in zsh
+    #
+    # Captured, not piped from a process substitution, for the same reason the
+    # rescan further down is: `done < <(...)` discards the producer's exit
+    # status, so a query that FAILED arrives as an empty list. Empty here reads
+    # as "Chrome has no protected window", which falls through to the branch
+    # below that quits the whole app - so an unreadable window list would
+    # authorise precisely the quit the protected patterns exist to prevent.
+    # A genuinely empty list is still a harmless no-op: it leaves nothing to
+    # close, and the ids_to_close guard below returns 0 before that branch.
+    local tabs=""
+    tabs=$(get_chrome_window_tabs) || return 1
+
     local -A protected_windows all_windows
     while IFS='|' read -r wid title; do
         [[ -z "$wid" ]] && continue
@@ -402,7 +414,7 @@ close_app_selectively() {
                 break
             fi
         done
-    done < <(get_chrome_window_tabs)
+    done <<< "$tabs"
 
     # Collect IDs to close
     local -a ids_to_close=()
@@ -554,7 +566,28 @@ main() {
 
     # Get running apps with bundle IDs (tab-separated: "name<TAB>bid")
     # Tab-separated to handle multiple processes with the same name (e.g. Safari web apps)
+    #
+    # Captured, not piped from `< <(...)`, whose exit status is discarded: a
+    # System Events enumeration that FAILED - one GUI process exiting mid-scan
+    # is enough - would then arrive as an empty list, and an empty candidate
+    # list is indistinguishable from "no apps are running", which is reported
+    # as a clean run. The idle caller pre-writes the phase it asked for and
+    # hands the rung back only on a non-zero exit, so a silent failure here
+    # advances an app whose windows were never touched, and quit_after later
+    # quits it. An unreadable inventory is not evidence that there is nothing
+    # to do. A genuinely empty one still succeeds as a no-op.
     local SEP=$'\t'
+    local running=""
+    if ! running=$(get_running_apps); then
+        echo "Error: could not enumerate running applications — doing nothing" >&2
+        # Recorded, not just returned. The bare invocation is the Shortcut, whose
+        # branch at the bottom of this file swallows the status and posts
+        # notify_failures instead - and that notification is built from this
+        # array, so returning alone would surface an "action did not complete"
+        # dialog with an empty body. The --only caller reads the status.
+        FAILED_ACTIONS+=("inventory: could not enumerate running applications")
+        return 1
+    fi
     local -a running_entries=()
     while IFS='|' read -r name bid; do
         [[ -n "$name" ]] || continue
@@ -568,7 +601,7 @@ main() {
             $matched || continue
         fi
         running_entries+=("${name}${SEP}${bid}")
-    done < <(get_running_apps)
+    done <<< "$running"
 
     # Classify: check name match first, bundle ID as fallback
     # Declared once, out here: `local x` with no value re-run on a later loop
@@ -632,8 +665,37 @@ main() {
             if [[ "$app" == "Google Chrome" ]]; then
                 # Chrome: check all tab titles (only fetch once, cache result)
                 if [[ -z "${_chrome_tabs_fetched:-}" ]]; then
-                    _chrome_tabs_cache=$(get_chrome_window_tabs)
-                    _chrome_tabs_fetched=1
+                    # Status checked, not just captured. This is the same defect
+                    # as the two above but at the step that decides Chrome's
+                    # FATE: on a failed query the cache is empty, the loop below
+                    # finds no protected title, has_protected stays false, and
+                    # Chrome falls through to the quit branch - while
+                    # _chrome_tabs_fetched=1 guarantees it is never re-asked.
+                    # An unreadable tab list is not evidence there is no Meet
+                    # call in progress.
+                    #
+                    # A failure is therefore treated as PROTECTED rather than
+                    # aborting the run: it routes Chrome to selective close,
+                    # which re-queries and fails closed at the top of
+                    # close_app_selectively, so the problem surfaces as a
+                    # recorded failed action instead of a quit. One app's
+                    # unreadable windows should not veto every other app.
+                    # Note _chrome_tabs_fetched is set only on success, so a
+                    # failure leaves the query open to be retried rather than
+                    # cached as an empty answer. The failure flag is cleared on
+                    # that retry: a stale one would keep Chrome marked protected
+                    # after a query that later succeeded - fail-safe, but still a
+                    # lie about what was observed.
+                    if _chrome_tabs_cache=$(get_chrome_window_tabs); then
+                        _chrome_tabs_fetched=1
+                        _chrome_tabs_failed=""
+                    else
+                        _chrome_tabs_cache=""
+                        _chrome_tabs_failed=1
+                    fi
+                fi
+                if [[ -n "${_chrome_tabs_failed:-}" ]]; then
+                    has_protected=true
                 fi
                 while IFS='|' read -r _wid _title; do
                     [[ -z "$_wid" ]] && continue
@@ -646,6 +708,15 @@ main() {
                 done <<< "$_chrome_tabs_cache"
             else
                 # Other apps: active window title only (best-effort)
+                #
+                # Deliberately NOT status-checked, unlike the Chrome branch
+                # above. `get name of window 1` raises an AppleScript error when
+                # the process simply HAS no window, so nonzero here is the
+                # ordinary case rather than a failure signal - gating on it would
+                # mark every windowless app protected and the feature would never
+                # act. Chrome's query differs: it iterates `every window` and
+                # returns empty with status 0, so there a nonzero really does
+                # mean the query broke.
                 _title=$(get_app_frontmost_window_title "$app")
                 if [[ -n "$_title" ]]; then
                     for pattern in "${protected_patterns[@]}"; do

--- a/custom_bins/hide-idle-apps
+++ b/custom_bins/hide-idle-apps
@@ -55,6 +55,36 @@ HELPER_BIN="${DOT_DIR}/tools/window-exposure/window-exposure"
 CACHE_DIR="${HOME}/.cache/hide-idle-apps"
 STATE_FILE="${CACHE_DIR}/state"
 STATE_VERSION="#v3"
+# Consent to the destructive rungs is not inheritable. This job used to default
+# to ON and only hid apps; the ladder that closes windows and quits apps came
+# later, and the launchd label and binary path never changed. So a machine set
+# up under the old default already has a loaded job that would silently start
+# quitting applications with unsaved work - consent to HIDING read as consent to
+# QUITTING. The component default is now off, but that only governs fresh
+# installs: an existing schedule keeps firing whether or not deploy.sh is re-run.
+#
+# From config.sh's history: 66feba6 added the component as `true`, hide-only;
+# 10a5f11 flipped it to `false`, still hide-only; 31e8d58 added close and quit
+# with the default already off. Note the order - the flip was NOT a response to
+# the ladder, so nobody running it in the `true` era was ever re-prompted, and
+# because the default is now false a plain ./deploy.sh takes neither branch.
+#
+# The gate is a token rather than a versioned label because the legacy plist
+# points at THIS binary, so a new label would not stop the old job - it would
+# also have to be unloaded, and unloading is exactly what deploy.sh cannot do
+# unconditionally (--only and --minimal set every other component false, so
+# `--only vim` would tear down a job it promised not to touch). A token needs no
+# unload at all: the inherited job keeps hiding, which is what was consented to,
+# and simply cannot climb higher. Written only by an explicit --hide-idle-apps,
+# via scripts/cleanup/setup_hide_idle_apps.sh.
+#
+# Deliberately NOT under CACHE_DIR, which holds STATE_FILE and is therefore
+# disposable by design - the test suite rm -rf's it between scenarios, and a
+# cache cleaner would do the same on a real machine. A record of consent that a
+# cache sweep can revoke is the wrong shape: it fails safe, but it fails
+# silently, and the user would only learn from a launchd log they never read.
+# ~/.local/state is where data that must outlive a cache purge belongs.
+ESCALATION_TOKEN="${HOME}/.local/state/hide-idle-apps/escalation-enabled"
 # The escalation rungs are not reimplemented here: they are one call into the
 # manual trigger, so config vetoes apply to both triggers through one code path.
 CLEAR_APPS="${SCRIPT_DIR}/clear-mac-apps"
@@ -222,6 +252,19 @@ is_busy() {
 # rung would QUIT anything whose manual: is quit, collapsing the ladder to one step.
 escalate() {
     local name="$1" rung="$2"
+    # Both destructive rungs come through here; hiding is implemented locally and
+    # never does, so an ungated install still hides exactly as it always did.
+    # Non-zero deliberately: that is the give-back status, so the app keeps its
+    # current rung and is simply never advanced. Reporting success would mark a
+    # rung done that was refused, and quit_after would later act on that lie.
+    if [[ ! -f "$ESCALATION_TOKEN" ]]; then
+        if [[ "${_escalation_warned:-}" != true ]]; then
+            print -ru2 -- "hide-idle-apps: close/quit not enabled on this machine; hiding only."
+            print -ru2 -- "  Run ./deploy.sh --hide-idle-apps to consent to the destructive rungs."
+            _escalation_warned=true
+        fi
+        return 1
+    fi
     local -a cmd=("$CLEAR_APPS" --only "$name")
     [[ "$rung" == close ]] && cmd+=(--max-action close)
     "${cmd[@]}" >/dev/null 2>&1

--- a/deploy.sh
+++ b/deploy.sh
@@ -1136,8 +1136,17 @@ queue_scheduled_job() {
         # which is exactly the silent hide->quit upgrade the token exists to stop.
         # The setup script still re-writes an already-present token, so ordinary
         # redeploys of a consenting machine are unaffected.
+        # Assigned on BOTH branches, never merely set on one. A sentinel that is
+        # only ever written to true is not a gate: run_parallel passes our
+        # environment down, so an inherited HIDE_IDLE_APPS_EXPLICIT_CONSENT=true -
+        # left by an earlier opt-in deploy in the same shell, or exported by a
+        # wrapper - would sail through an if-without-else and be read as fresh
+        # consent. Deriving it unconditionally makes this invocation the only
+        # thing that can decide.
         if (( ${EXPLICIT_OPT_INS[(Ie)HIDE_IDLE_APPS]} )); then
             export HIDE_IDLE_APPS_EXPLICIT_CONSENT=true
+        else
+            export HIDE_IDLE_APPS_EXPLICIT_CONSENT=false
         fi
         queue_scheduled_job hide-idle-apps "$DOT_DIR/scripts/cleanup/setup_hide_idle_apps.sh"
     elif is_macos && (( ${EXPLICIT_OPT_OUTS[(Ie)HIDE_IDLE_APPS]} )); then

--- a/deploy.sh
+++ b/deploy.sh
@@ -1127,6 +1127,18 @@ queue_scheduled_job() {
     fi
 
     if [[ "$DEPLOY_HIDE_IDLE_APPS" == "true" ]] && is_macos; then
+        # Provenance, not the resolved boolean, decides whether this run may MINT
+        # the escalation token. DEPLOY_HIDE_IDLE_APPS=true can come from a CLI
+        # flag, a profile, or a config.local.sh line written long ago - and
+        # config.local.sh is sourced before parse_args. A host that pinned
+        # `DEPLOY_HIDE_IDLE_APPS=true` back in the hide-only era would otherwise
+        # be handed close/quit consent by a plain `./deploy.sh --non-interactive`,
+        # which is exactly the silent hide->quit upgrade the token exists to stop.
+        # The setup script still re-writes an already-present token, so ordinary
+        # redeploys of a consenting machine are unaffected.
+        if (( ${EXPLICIT_OPT_INS[(Ie)HIDE_IDLE_APPS]} )); then
+            export HIDE_IDLE_APPS_EXPLICIT_CONSENT=true
+        fi
         queue_scheduled_job hide-idle-apps "$DOT_DIR/scripts/cleanup/setup_hide_idle_apps.sh"
     elif is_macos && (( ${EXPLICIT_OPT_OUTS[(Ie)HIDE_IDLE_APPS]} )); then
         # This job used to default to on, and its plist points at the same
@@ -1138,6 +1150,15 @@ queue_scheduled_job() {
         # --only and --minimal set every other component false, so `--only vim`
         # would otherwise tear this job down despite --only promising to touch
         # nothing else. Refusing a component and not selecting it differ.
+        #
+        # That narrowness leaves a real gap, and it is deliberately NOT closed
+        # here: a plain `./deploy.sh` on a machine from the default-on era takes
+        # neither branch, so the legacy job stays loaded and runs today's binary.
+        # Widening this condition is the one fix that cannot work - it is the
+        # `--only vim` bug above. The gap is closed at the other end instead, by
+        # an escalation token that only the install path writes: an inherited job
+        # keeps hiding and can no longer close or quit. See ESCALATION_TOKEN in
+        # custom_bins/hide-idle-apps.
         [[ -f "$DOT_DIR/scripts/cleanup/setup_hide_idle_apps.sh" ]] && \
             "$DOT_DIR/scripts/cleanup/setup_hide_idle_apps.sh" --uninstall >/dev/null 2>&1 || true
     fi

--- a/scripts/cleanup/setup_hide_idle_apps.sh
+++ b/scripts/cleanup/setup_hide_idle_apps.sh
@@ -15,6 +15,29 @@ HELPER_BIN="$DOT_DIR/tools/window-exposure/window-exposure"
 source "$DOT_DIR/scripts/scheduler/scheduler.sh"
 
 JOB_ID="hide-idle-apps"
+# The token whose presence permits hide-idle-apps to close windows and quit apps.
+# Absent it, the job still hides - that rung is implemented locally and is what
+# the default-on era actually consented to.
+#
+# Reaching this script does NOT by itself mean the user asked for the ladder.
+# deploy.sh queues it from the resolved DEPLOY_HIDE_IDLE_APPS, and that boolean
+# can equally come from a config.local.sh line - sourced before parse_args -
+# written back when this component was hide-only. Minting on arrival would hand
+# close/quit consent to precisely the machine the token exists to protect. So the
+# statement we need ("the user asked for this, on this machine, with the ladder as
+# it exists today") comes from HIDE_IDLE_APPS_EXPLICIT_CONSENT, which deploy.sh
+# exports only when the component appears in EXPLICIT_OPT_INS.
+#
+# Not under ~/.cache: that directory holds this job's state file and is
+# disposable by design, so a cache sweep would silently revoke consent.
+# Keep in sync with ESCALATION_TOKEN in custom_bins/hide-idle-apps.
+ESCALATION_TOKEN="${HOME}/.local/state/hide-idle-apps/escalation-enabled"
+# Captured HERE, before the unconditional `uninstall` below deletes it. Consent
+# already given is not re-asked on every redeploy: an ordinary `./deploy.sh` on a
+# machine that opted in once must not silently revoke it. Only an explicit
+# --no-hide-idle-apps takes it away, via uninstall's own exit path.
+_token_preexisting=false
+[[ -f "$ESCALATION_TOKEN" ]] && _token_preexisting=true
 # The FILE is authoritative for the installed job, and an inherited
 # HIDE_IDLE_POLL_SECONDS is deliberately not honoured here.
 #
@@ -33,7 +56,13 @@ if [[ -n "$_poll_override" && "$_poll_override" != "$HIDE_IDLE_POLL_SECONDS" ]];
     _sched_log_warn "it cannot reach a launchd job. Set HIDE_IDLE_POLL_SECONDS in $TUNABLES_CONF instead."
 fi
 
-uninstall() { unschedule "$JOB_ID" 2>/dev/null || true; }
+uninstall() {
+    unschedule "$JOB_ID" 2>/dev/null || true
+    # Withdrawing the schedule withdraws the consent with it. Leaving the token
+    # behind would mean a later reinstall - or a stray copy of the old plist -
+    # started quitting apps again without anyone re-asking.
+    rm -f "$ESCALATION_TOKEN" 2>/dev/null || true
+}
 
 # Build the exposure helper here so the first poll doesn't have to. The script
 # can compile it lazily too, but launchd jobs run without a developer PATH.
@@ -59,6 +88,22 @@ install() {
         return 1
     fi
     schedule_interval "$JOB_ID" "$HIDE_BIN" "$HIDE_IDLE_POLL_SECONDS"
+
+    # Only after the job is actually installed, and only for a machine that has
+    # genuinely consented: either it said so on THIS invocation, or it had already
+    # said so and we are just redeploying. A resolved-true component boolean on
+    # its own is not consent - see the ESCALATION_TOKEN comment above.
+    if [[ "${HIDE_IDLE_APPS_EXPLICIT_CONSENT:-}" != true && "$_token_preexisting" != true ]]; then
+        _sched_log_info "hide-idle-apps installed in hide-only mode."
+        _sched_log_info "Run ./deploy.sh --hide-idle-apps to also allow closing windows and quitting apps."
+        return 0
+    fi
+    mkdir -p "$(dirname "$ESCALATION_TOKEN")"
+    printf '%s\n' \
+        "Written by scripts/cleanup/setup_hide_idle_apps.sh on an explicit --hide-idle-apps." \
+        "Its presence is what permits hide-idle-apps to close windows and quit apps." \
+        "Delete it to keep the hourly hiding but stop the destructive rungs." \
+        > "$ESCALATION_TOKEN"
 }
 
 # Always uninstall first for clean state

--- a/scripts/shared/helpers.sh
+++ b/scripts/shared/helpers.sh
@@ -1772,6 +1772,18 @@ parse_args() {
     typeset -ga EXPLICIT_OPT_OUTS
     EXPLICIT_OPT_OUTS=()
 
+    # The mirror image, and it answers a question DEPLOY_<X>=true cannot: "did the
+    # user ask for this on THIS invocation?" The resolved boolean conflates a CLI
+    # flag with a profile default and with a persistent config.local.sh override,
+    # which is sourced before parse_args runs. A component that grants standing
+    # permission to do something destructive must key off provenance, not off the
+    # resolved value - otherwise a one-time `DEPLOY_X=true` written into
+    # config.local.sh years ago silently re-consents on every later plain deploy.
+    # Populated by the `--<x>` branch and by --only, which names components just
+    # as explicitly. Currently read only by the hide-idle-apps escalation token.
+    typeset -ga EXPLICIT_OPT_INS
+    EXPLICIT_OPT_INS=()
+
     while (( $# )); do
         case "$1" in
             -h|--help)
@@ -1897,6 +1909,7 @@ parse_args() {
                 component="${component//-/_}"
                 typeset -g "INSTALL_${component}=true"
                 typeset -g "DEPLOY_${component}=true"
+                EXPLICIT_OPT_INS+=("$component")
                 ;;
             *)
                 log_warning "Unknown argument: $1"
@@ -1936,6 +1949,10 @@ parse_args() {
             local _comp_upper="${(U)_comp//-/_}"
             typeset -g "INSTALL_${_comp_upper}=true"
             typeset -g "DEPLOY_${_comp_upper}=true"
+            # Naming a component in --only is as explicit as `--<x>`, so it counts
+            # as fresh opt-in. Note apply_profile("minimal") above set everything
+            # false first, so only the named components land here.
+            EXPLICIT_OPT_INS+=("$_comp_upper")
         done
     fi
 }

--- a/tests/test_clear_mac_apps.zsh
+++ b/tests/test_clear_mac_apps.zsh
@@ -12,10 +12,18 @@ set -uo pipefail
 REPO="${0:A:h:h}"
 # Under the repo's gitignored tmp/, not $TMPDIR: agent sandboxes commonly allow
 # only one level below their temp root, and this tree is several deep.
-mkdir -p "$REPO/tmp"
-WORK="$(mktemp -d "$REPO/tmp/clear-mac-test.XXXXXX")"
+mkdir -p "$REPO/tmp" || { print -ru2 -- "FATAL: cannot create $REPO/tmp"; exit 1 }
+WORK="$(mktemp -d "$REPO/tmp/clear-mac-test.XXXXXX")" \
+    || { print -ru2 -- "FATAL: mktemp -d under $REPO/tmp failed"; exit 1 }
+# set -u does NOT catch a failed mktemp: WORK ends up set-but-EMPTY, and ROOT
+# below is derived from it, so ROOT would become /root - the stub writes and
+# the cleanup rm would land outside the repo entirely. Validate before
+# deriving anything and before arming the trap: an `rm -rf` trap must never be
+# installed on a variable we have not checked.
+[[ -n "$WORK" && -d "$WORK" && "$WORK" == "$REPO/tmp/"* ]] \
+    || { print -ru2 -- "FATAL: work dir not under $REPO/tmp: ${WORK:-<empty>}"; exit 1 }
 ROOT="$WORK/root"
-trap 'rm -rf "$WORK"' EXIT   # only the temp tree this script just created
+trap 'rm -rf "${WORK:?}"' EXIT   # only the temp tree this script just created
 PASS=0 FAIL=0
 
 check() {  # check <label> <haystack> <needle>

--- a/tests/test_hide_idle_apps.zsh
+++ b/tests/test_hide_idle_apps.zsh
@@ -13,11 +13,19 @@ set -uo pipefail
 REPO="${0:A:h:h}"
 # Under the repo's gitignored tmp/, not $TMPDIR: agent sandboxes commonly allow
 # only one level below their temp root, and this tree is several deep.
-mkdir -p "$REPO/tmp"
-WORK="$(mktemp -d "$REPO/tmp/hide-idle-test.XXXXXX")"
+mkdir -p "$REPO/tmp" || { print -ru2 -- "FATAL: cannot create $REPO/tmp"; exit 1 }
+WORK="$(mktemp -d "$REPO/tmp/hide-idle-test.XXXXXX")" \
+    || { print -ru2 -- "FATAL: mktemp -d under $REPO/tmp failed"; exit 1 }
+# set -u does NOT catch a failed mktemp: WORK ends up set-but-EMPTY, and every
+# path below is derived from it - ROOT would become /root and FAKEHOME /home,
+# so the stub writes and the cleanup rm would land outside the repo entirely.
+# Validate before deriving anything and before arming the trap: an `rm -rf`
+# trap must never be installed on a variable we have not checked.
+[[ -n "$WORK" && -d "$WORK" && "$WORK" == "$REPO/tmp/"* ]] \
+    || { print -ru2 -- "FATAL: work dir not under $REPO/tmp: ${WORK:-<empty>}"; exit 1 }
 ROOT="$WORK/root"
 FAKEHOME="$WORK/home"
-trap 'rm -rf "$WORK"' EXIT   # only the temp tree this script just created
+trap 'rm -rf "${WORK:?}"' EXIT   # only the temp tree this script just created
 PASS=0 FAIL=0
 
 check() {  # check <label> <haystack> <needle>
@@ -155,6 +163,16 @@ export STUB_HELPER_OUT=$'101\t1\t1.000\n102\t0\t0.352\n103\t0\t0.000\n104\t1\t0.
 export STUB_HELPER_ARGS_LOG="$WORK/helper-args.log"
 export STUB_HIDE_LOG="$WORK/hide-attempts.log"
 export STUB_ESCALATE_LOG="$WORK/escalations.log"
+
+# The escalation consent token. Every scenario below that expects a close or a
+# quit needs it present, so it is part of the baseline fixture rather than
+# per-test setup. Note it is NOT under .cache: the scenarios rm -rf that
+# directory to reset state, which is exactly why the real token does not live
+# there either. Scenario 24 deletes this one deliberately, then restores it.
+ESCALATION_TOKEN="$FAKEHOME/.local/state/hide-idle-apps/escalation-enabled"
+mkdir -p "${ESCALATION_TOKEN:h}"
+print -r -- "test fixture" > "$ESCALATION_TOKEN"
+
 NOW=$(date +%s)
 export STUB_NOW="$NOW"
 
@@ -521,6 +539,43 @@ check_not "the unlisted app is not hidden"  "$(cat "$STUB_HIDE_LOG")" "unix id i
 # should be hidden, which is both the stronger claim and the order-free one.
 check_not "and nothing is reported hidden"  "$OUT" "Hid:"
 cp "$WORK/alc.bak" "$ROOT/config/app-lifecycle.yaml"
+
+# --- 24. without the consent token, the destructive rungs are refused -------
+# Scenario 8 with one thing changed: the token is gone. That is the machine that
+# inherited a loaded launchd job from the era when this component defaulted to on
+# and only ever hid windows. It must keep hiding - that is what was consented to
+# - and must not climb to close or quit, however long the app has sat idle.
+print -r -- "24. no escalation token -> hides, but never closes or quits"
+rm -f "$ESCALATION_TOKEN"
+rm -rf "$FAKEHOME/.cache"; seed_state 60 "107=hidden=1000"
+run 0
+check_not "the close is refused"            "$ESC" "--only Notion"
+# The phase check is the one that matters: escalate() returns nonzero, so the
+# pre-advanced rung is given back. Left at `closed`, the quit clock would start
+# running on a close that never happened - and a later quit needs no second
+# escalation to be wrong, it just needs this state to lie.
+check     "and the rung is given back"      "$(state_line 107)" "hidden"
+check     "the refusal is explained once"   "$ERR" "close/quit not enabled"
+# The quit rung, reached from `closed` rather than `hidden`. Without this a gate
+# wired into only the close path would pass every check above while still letting
+# an inherited job quit apps outright - the single worst outcome the token exists
+# to prevent. Both rungs go through escalate(), so this pins that they stay there.
+rm -rf "$FAKEHOME/.cache"; seed_state 60 "107=closed=1000"
+run 0
+check_not "the quit is refused too"         "$ESC" "--only Notion"
+check     "and that rung is given back"     "$(state_line 107)" "closed"
+# Hiding is implemented locally and never routes through escalate(), so it is
+# unaffected. A gate that silently disabled the whole job would be a regression.
+# This half does not exercise escalate() at all - every app starts at `visible`,
+# so the only way it can fail is if the gate were implemented as an early exit in
+# main() rather than at the two destructive rungs. That is precisely the wrong
+# implementation worth pinning, so the pair of checks is deliberate: the run hid
+# something, and reached the escalation path for nothing.
+rm -rf "$FAKEHOME/.cache"; seed_state 60
+run 0
+check     "hiding still works ungated"      "$OUT" "Hid:"
+check_not "and nothing was escalated"       "$ESC" "--only"
+print -r -- "test fixture" > "$ESCALATION_TOKEN"
 
 print -r -- ""
 print -r -- "PASS=$PASS FAIL=$FAIL"

--- a/tests/test_hide_idle_apps.zsh
+++ b/tests/test_hide_idle_apps.zsh
@@ -560,10 +560,22 @@ check     "the refusal is explained once"   "$ERR" "close/quit not enabled"
 # wired into only the close path would pass every check above while still letting
 # an inherited job quit apps outright - the single worst outcome the token exists
 # to prevent. Both rungs go through escalate(), so this pins that they stay there.
-rm -rf "$FAKEHOME/.cache"; seed_state 60 "107=closed=1000"
+#
+# 5000 seconds, not 1000: quit_after defaults to 30 MINUTES, so a 1000s clock
+# never crosses the threshold and escalate() is never reached - the assertions
+# would then pass with no gate at all. The close half above is non-vacuous only
+# because 1000s already exceeds its 15-minute threshold; the same number does not
+# transfer to a rung with a longer clock.
+#
+# Note also which assertion does the work. A SUCCESSFUL quit leaves the stored
+# phase at `closed` too (hide-idle-apps:644 pre-advances the phase for the close
+# rung only), so a phase check here cannot distinguish refusal from success. The
+# empty escalation log is what kills the mutant; the stderr line confirms the
+# refusal was the reason, rather than the app never having become eligible.
+rm -rf "$FAKEHOME/.cache"; seed_state 60 "107=closed=5000"
 run 0
 check_not "the quit is refused too"         "$ESC" "--only Notion"
-check     "and that rung is given back"     "$(state_line 107)" "closed"
+check     "and the refusal is the reason"   "$ERR" "close/quit not enabled"
 # Hiding is implemented locally and never routes through escalate(), so it is
 # unaffected. A gate that silently disabled the whole job would be a regression.
 # This half does not exercise escalate() at all - every app starts at `visible`,


### PR DESCRIPTION
## What

Four fail-open defects in the app-lifecycle / idle-app machinery, where a failed *read* was treated as an authoritative *empty result* — and empty authorised the destructive branch.

| # | Where | Fail-open shape |
|---|---|---|
| 1 | `app-lifecycle-config` | A config that failed to parse resolved to `quit` defaults — an unreadable policy became the most destructive policy. |
| 2 | `clear-mac-apps` | A failed Chrome tab query returned empty, and empty read as "no tabs open, safe to quit". |
| 3 | `hide-idle-apps` | Close/quit rungs ran on any machine the component was deployed to, with no record of consent to the destructive rungs. |
| 4 | `setup_hide_idle_apps.sh` | Absence of evidence of consent was read as consent. |

Defects 3 and 4 are the same shape one level up: *absent evidence of consent, read as consent.*

## Key design points

**One constant was serving two opposite semantics.** `DEFAULT_KEYS` fallbacks answer "the policy does not say; what should we do?" (answer: as little as possible → `skip`). But `migrate()` reused the same constants to answer "the old `.conf` did not list this app; what did that MEAN?" — where absence was an *affirmative* policy of `quit`. Collapsing them would have made every migrated config inert. Split into `MIGRATION_DEFAULTS`, guarded by the byte-identical golden-file test in `tests/test_clear_mac_apps.zsh`.

**A sentinel written on only one branch is not a gate.** `run_parallel` passes the environment down, so `HIDE_IDLE_APPS_EXPLICIT_CONSENT=true` inherited from an earlier opt-in deploy would sail through an `if` without `else`. It is now assigned on both branches, so only this invocation can decide.

**Provenance had to be tracked separately from the resolved boolean.** `config.local.sh` is sourced at `config.sh:330`, *before* `parse_args` — so `DEPLOY_HIDE_IDLE_APPS=true` conflates a CLI flag, a profile default, and a years-old persistent override. Hence `EXPLICIT_OPT_INS`, which records only what this command line asked for.

**The consent token lives in `~/.local/state`, not `~/.cache`** — `CACHE_DIR` is disposable by design, and a disposable consent record is not a consent record.

**Producer asymmetry decides whether a status check is correct.** `get_chrome_window_tabs` iterates `every window` and returns empty with exit 0, so nonzero genuinely means failure — worth gating. `get_app_frontmost_window_title` uses `get name of window 1`, which *errors when an app simply has no windows*, so nonzero is the ordinary case; gating there would have marked every windowless app protected. Both decisions are documented inline at the call sites.

## Verification

All of the below was executed on this Linux worktree and independently reproduced by a separate Codex verification run.

**Parser probes** (`app-lifecycle-config`):

| Input | Exit | Result |
|---|---|---|
| `defaults:` then EOF (truncated) | 0 | `manual=skip auto=skip` |
| zero-byte file | 78 | refuses: "config is empty - refusing to guess a policy" |
| comments-only file | 78 | same refusal |
| `apps:`-only (sparse, no `defaults:`) | 0 | `manual=skip auto=skip` — sparse policies still accepted |
| real `config/app-lifecycle.yaml` | 0 | `manual=quit auto=quit` |

**Migration** emits `manual: quit` / `auto: quit`, byte-identical to the golden file — confirming `MIGRATION_DEFAULTS` did not regress.

**Suites:** `zsh tests/test_hide_idle_apps.zsh` → PASS=84 FAIL=0. `zsh tests/test_clear_mac_apps.zsh` → PASS=79 FAIL=0.

**Mutation test on the new escalation gate.** Two earlier review rounds caught assertions in this very scenario that passed without exercising anything, so a green run was not accepted as evidence. Replacing the gate with `if false` produced PASS=79 FAIL=5: all five gate assertions failed, while "hiding still works ungated" and "nothing was escalated" correctly stayed green (the mutant does not touch the hiding path). Scenario 24 is non-vacuous for **both** the close and the quit rung. Gate restored; `git diff` clean.

Two review-driven fixes are themselves worth flagging, because each was a defect *introduced while fixing*: the `MIGRATION_DEFAULTS` split, and a quit-rung test that seeded 1000s against a 30-minute `quit_after` and so asserted against a rung that was never eligible.

## Not executed

`clear-mac-apps`, `hide-idle-apps`, `deploy.sh` and the setup script were never run — they quit real applications and install launchd jobs. Only the stubbed test suites and the parser were executed.

## Residual

Truncation mid-`defaults:` is indistinguishable from a deliberately sparse policy, so it resolves to `skip` rather than being rejected. That is fail-*safe* but still silent. Options: a trailing completeness marker, atomic emission (write-temp-then-rename), or accept it. Not addressed here.
