### PR TITLE
Record what the council's ballots cost

### DIFF
--- a/claude/skills/council/SKILL.md
+++ b/claude/skills/council/SKILL.md
@@ -78,6 +78,8 @@ The ones you already know — so the panel spends its budget past them.
 
 **Fusion has no peer-ranking stage** — panel models never see each other's answers, and OpenRouter ships no council product (checked 2026-09-01: Labs offers Fusion, Cost Simulator and Spawn). `--rank` is built here, and it is the only way to learn which answer the *other models* found strongest. Skip it for a straightforward question; it roughly doubles cost for a signal you will not use.
 
+The call log records **every** stage of a `--rank` run — the eight seat answers, the eight ballots and the chair — so the recorded spend is the whole run. The `--dry-run` estimate is still a floor, because it counts no reasoning tokens.
+
 **Both modes fail closed.** A council that quietly lost three members still looks like corroboration, which is worse than no council. Default mode inherits fusion's integrity check; `--rank` refuses outright if any seat returns no answer. If it refuses, report the degraded panel and stop — do not retry with `--panel` trimmed to whoever answered, which converts a failure into a fabricated consensus.
 
 ### Borda measures acceptability, not correctness

--- a/custom_bins/openrouter-cli
+++ b/custom_bins/openrouter-cli
@@ -1162,19 +1162,24 @@ line, and nothing else.
 
 
 def cross_rank(answers: dict[str, dict], question: str, key: str,
-               max_tokens: int) -> tuple[dict[str, float], list[str]]:
+               max_tokens: int) -> tuple[dict[str, float], list[str], dict]:
     """Blind peer ranking, aggregated by Borda count.
 
     Each ranker sees every answer but its own, under labels shuffled per ranker
     so position and identity both carry no signal. Excluding self is what makes
     the ballot a peer review rather than a self-assessment; shuffling per ranker
     is what stops "answer A" meaning the same model to everyone.
+
+    Returns the tally, any notes, and the BALLOT USAGE. The usage used to be
+    discarded, which left roughly half a --rank run missing from the recorded
+    spend -- the call log's whole job is to say what a run cost.
     """
     import concurrent.futures as cf
     import random
     live = {s: a for s, a in answers.items() if a.get("content")}
+    usage: dict[str, dict] = {}
     if len(live) < 3:
-        return {}, ["cross-ranking needs at least 3 live answers"]
+        return {}, ["cross-ranking needs at least 3 live answers"], {}
     points: dict[str, float] = {s: 0.0 for s in live}
     notes: list[str] = []
     # Per ranker: the prompt it sees, and the label -> slug map needed to read
