### PR TITLE
council: seat gpt-6-astra and muse-spark-1.3; codex model gpt-6-astra

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "ultra"
 approval_policy = "on-request"
 approvals_reviewer = "auto_review"

--- a/config/openrouter-models.toml
+++ b/config/openrouter-models.toml
@@ -96,7 +96,7 @@ families = [
 #
 # Families, not slugs, so this stays index-driven: whoever holds the anthropic
 # and openai seats after a refresh becomes the advisor pair automatically. Today
-# that is claude-fable-5 and gpt-5.6-sol, the two highest-scoring models in the
+# that is gpt-6-astra and claude-fable-5, the two highest-scoring models in the
 # catalogue under the price cap.
 advisor_families = ["anthropic", "openai"]
 
@@ -104,13 +104,14 @@ advisor_families = ["anthropic", "openai"]
 # which models can be seated, so both are spend decisions: a council run costs
 # roughly the sum of its seats.
 #
-# 60.0 output admits `claude-fable-5` at $50 and excludes `gpt-5.5-pro` at $180.
+# 60.0 output admits `gpt-6-astra` and `claude-fable-5` at $50 and excludes
+# `gpt-5.5-pro` at $180.
 #
 # The INPUT cap exists because an output-only cap misprices this workload. The
 # `--rank` round sends every seat the other seven answers, so input dominates
 # there -- a model at $59/M output but $200/M input would pass an output-only
 # check and then cost more than anything it displaced. 15.0 admits the current
-# roster (dearest input is claude-fable-5 at $10) with headroom.
+# roster (dearest inputs are gpt-6-astra and claude-fable-5 at $10) with headroom.
 max_input_price = 15.0
 max_output_price = 60.0
 
@@ -120,7 +121,7 @@ review_days = 14
 
 # Stamped by `council refresh --apply`. A date in the past by more than
 # `review_days` is what makes the nudge fire.
-reviewed = "2026-09-01"
+reviewed = "2026-09-04"
 
 # Everything between the markers is REWRITTEN mechanically by
 # `openrouter-cli council refresh --apply`. Edit by hand only to force a seat;
@@ -135,14 +136,14 @@ reviewed = "2026-09-01"
 #
 # BEGIN council-auto
 seats = [
-  { alias = "fable", slug = "anthropic/claude-fable-5", family = "anthropic", score = 162.5, basis = "eci" },
-  { alias = "gpt", slug = "openai/gpt-5.6-sol", family = "openai", score = 161.1, basis = "eci" },
-  { alias = "kimi", slug = "moonshotai/kimi-k3", family = "moonshotai", score = 157.3, basis = "eci" },
-  { alias = "gemini", slug = "google/gemini-3.7-flash", family = "google", score = 157.1, basis = "eci" },
-  { alias = "qwen", slug = "qwen/qwen3.8-max", family = "qwen", score = 156.4, basis = "eci" },
-  { alias = "grok", slug = "x-ai/grok-4.6", family = "x-ai", score = 156.2, basis = "eci" },
-  { alias = "muse", slug = "meta/muse-spark-1.2", family = "meta", score = 155.2, basis = "eci" },
-  { alias = "glm", slug = "z-ai/glm-5.3", family = "z-ai", score = 0.0, basis = "newest-in-line" },
+  { alias = "gpt", slug = "openai/gpt-6-astra", family = "openai", score = 169.2, basis = "eci" },
+  { alias = "fable", slug = "anthropic/claude-fable-5", family = "anthropic", score = 162.9, basis = "eci" },
+  { alias = "kimi", slug = "moonshotai/kimi-k3", family = "moonshotai", score = 157.6, basis = "eci" },
+  { alias = "qwen", slug = "qwen/qwen3.8-max", family = "qwen", score = 156.6, basis = "eci" },
+  { alias = "grok", slug = "x-ai/grok-4.6", family = "x-ai", score = 156.3, basis = "eci" },
+  { alias = "glm", slug = "z-ai/glm-5.3", family = "z-ai", score = 155.3, basis = "eci" },
+  { alias = "gemini", slug = "google/gemini-3.8-flash", family = "google", score = 0.0, basis = "newest-in-line" },
+  { alias = "muse", slug = "meta/muse-spark-1.3", family = "meta", score = 0.0, basis = "newest-in-line" },
 ]
 # END council-auto
 

--- a/custom_bins/openrouter-cli
+++ b/custom_bins/openrouter-cli
@@ -55,7 +55,11 @@ except ImportError:  # Python < 3.11
 OR_BASE = "https://openrouter.ai/api/v1"
 AA_URL = "https://artificialanalysis.ai/api/v2/data/llms/models"
 EPOCH_ZIP = "https://epoch.ai/data/benchmark_data.zip"
-ECI_CSV = "epoch_capabilities_index.csv"
+# Epoch moved the file into a subfolder and renamed the columns on 2026-09-05
+# (was a top-level epoch_capabilities_index.csv with "Model name"/"ECI Score");
+# fetch_eci() accepts either layout.
+ECI_CSV = "epoch_capabilities_index/eci_scores.csv"
+ECI_CSV_LEGACY = "epoch_capabilities_index.csv"
 
 # Resolved relative to this script so the tool works from any cwd.
 CONFIG = Path(__file__).resolve().parent.parent / "config" / "openrouter-models.toml"
@@ -389,11 +393,12 @@ def fetch_eci() -> dict[str, float]:
     with urllib.request.urlopen(req, timeout=120) as r:
         blob = r.read()
     z = zipfile.ZipFile(io.BytesIO(blob))
-    rows = csv.DictReader(io.StringIO(z.read(ECI_CSV).decode("utf-8", "replace")))
+    member = ECI_CSV if ECI_CSV in z.namelist() else ECI_CSV_LEGACY
+    rows = csv.DictReader(io.StringIO(z.read(member).decode("utf-8", "replace")))
     out: dict[str, float] = {}
     for row in rows:
-        score = (row.get("ECI Score") or "").strip()
-        name = (row.get("Model name") or "").strip()
+        score = (row.get("eci") or row.get("ECI Score") or "").strip()
+        name = (row.get("Model") or row.get("Model name") or "").strip()
         if not score or not name:
             continue  # unscored entries exist (Confidence == Unverified)
         try:


### PR DESCRIPTION
Roster re-picked with `openrouter-cli council refresh --apply`: gpt-6-astra
(Epoch 169.2, $10/$50, under both caps) replaces gpt-5.6-sol, muse-spark-1.3
replaces 1.2 as newest-in-line, and the same pass moved gemini to 3.8-flash
(newest-in-line) and recorded glm-5.3's first real score. Codex's default
model follows, and its models_cache.json already lists gpt-6-astra.

The refresh had been failing since Epoch reshaped benchmark_data.zip: the
index now lives at epoch_capabilities_index/eci_scores.csv with columns
Model/eci instead of a top-level CSV with "Model name"/"ECI Score".
fetch_eci() reads whichever layout the archive carries, so the fortnightly
council-roster timer works again.
## Review points

- Two extra roster changes beyond the ask came from the refresh tool itself: gemini 3.7-flash -> 3.8-flash (newest-in-line, unscored) and glm-5.3 now carries a real Epoch score (155.3). Revert the gemini seat by hand if 3.8-flash is unwanted; the next refresh will re-pick it.
- The parser fix was verified live: `council refresh` had failed on the old CSV name and returns a full scored roster with the fix. `tests/test_council_roster.py` passes (43/43); `openrouter-cli models --check` finds every configured slug in the catalogue.
- Not touched: `claude/settings.json`'s uncommitted working-copy env still names `gpt-5.6-sol` as `ANTHROPIC_CUSTOM_MODEL_OPTION`. That block is the gateway diff held out of commits, so it is edited in place, not here.

https://claude.ai/code/session_018RLgCMrsWu4peMoXHsVR8W