### PR TITLE
plugins: make claude-plugin-reset derive from the settings.json manifest

### DIFF
--- a/claude/hooks/clean_plugin_symlinks_session.sh
+++ b/claude/hooks/clean_plugin_symlinks_session.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SessionStart hook: clean stale plugin-created skill symlinks in the background.
+# Plugin operations recreate them (anthropics/claude-code#14549) and they cause
+# duplicate entries in the slash-command picker. This is the sole survivor of the
+# retired context_auto_apply.sh — profiles are gone, the cleanup is still needed.
+CLEAN_SCRIPT="${DOT_DIR:-$HOME/code/dotfiles}/scripts/cleanup/clean_plugin_symlinks.sh"
+if [ -f "$CLEAN_SCRIPT" ]; then
+    bash "$CLEAN_SCRIPT" &>/dev/null &
+    disown 2>/dev/null
+fi
+exit 0  # Never block session start

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -709,6 +709,11 @@
           },
           {
             "type": "command",
+            "command": "$HOME/.claude/hooks/clean_plugin_symlinks_session.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/with-anthropic-key.sh python3 $HOME/.claude/hooks/anthropic_keycheck.py",
             "timeout": 10
           }

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -24,9 +24,6 @@ if [ -n "$machine_name_output" ]; then
   machine_prefix="$icon $(printf '\033[35m')${name}$(printf '\033[0m') "
 fi
 
-# Context profiles were removed — every installed plugin is enabled everywhere.
-profiles_info=""
-
 # ============================================================================
 # DIRECTORY PATH (~ for HOME)
 # ============================================================================
@@ -103,7 +100,7 @@ fi
 # OUTPUT: Line 1 (location) + Line 2 (session)
 # ============================================================================
 # Line 1: location
-printf "%s%s\033[2m\033[36m%s\033[0m%s" "$machine_prefix" "$profiles_info" "$dir" "$git_info"
+printf "%s\033[2m\033[36m%s\033[0m%s" "$machine_prefix" "$dir" "$git_info"
 
 # Line 2: session state (model · ctx · duration)
 session_parts=()