@@ -1203,12 +1208,13 @@ def cross_rank(answers: dict[str, dict], question: str, key: str,
         for fut in cf.as_completed(futs):
             ranker = futs[fut]
             try:
-                content, _ = fut.result()
+                content, resp = fut.result()
             # SystemExit too: ask_one reports provider failures through die().
             except (SystemExit, Exception) as exc:  # noqa: BLE001
                 notes.append(f"{ranker} cast no ballot: {exc}")
                 continue
             results[ranker] = content
+            usage[ranker] = {"usage": resp.get("usage") or {}}
 
     for ranker, content in results.items():
         labels = ballots[ranker][1]
@@ -1236,7 +1242,7 @@ def cross_rank(answers: dict[str, dict], question: str, key: str,
                 "score 0 for this ballot")
         for pos, slug in enumerate(order):
             points[slug] += n - pos
-    return points, notes
+    return points, notes, sum_usage(usage)
 
 
 CHAIR_PROMPT = """You are chairing a panel of independent AI models that each \
@@ -1442,7 +1448,7 @@ def cmd_council_ask(args, cfg) -> None:
         die("council incomplete - no answer from: " + ", ".join(dead)
             + "\nrefusing to present a partial council as a full one")
 
-    points, notes = cross_rank(live, prompt, key, max_tokens)
+    points, notes, ballot_usage = cross_rank(live, prompt, key, max_tokens)
     for n in notes:
         print(f"openrouter-cli: {n}", file=sys.stderr)
 
@@ -1461,12 +1467,14 @@ def cmd_council_ask(args, cfg) -> None:
                                rankings=rank_block, nonce=nonce)
     content, resp = ask_one(chair, final, key, max_tokens)
     entries_.append({"role": "chair", "requested": chair, "resolved": resp.get("model")})
-    # Seats + chair, not the chair alone: the synthesis is one call out of
-    # seventeen, so logging only its usage would understate the run ~16-fold.
-    # Ballot usage is not captured -- cross_rank discards its responses -- so
-    # this is a floor, and the flag says so.
-    spend = sum_usage({**answers, "_chair": {"usage": resp.get("usage") or {}}})
-    spend["excludes_ballots"] = True
+    # Every stage: seat answers, ballots and the chair. Logging the chair alone
+    # understated a seventeen-call run ~16-fold, and counting seats+chair still
+    # left the eight ballots -- about half the requests -- out of the record.
+    spend = sum_usage({
+        **answers,
+        "_ballots": {"usage": ballot_usage},
+        "_chair": {"usage": resp.get("usage") or {}},
+    })
     log_call("council", prompt, entries_, resp.get("id"), spend)
 
     if args.show_answers:

--- a/tests/test_council_roster.py
+++ b/tests/test_council_roster.py
@@ -225,7 +225,7 @@ class TestAdvisorPair:
 class TestCrossRank:
     def test_needs_at_least_three_live_answers(self):
         answers = {"a/one": {"content": "x"}, "b/two": {"content": "y"}}
-        points, notes = orc.cross_rank(answers, "q", "key", 100)
+        points, notes, _ = orc.cross_rank(answers, "q", "key", 100)
         assert points == {} and notes
 
     def test_ballots_exclude_the_ranker_and_borda_totals(self, monkeypatch):
@@ -240,7 +240,7 @@ class TestCrossRank:
             return "\n".join(labels), {}
 
         monkeypatch.setattr(orc, "ask_one", fake_ask)
-        points, notes = orc.cross_rank(answers, "q", "key", 100)
+        points, notes, _ = orc.cross_rank(answers, "q", "key", 100)
         assert not notes
         for slug, prompt in seen.items():
             assert answers[slug]["content"] not in prompt, "a ranker saw its own answer"
@@ -251,7 +251,7 @@ class TestCrossRank:
     def test_an_unparseable_ballot_is_noted_not_fatal(self, monkeypatch):
         answers = {f"m/{i}": {"content": f"answer {i}"} for i in range(3)}
         monkeypatch.setattr(orc, "ask_one", lambda *a, **k: ("no labels here", {}))
-        points, notes = orc.cross_rank(answers, "q", "key", 100)
+        points, notes, _ = orc.cross_rank(answers, "q", "key", 100)
         assert points == {s: 0.0 for s in answers}
         assert len(notes) == 3
 
@@ -328,7 +328,8 @@ class TestBallotParsing:
     def _rank(self, monkeypatch, reply, n=3):
         answers = {f"m/{i}": {"content": f"answer {i}"} for i in range(n)}
         monkeypatch.setattr(orc, "ask_one", lambda *a, **k: (reply, {}))
-        return orc.cross_rank(answers, "q", "key", 100)
+        points, notes, _ = orc.cross_rank(answers, "q", "key", 100)
+        return points, notes
 
     def test_an_english_article_is_not_a_vote(self, monkeypatch):
         """'A ranking follows:' once credited label A with the TOP rank.
@@ -354,6 +355,26 @@ class TestBallotParsing:
     def test_list_chrome_around_a_label_still_counts(self, monkeypatch):
         points, _ = self._rank(monkeypatch, "1. B\n2. A")
         assert sum(points.values()) > 0
+
+
+class TestBallotUsageIsRecorded:
+    """The eight ballots are about half a --rank run's requests. Discarding
+    their usage left the call log -- whose whole job is to say what a run cost
+    -- understating the run by roughly half."""
+
+    def test_ballot_usage_is_returned_and_summed(self, monkeypatch):
+        answers = {f"m/{i}": {"content": f"answer {i}"} for i in range(3)}
+        monkeypatch.setattr(
+            orc, "ask_one",
+            lambda *a, **k: ("A\nB", {"usage": {"cost": 0.25, "total_tokens": 10}}))
+        _, _, usage = orc.cross_rank(answers, "q", "key", 100)
+        assert usage == {"cost": 0.75, "total_tokens": 30}
+
+    def test_no_ballots_yields_empty_usage(self, monkeypatch):
+        """Below three live answers cross-ranking is skipped entirely."""
+        answers = {"a/one": {"content": "x"}, "b/two": {"content": "y"}}
+        points, notes, usage = orc.cross_rank(answers, "q", "key", 100)
+        assert points == {} and notes and usage == {}
 
 
 class TestCatalogVariantExclusion:


### PR DESCRIPTION
Follow-up to #82, closing the last finding from the Fable docs review rather than documenting it.

`cross_rank` discarded its responses, so the eight ballots — **about half the requests in a `--rank` run** — never reached the call log, and the row was stamped `excludes_ballots` to admit it. A log whose whole job is to say what a run cost should not be missing half the run.

`cross_rank` now returns its usage alongside the tally and notes, and `cmd_council_ask` folds seat, ballot and chair spend into one total. The caveat flag is gone because the caveat is gone. The skill says the log covers every stage, and keeps the separate, still-true warning that the `--dry-run` *estimate* is a floor because it counts no reasoning tokens.

### Verified against merged main first

All sixteen findings from the two reviewers are present in the shipped code — checked by reading `origin/main`, not by trusting the commit messages.

One reviewer reported `import secrets` **missing** mid-run, which would have raised `NameError` on every `--rank` synthesis *after* the fan-out was already billed. That was a window between two of my edits and never a shipped state: merged `main` has the import at line 39 with both its uses.

68 tests pass.
