### PR TITLE
gmail-connector: printout scripts (build.py, render.py) from API bodies

### DIFF
--- a/claude/skills/gmail-connector/SKILL.md
+++ b/claude/skills/gmail-connector/SKILL.md
@@ -46,6 +46,15 @@ HTML-only receipts: `_body.txt` (or the `html_body` from `FULL_CONTENT`) is a wo
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --print-to-pdf=out.pdf file:///abs/path/receipt.html
 ```
 
+For a whole thread the two scripts in `scripts/` do it end to end: `build.py` turns a `get_thread` result (`messageFormat: FULL_CONTENT`, so `htmlBody` is present; save the spilled JSON as `<basename>.txt`, the output takes the file stem) or the delimited `threads.txt` capture (format in its docstring) into a Gmail-print-style page — account header, subject, message count, each message boxed with From/To/Cc/Date/Attachments, tracking pixels and tokenised links stripped; `render.py` prints those pages to PDF and reports bytes and page count:
+
+```bash
+python3 ~/.claude/skills/gmail-connector/scripts/build.py work/threads.txt work/<basename>.txt --out work/html --account lin.yulong@gmail.com
+python3 ~/.claude/skills/gmail-connector/scripts/render.py work/html/*.html --out work/pdf   # sandbox off
+```
+
+Gmail's own print view cannot be pulled through the claude-in-chrome extension: its redaction fires on `a=b; c=d` shapes in the page HTML, and the auto-mode classifier blocks working around it, so the printout is built from the API body plus headers instead. Chrome 152 headless needs the sandbox off and never exits after `--print-to-pdf`; `render.py` polls until the PDF size is stable, then kills it, and flags anything under 10 KB as a blank page.
+
 ## Search lessons from the 2026-09 sweep
 
 - **`from:` fails for relayed senders.** Hetzner arrives via an iCloud relay, so `from:hetzner.com` returns nothing; search the keyword `hetzner` instead. When a monthly vendor shows zero hits, retry by keyword and by invoice-number prefix before concluding there is nothing.

--- a/claude/skills/gmail-connector/scripts/build.py
+++ b/claude/skills/gmail-connector/scripts/build.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Build a Gmail-print-style HTML page per thread from claude.ai Gmail connector captures.
+
+Inputs, any mix:
+  - a get_thread result saved as JSON ({"id": <threadId>, "messages": [{sender, toRecipients,
+    ccRecipients, date, subject, htmlBody | plaintextBody, attachments}, ...]}), fetched with
+    messageFormat FULL_CONTENT so htmlBody is present; output name is the file stem
+  - a delimited threads.txt: blocks start "=== THREAD <threadId> | <basename> ===", each message
+    starts "--- MESSAGE ---", then From/To/Cc/Date/Subject/Attachments header lines, then a line
+    "--- HTML ---" or "--- TEXT ---" and the body up to the next marker; dates are UTC "Z"
+
+Writes <out>/<basename>.html (headers, message count, each message boxed, tracking pixels and
+tokenised links stripped) and prints one line per thread. Feed the result to render.py.
+Exit 1 if any input fails to parse.
+"""
+import argparse
+import html
+import json
+import re
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+from pathlib import Path
+
+TRACKING_HOSTS = ("unsubscribe", "track", "click", "pixel", "beacon", "open.")
+TOKEN_PARAM = re.compile(r"[?&][^=&]*=([A-Za-z0-9_\-%.,]{20,})")
+
+
+def fmt_date(z: str) -> str:
+    dt = datetime.strptime(z, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    return dt.strftime("%a, %d %b %Y %H:%M UTC")
+
+
+def clean_href(href: str) -> str:
+    """Unwrap linkprotect wrappers and drop query strings carrying opaque tokens."""
+    raw = html.unescape(href)
+    p = urllib.parse.urlsplit(raw)
+    if p.netloc.endswith("linkprotect.cudasvc.com"):
+        target = urllib.parse.parse_qs(p.query).get("a", [""])[0]
+        if target:
+            return html.escape(target, quote=True)
+    if p.query and TOKEN_PARAM.search("?" + p.query):
+        return html.escape(urllib.parse.urlunsplit((p.scheme, p.netloc, p.path, "", "")), quote=True)
+    return href
+
+
+def strip_img(m: re.Match) -> str:
+    tag = m.group(0)
+    if re.search(r'width=["\']?1["\']?', tag) and re.search(r'height=["\']?1["\']?', tag):
+        return ""
+    src = re.search(r'src=["\']([^"\']+)', tag)
+    if src and src.group(1).startswith("http"):
+        host = urllib.parse.urlsplit(src.group(1)).netloc.lower()
+        if any(k in host for k in TRACKING_HOSTS):
+            return ""
+    return tag
+
+
+def clean_html_body(body: str) -> str:
+    body = re.sub(r"<!DOCTYPE[^>]*>", "", body, flags=re.I)
+    body = re.sub(r"<head\b.*?</head>", "", body, flags=re.I | re.S)
+    body = re.sub(r"</?html\b[^>]*>", "", body, flags=re.I)
+    body = re.sub(r"</?body\b[^>]*>", "", body, flags=re.I)
+    body = re.sub(r"<img\b[^>]*>", strip_img, body, flags=re.I)
+    body = re.sub(r'href="([^"]+)"', lambda m: f'href="{clean_href(m.group(1))}"', body)
+    return body.strip()
+
+
+def parse_threads_txt(path: Path) -> dict[str, dict]:
+    text = path.read_text(errors="replace")
+    threads = {}
+    blocks = re.split(r"^=== THREAD (\S+) \| (\S+) ===\n", text, flags=re.M)
+    for i in range(1, len(blocks), 3):
+        tid, base, body = blocks[i], blocks[i + 1], blocks[i + 2]
+        msgs = []
+        for chunk in re.split(r"^--- MESSAGE ---\n", body, flags=re.M)[1:]:
+            m = re.match(r"(.*?)\n--- (HTML|TEXT) ---\n(.*)\Z", chunk, re.S)
+            if not m:
+                raise ValueError(f"{path}: malformed message in thread {tid}")
+            hdr, kind, content = m.group(1), m.group(2), m.group(3)
+            h = {}
+            for line in hdr.split("\n"):
+                k, _, v = line.partition(": ")
+                h[k] = v
+            msgs.append({
+                "from": h["From"], "to": h.get("To", ""), "cc": h.get("Cc", ""),
+                "date": h["Date"], "subject": h["Subject"],
+                "attachments": h.get("Attachments", ""),
+                "kind": kind, "body": content.rstrip("\n"),
+            })
+        threads[base] = {"id": tid, "messages": msgs}
+    return threads
+
+
+def parse_thread_json(path: Path) -> dict:
+    d = json.loads(path.read_text())
+    msgs = []
+    for m in d["messages"]:
+        att = m.get("attachments") or []
+        names = ", ".join(a.get("filename", a.get("name", "")) for a in att) if isinstance(att, list) else ""
+        if m.get("htmlBody"):
+            kind, body = "HTML", m["htmlBody"]
+        else:
+            kind, body = "TEXT", m.get("plaintextBody", "")
+        msgs.append({
+            "from": m["sender"], "to": ", ".join(m.get("toRecipients") or []),
+            "cc": ", ".join(m.get("ccRecipients") or []), "date": m["date"],
+            "subject": m["subject"], "attachments": names, "kind": kind, "body": body,
+        })
+    return {"id": d["id"], "messages": msgs}
+
+
+def build(base: str, thread: dict, out_dir: Path, account: str, footer: str) -> Path:
+    msgs = thread["messages"]
+    subject = msgs[0]["subject"]
+    n = len(msgs)
+    parts = [f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>{html.escape(subject)}</title>
+<style>
+body {{ font-family: Arial, Helvetica, sans-serif; font-size: 13px; color: #000; margin: 24px; }}
+.hdr {{ display: flex; justify-content: space-between; align-items: baseline; border-bottom: 1px solid #ccc; padding-bottom: 6px; }}
+.hdr .wordmark {{ font-size: 22px; font-weight: bold; color: #444; }}
+h2 {{ font-size: 18px; margin: 14px 0 4px; }}
+.count {{ color: #555; margin-bottom: 14px; }}
+.msg {{ border: 1px solid #ccc; padding: 10px 12px; margin-bottom: 14px; page-break-inside: avoid; }}
+.msg .sender {{ font-weight: bold; }}
+.msg .meta {{ color: #666; }}
+.msg hr {{ border: 0; border-top: 1px solid #ddd; margin: 8px 0; }}
+.msg pre {{ white-space: pre-wrap; font-family: Arial, Helvetica, sans-serif; font-size: 13px; margin: 0; }}
+.body img {{ max-width: 100%; }}
+.footer {{ color: #666; font-size: 11px; border-top: 1px solid #ccc; padding-top: 6px; margin-top: 20px; }}
+</style></head><body>
+<div class="hdr"><span>{html.escape(account)}</span><span class="wordmark">Gmail</span></div>
+<h2>{html.escape(subject)}</h2>
+<div class="count">{n} message{"s" if n != 1 else ""}</div>
+"""]
+    for m in msgs:
+        meta = [f"To: {html.escape(m['to'])}"]
+        if m["cc"]:
+            meta.append(f"Cc: {html.escape(m['cc'])}")
+        if m["attachments"]:
+            meta.append(f"Attachments: {html.escape(m['attachments'])}")
+        if m["kind"] == "HTML":
+            body = clean_html_body(m["body"])
+        else:
+            body = f"<pre>{html.escape(m['body'])}</pre>"
+        parts.append(f"""<div class="msg">
+<div class="sender">{html.escape(m['from'])} &nbsp; {fmt_date(m['date'])}</div>
+<div class="meta">{"<br>".join(meta)}</div>
+<hr>
+<div class="body">{body}</div>
+</div>
+""")
+    parts.append(f"""<div class="footer">{html.escape(footer)}; thread id {thread['id']}</div>
+</body></html>
+""")
+    out = out_dir / f"{base}.html"
+    out.write_text("".join(parts))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("inputs", nargs="+", type=Path, help="threads.txt files and/or get_thread JSON files")
+    ap.add_argument("--out", type=Path, required=True, help="directory for the .html files")
+    ap.add_argument("--account", required=True, help="mailbox address shown in the page header")
+    ap.add_argument("--footer", default=None,
+                    help='footer text; default "Printed from Gmail via the Gmail API on <today> (UTC)"')
+    a = ap.parse_args()
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    footer = a.footer or f"Printed from Gmail via the Gmail API on {today} (UTC)"
+    a.out.mkdir(parents=True, exist_ok=True)
+
+    threads: dict[str, dict] = {}
+    failed = 0
+    for p in a.inputs:
+        try:  # spilled tool results are .txt whatever they hold, so sniff the content
+            if p.read_text(errors="replace").lstrip().startswith("{"):
+                threads[p.stem] = parse_thread_json(p)
+            else:
+                threads.update(parse_threads_txt(p))
+        except (ValueError, KeyError, OSError) as e:
+            print(f"{p}\tFAILED\t{e}", file=sys.stderr)
+            failed += 1
+    for base, t in threads.items():
+        out = build(base, t, a.out, a.account, footer)
+        print(f"{base}\t{t['id']}\t{len(t['messages'])} msgs\t{out.stat().st_size} B")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/skills/gmail-connector/scripts/render.py
+++ b/claude/skills/gmail-connector/scripts/render.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Render HTML files (from build.py, or any saved receipt page) to PDF with headless Chrome.
+
+Writes <out>/<stem>.pdf for each input and prints "<stem>\tstatus\tbytes\tpages" per file.
+Chrome 152 headless never exits after --print-to-pdf, so each run is polled until the PDF size
+stops changing, then the process is killed. Run with the sandbox off: Chrome cannot start its
+helpers inside it. A PDF under --min-bytes is reported as failed (blank page). Exit 1 if any
+file failed. Then `cp` (never `mv`) the PDFs into the pack.
+"""
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+
+def page_count(pdf: Path) -> int:
+    return len(re.findall(rb"/Type\s*/Page[^s]", pdf.read_bytes()))
+
+
+def render(src: Path, out_dir: Path, chrome: str, profile: Path, timeout: int, min_bytes: int) -> tuple[str, int, int]:
+    pdf = out_dir / f"{src.stem}.pdf"
+    clean = profile / f"{src.stem}.clean.html"  # the page's own window.print() would block the export
+    clean.write_text(re.sub(r"window\.print\(\)", "", src.read_text(errors="replace")))
+    pdf.unlink(missing_ok=True)
+    proc = subprocess.Popen(
+        [chrome, "--headless=new", "--disable-gpu", "--disable-crash-reporter",
+         f"--user-data-dir={profile}", "--no-pdf-header-footer",
+         f"--print-to-pdf={pdf}", f"file://{clean.resolve()}"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    deadline = time.time() + timeout
+    last, stable = -1, 0
+    while time.time() < deadline:
+        time.sleep(1)
+        if proc.poll() is not None:
+            break
+        size = pdf.stat().st_size if pdf.exists() else -1
+        stable = stable + 1 if size > 0 and size == last else 0
+        if stable >= 2:
+            break
+        last = size
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    if not pdf.exists():
+        return ("render failed (no pdf)", 0, 0)
+    size = pdf.stat().st_size
+    if size < min_bytes:
+        return (f"pdf too small ({size} B)", size, page_count(pdf))
+    return ("ok", size, page_count(pdf))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("html", nargs="+", type=Path, help="HTML files to print")
+    ap.add_argument("--out", type=Path, required=True, help="directory for the PDFs")
+    ap.add_argument("--chrome", default=CHROME, help=f"Chrome binary (default: {CHROME})")
+    ap.add_argument("--timeout", type=int, default=90, help="seconds to wait per file (default 90)")
+    ap.add_argument("--min-bytes", type=int, default=10_000, help="smaller PDFs count as failed (default 10000)")
+    a = ap.parse_args()
+    a.out.mkdir(parents=True, exist_ok=True)
+    failed = 0
+    with tempfile.TemporaryDirectory(prefix="chrome-headless-") as tmp:
+        for src in a.html:
+            if not src.exists():
+                status, size, pages = "missing html", 0, 0
+            else:
+                status, size, pages = render(src, a.out, a.chrome, Path(tmp), a.timeout, a.min_bytes)
+            failed += status != "ok"
+            print(f"{src.stem}\t{status}\t{size}\t{pages}", flush=True)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`rules/evidence.md` points at the gmail-connector skill for the print-to-PDF mechanics, but the scripts that produced the Sep 2026 exit-permit printouts lived in a job tmp dir. They now live in `claude/skills/gmail-connector/scripts/`.

- `build.py`: get_thread JSON (FULL_CONTENT) and/or the delimited `threads.txt` capture -> one Gmail-print-style HTML per thread. Input format sniffed by content (spilled tool results are `.txt` whatever they hold). `--out`, `--account`, `--footer`; exit 1 on a bad input.
- `render.py`: HTML -> PDF via headless Chrome, temp profile, polls for a stable file size then kills Chrome 152 (it never exits after `--print-to-pdf`), flags PDFs under `--min-bytes`. Exit 1 if any file failed. Needs the sandbox off.
- SKILL.md "Decoding RAW": invocation, why Gmail's own print view is not reachable through claude-in-chrome, the Chrome 152 quirk.

Smoke-tested on the nine real captures: all nine build; three rendered (2, 9 pages; `%PDF-` magic; no Chrome left running).

https://claude.ai/code/session_014SFazVFdsnPXT9gUNGzSJ3