--- a/config.sh
+++ b/config.sh
@@ -139,30 +139,9 @@ MCP_SERVERS=(
 # Format: "name:repo:binary_name:env_var_for_token"
 MCP_SERVERS_LOCAL=()
 
-# Claude Code Plugin Marketplaces
-# Format: "name:source" (source = GitHub user/repo)
-# Both official and custom marketplaces need explicit registration + plugin install
-PLUGIN_MARKETPLACES=(
-    "claude-plugins-official:anthropics/claude-plugins-official"
-    "ai-safety-plugins:yulonglin/ai-safety-plugins"
-)
-
-# Official plugins to auto-install from claude-plugins-official marketplace.
-# Matches everything referenced in settings.json enabledPlugins.
-OFFICIAL_PLUGINS=(
-    # Base profile (always-on)
-    "superpowers" "hookify" "plugin-dev" "commit-commands"
-    "claude-md-management" "context7"
-    # Development
-    "code-simplifier" "code-review" "security-guidance" "feature-dev"
-    "pr-review-toolkit" "playground" "ralph-loop"
-    # Integrations
-    "Notion" "vercel" "playwright"
-    # Language servers
-    "pyright-lsp" "typescript-lsp"
-    # Specialized
-    "frontend-design"
-)
+# Claude Code plugins and marketplaces are NOT listed here — the single source
+# of truth is claude/settings.json (extraKnownMarketplaces + enabledPlugins).
+# claude-plugin-reset derives its lists from that file at runtime.
 
 # ─── Core Packages ────────────────────────────────────────────────────────────
 # Installed on all platforms

--- a/custom_bins/claude-plugin-reset
+++ b/custom_bins/claude-plugin-reset
@@ -2,10 +2,13 @@
 # claude-plugin-reset — Reinstall plugin defaults for Claude Code.
 #
 # Bundles the full plugin reset workflow:
-#   1. Update all plugins from registered marketplaces
-#   2. Install official marketplace plugins
+#   1. Update all marketplaces declared in settings.json extraKnownMarketplaces
+#   2. Install every plugin in the settings.json enabledPlugins manifest
 #   3. Clean stale plugin cache versions
 #   4. Clean duplicate skill symlinks
+#
+# The manifest in claude/settings.json is the single source of truth — this
+# script derives its marketplace and plugin lists from it at runtime.
 #
 # Usage:
 #   claude-plugin-reset            # Full reset
@@ -45,16 +48,20 @@ run_step() {
   echo -e "\n${BOLD}[$step]${NC} $1"
 }
 
+SETTINGS_JSON="$DOT_DIR/claude/settings.json"
+if [[ ! -f "$SETTINGS_JSON" ]]; then
+  echo -e "${RED}Manifest not found: $SETTINGS_JSON${NC}"
+  exit 1
+fi
+
 # --- Step 1: Update plugin marketplaces ---
-source "$DOT_DIR/config.sh"
 run_step "Updating plugin marketplaces..."
 
 if ! command -v claude &>/dev/null; then
   echo -e "  ${RED}claude CLI not found — skipping marketplace update${NC}"
 else
-  for entry in "${PLUGIN_MARKETPLACES[@]}"; do
-    name="${entry%%:*}"
-    src="${entry#*:}"
+  while IFS=$'\t' read -r name src; do
+    [[ -n "$name" ]] || continue
 
     if $DRY_RUN; then
       echo -e "  ${YELLOW}Would ensure marketplace: $name ($src)${NC}"
@@ -73,18 +80,25 @@ else
     # Update
     claude plugin marketplace update "$name" 2>&1 || \
       echo -e "  ${YELLOW}$name update had warnings (may be OK)${NC}"
-  done
+  done < <(python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+for name, m in d.get("extraKnownMarketplaces", {}).items():
+    src = m.get("source", {})
+    if src.get("source") == "github" and src.get("repo"):
+        print(name + "\t" + src["repo"])
+' "$SETTINGS_JSON")
 fi
 
-# --- Step 2: Install official marketplace plugins ---
-run_step "Installing official marketplace plugins..."
+# --- Step 2: Install manifest plugins ---
+run_step "Installing manifest plugins (settings.json enabledPlugins)..."
 
 if ! command -v claude &>/dev/null; then
   echo -e "  ${RED}claude CLI not found — skipping${NC}"
 else
   installed=0 skipped=0 failed=0
-  for plugin in "${OFFICIAL_PLUGINS[@]}"; do
-    qualified="${plugin}@claude-plugins-official"
+  while IFS= read -r qualified; do
+    [[ -n "$qualified" ]] || continue
     if $DRY_RUN; then
       echo -e "  ${YELLOW}Would ensure: $qualified${NC}"
       continue
@@ -100,7 +114,13 @@ else
       echo -e "  ${YELLOW}Failed: $qualified${NC}"
       failed=$((failed + 1))
     fi
-  done
+  done < <(python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+for k, v in sorted(d.get("enabledPlugins", {}).items()):
+    if v is True:
+        print(k)
+' "$SETTINGS_JSON")
   if ! $DRY_RUN; then
     echo -e "  ${GREEN}Installed: $installed${NC}, Skipped: $skipped, Failed: $failed"
   fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -755,7 +755,7 @@ if [[ "$DEPLOY_CLAUDE" == "true" ]]; then
 
         log_success "Claude Code configuration deployed"
         log_info "  Config: CLAUDE.md, settings.json, agents/, hooks/, skills/"
-        log_info "  Plugins: 24 declared in settings.json enabledPlugins; all enabled by default"
+        log_info "  Plugins: declared in settings.json enabledPlugins; all enabled"
     else
         log_warning "Claude directory not found at $DOT_DIR/claude"
     fi

--- a/scripts/audit/stale-claims.sh
+++ b/scripts/audit/stale-claims.sh
@@ -250,11 +250,11 @@ check_plugin_manifest() {
         skip "$loc" "settings.json not found"
         return
     fi
-    falses=$(python3 -c "
+    falses=$(python3 -c '
 import json,sys
-d=json.load(open('$json'))
-print(' '.join(k for k,v in d.get('enabledPlugins',{}).items() if v is not True))
-" 2>/dev/null) || { skip "$loc" "could not parse settings.json"; return; }
+d=json.load(open(sys.argv[1]))
+print(" ".join(k for k,v in d.get("enabledPlugins",{}).items() if v is not True))
+' "$json" 2>/dev/null) || { skip "$loc" "could not parse settings.json"; return; }
     if [[ -z "$falses" ]]; then
         ok "$loc" "every entry is true"
     else


### PR DESCRIPTION
## What

Stacked on #58 — fixes the review findings so the manifest is genuinely the single source of truth.

## Changes

- **`claude-plugin-reset` now derives from the manifest.** `config.sh`'s hand-maintained `OFFICIAL_PLUGINS`/`PLUGIN_MARKETPLACES` arrays contradicted #58: they still listed the pruned `plugin-dev` and `ralph-loop`, five plugins not in the manifest at all (`code-review`, `feature-dev`, `pr-review-toolkit`, `Notion`, `vercel`), and only 2 of 6 marketplaces — running the reset script would have reinstalled what #58 pruned. Both arrays are deleted; the script reads `extraKnownMarketplaces` and `enabledPlugins` from `claude/settings.json` at runtime and installs at `--scope user` (which also serves #58's reinstall-at-user-scope follow-up).
- **Restored the per-session symlink cleanup** as a minimal SessionStart hook (`clean_plugin_symlinks_session.sh`). The deleted `context_auto_apply.sh` was also the thing running `clean_plugin_symlinks.sh` every session; without it, duplicate skill-picker entries accumulate until the next deploy.
- `deploy.sh`: dropped the hardcoded "24" plugin count.
- `statusline.sh`: removed the dead `profiles_info` variable and its printf slot.
- `stale-claims.sh`: settings path now passed via `sys.argv` instead of string interpolation.

## Verification

- `claude-plugin-reset --dry-run` derives exactly the 6 marketplaces and 24 manifest plugins from `claude/settings.json`
- `shellcheck` clean on changed scripts; `bash -n`/`zsh -n` pass
- `statusLine`/`hooks`/`permissions` gate passes; new hook registered in SessionStart
- New hook exits 0 standalone

https://claude.ai/code/session_01WoJYQoyUNVUn56h87MHDQ7
