### PR TITLE
simplify-nudge: imperative wording, drop the hedge that defused it

### DIFF
--- a/claude/hooks/simplify_nudge.sh
+++ b/claude/hooks/simplify_nudge.sh
@@ -46,7 +46,7 @@ PARTS=()
 
 if [ -f "$MARKER" ]; then
   rm -f "$MARKER" 2>/dev/null || true
-  PARTS+=("Code changed this turn — \`/simplify\` will run a quality pass over the changed files if it's worth one.")
+  PARTS+=("Code changed this turn — run \`/simplify\` over it: reuse, simplification, efficiency, altitude.")
 fi
 
 if [ -n "$REUSE_STATE" ] && [ -f "$REUSE_STATE" ]; then


### PR DESCRIPTION
The Stop-hook nudge read:

> Code changed this turn — `/simplify` will run a quality pass over the changed files if it's worth one.

"if it's worth one" invites the reader to conclude it probably isn't. Now:

> Code changed this turn — run `/simplify` over it: reuse, simplification, efficiency, altitude.

Imperative, and it names the skill's own four axes instead of an invented friendlier description. Shorter than the original.

**Wording only** — still a `systemMessage`, not `additionalContext`. The header comment (lines 12-21) documents why that mechanism was chosen; nothing about it changed.

Verified: `shellcheck` clean (the one SC2015 info is pre-existing at line 72, untouched), `bash -n` syntax OK, backticks confirmed backslash-escaped via `cat -A` so there's no command substitution.

Not verified: end-to-end execution of the hook — the permission classifier was down for the whole session and blocked every attempt to run it. Worth one `printf '{"session_id":"x"}' | ./claude/hooks/simplify_nudge.sh` before merging. Codex review also couldn't run (sandbox denies writes under `~/.claude/plugins`).

https://claude.ai/code/session_011Df1GpSAjSNT3iFCmnbB9g