### PR TITLE
claude: remove watchdog model triage and audit recorded usage

### DIFF
--- a/claude/hooks/watchdog.sh
+++ b/claude/hooks/watchdog.sh
@@ -9,7 +9,6 @@
 #   CLAUDE_WATCHDOG_INTERVAL     - check frequency in seconds (default: 60)
 #   CLAUDE_WATCHDOG_MAX_LIFE     - max lifetime in seconds (default: 28800 = 8h)
 #   CLAUDE_WATCHDOG_MEM_LIMIT_MB - RSS threshold for memory alerts (default: 4096)
-#   Requires: claude CLI in PATH with valid auth (Claude Max / OAuth)
 
 set -uo pipefail
 
@@ -78,64 +77,6 @@ send_notification() {
   printf '\a' 2>/dev/null || true
 }
 
-# Ask Haiku whether the session is genuinely stuck
-# Returns 0 (stuck) or 1 (not stuck). Falls through to 0 on any error.
-triage_with_haiku() {
-  local transcript_path="$1" stale_min="$2"
-
-  # Gate: need claude CLI
-  if ! command -v claude &>/dev/null; then
-    return 0  # No CLI — assume stuck, notify
-  fi
-
-  # Read last ~8KB of transcript for context
-  local context
-  context=$(tail -c 8000 "$transcript_path" 2>/dev/null || true)
-  if [[ -z "$context" ]]; then
-    return 0
-  fi
-
-  local prompt="The following Claude Code session transcript has had no new output for ${stale_min} minutes. Is the session stuck (e.g., error loop, hanging tool call, no progress) or not stuck (e.g., finished successfully, waiting for user input, completed its task)? Reply with exactly STUCK or NOT_STUCK followed by a one-sentence reason.
-
-Transcript (last 8KB):
-${context}"
-
-  # Runs synchronously — timeout caps at 45s, loop can't overlap itself
-  # Empty MCP config prevents connecting to external services (GitHub, Linear, etc.)
-  local mcp_config="${TMPDIR}/claude-watchdog-mcp.json"
-  [[ -f "$mcp_config" ]] || printf '{"mcpServers":{}}\n' > "$mcp_config"
-
-  local verdict
-  verdict=$(
-    printf '%s' "$prompt" | \
-    env -u CLAUDECODE CLAUDE_WATCHDOG_ENABLED=0 \
-    timeout 45 claude -p \
-      --model haiku \
-      --output-format text \
-      --no-session-persistence \
-      --tools "" \
-      --disable-slash-commands \
-      --mcp-config "$mcp_config" \
-      --strict-mcp-config \
-      2>/dev/null
-  ) || true
-
-  if [[ -z "$verdict" ]]; then
-    return 0  # CLI failed — assume stuck
-  fi
-
-  # Store reason for notification message
-  TRIAGE_REASON=$(printf '%s' "$verdict" | sed 's/^[A-Z_]* *//')
-
-  if [[ "$verdict" == NOT_STUCK* ]]; then
-    return 1  # Not stuck — skip notification
-  fi
-
-  return 0  # Stuck or ambiguous — notify
-}
-
-TRIAGE_REASON=""
-
 while true; do
   sleep "$INTERVAL"
 
@@ -186,20 +127,9 @@ while true; do
     fi
 
     STALE_MIN=$(( STALE_SECONDS / 60 ))
-    TRIAGE_REASON=""
-
-    # Haiku triage: check if actually stuck before notifying
-    if triage_with_haiku "$TRANSCRIPT_PATH" "$STALE_MIN"; then
-      # Stuck — send notification
-      local_msg="No progress for ${STALE_MIN}m"
-      if [[ -n "$TRIAGE_REASON" ]]; then
-        local_msg="${local_msg} — ${TRIAGE_REASON}"
-      else
-        local_msg="${local_msg} — session may be stuck"
-      fi
-      send_notification "$local_msg" "$PROJECT_NAME" "$SESSION_ID"
-      LAST_NOTIFY=$NOW
-    fi
-    # If not stuck, skip notification silently
+    send_notification \
+      "No recent output for ${STALE_MIN}m — session may still be running or waiting" \
+      "$PROJECT_NAME" "$SESSION_ID"
+    LAST_NOTIFY=$NOW
   fi
 done

--- a/custom_bins/claude-usage-audit
+++ b/custom_bins/claude-usage-audit
@@ -36,6 +36,23 @@ TOKEN_FIELDS = (
     "cache_read_input_tokens",
     "cache_creation_input_tokens",
 )
+# The one definition of every limit the report states, so the JSON and the human
+# report cannot drift apart. Both renderers read these through the report data.
+REPORT_COVERAGE = {
+    "native_auto_mode_classifier": "successful calls unobserved",
+    "approval_classifier": (
+        "direct API USAGE log only; CLI subscription fallback is unobserved"
+    ),
+    "project_filter_scope": (
+        "--project filters transcript usage only; approval and quota are host-wide"
+    ),
+    "quota_history": (
+        "sampled only when --model-usage runs, without account attribution; "
+        "samples may interleave accounts and no identity is recorded"
+    ),
+    "non_persisted_calls": "absent",
+}
+REPORT_NOTES = ("tokens are not subscription quota",)
 
 
 def parse_args():
@@ -181,6 +198,23 @@ def aggregate_usage_records(records, coverage):
     return summary
 
 
+def transcript_paths(projects_dir, project_filter=""):
+    """Session files to scan, skipping the subtrees of non-matching projects entirely."""
+    if not project_filter:
+        return sorted(projects_dir.rglob("*.jsonl"))
+    try:
+        entries = list(projects_dir.iterdir())
+    except OSError:
+        # An unreadable root yields nothing, as the unfiltered glob has always done.
+        return []
+    selected = [
+        entry
+        for entry in entries
+        if entry.is_dir() and project_filter.lower() in entry.name.lower()
+    ]
+    return sorted(path for entry in selected for path in entry.rglob("*.jsonl"))
+
+
 def scan_transcript_model_usage(projects_dir, cutoff_epoch=0, project_filter=""):
     coverage = {
         "earliest_in_period": None,
@@ -195,13 +229,7 @@ def scan_transcript_model_usage(projects_dir, cutoff_epoch=0, project_filter="")
     if not projects_dir.is_dir():
         return aggregate_usage_records([], coverage)
 
-    for path in sorted(projects_dir.rglob("*.jsonl")):
-        relative = path.relative_to(projects_dir)
-        if project_filter and (
-            not relative.parts
-            or project_filter.lower() not in relative.parts[0].lower()
-        ):
-            continue
+    for path in transcript_paths(projects_dir, project_filter):
         try:
             lines = path.open(errors="replace")
         except OSError:
@@ -230,16 +258,24 @@ def scan_transcript_model_usage(projects_dir, cutoff_epoch=0, project_filter="")
                     continue
                 if cutoff_epoch and epoch < cutoff_epoch:
                     continue
-                message_id = message.get("id")
-                request_id = entry.get("requestId")
-                if isinstance(message_id, str) and message_id and isinstance(request_id, str) and request_id:
-                    key = ("request", message_id, request_id)
-                else:
-                    uuid = entry.get("uuid")
-                    if not isinstance(uuid, str) or not uuid:
-                        coverage["unkeyed_rows"] += 1
-                        continue
-                    key = ("uuid", uuid)
+                # One streamed response spans many rows that share a response identity
+                # but carry distinct row UUIDs, so the UUID is the last resort only.
+                identity = (
+                    ("message", message.get("id")),
+                    ("request", entry.get("requestId")),
+                    ("uuid", entry.get("uuid")),
+                )
+                key = next(
+                    (
+                        (kind, value)
+                        for kind, value in identity
+                        if isinstance(value, str) and value
+                    ),
+                    None,
+                )
+                if key is None:
+                    coverage["unkeyed_rows"] += 1
+                    continue
                 model = message.get("model")
                 if not isinstance(model, str) or not model:
                     model = "unknown"
@@ -260,10 +296,10 @@ def scan_transcript_model_usage(projects_dir, cutoff_epoch=0, project_filter="")
                     snapshots[key] = (rank, record)
 
     records = [item[1] for item in snapshots.values()]
-    records.sort(key=lambda record: record["epoch"])
     if records:
-        coverage["earliest_in_period"] = records[0]["timestamp"]
-        coverage["latest_in_period"] = records[-1]["timestamp"]
+        # Aggregation groups by model and day, so only the endpoints need an order.
+        coverage["earliest_in_period"] = min(records, key=lambda r: r["epoch"])["timestamp"]
+        coverage["latest_in_period"] = max(records, key=lambda r: r["epoch"])["timestamp"]
     return aggregate_usage_records(records, coverage)
 
 
@@ -317,10 +353,22 @@ def scan_approval_usage(log_path, cutoff_epoch=0):
             },
         })
     if retained:
-        retained.sort()
-        coverage["earliest_retained_at"] = retained[0][1]
-        coverage["latest_retained_at"] = retained[-1][1]
+        coverage["earliest_retained_at"] = min(retained)[1]
+        coverage["latest_retained_at"] = max(retained)[1]
     return aggregate_usage_records(records, coverage)
+
+
+def quota_bucket(name, utilization, resets_at):
+    """Build one canonical bucket, or None when the utilization is unusable."""
+    if isinstance(utilization, bool) or not isinstance(utilization, (int, float)):
+        return None
+    if not math.isfinite(utilization):
+        return None
+    return {
+        "name": name,
+        "utilization": utilization,
+        "resets_at": canonical_timestamp(resets_at),
+    }
 
 
 def quota_buckets(payload):
@@ -329,26 +377,14 @@ def quota_buckets(payload):
         bucket = payload.get(name)
         if not isinstance(bucket, dict):
             continue
-        utilization = bucket.get("utilization")
-        if isinstance(utilization, bool) or not isinstance(utilization, (int, float)):
-            continue
-        if not math.isfinite(utilization):
-            continue
-        buckets.append({
-            "name": name,
-            "utilization": utilization,
-            "resets_at": canonical_timestamp(bucket.get("resets_at")),
-        })
+        built = quota_bucket(name, bucket.get("utilization"), bucket.get("resets_at"))
+        if built is not None:
+            buckets.append(built)
     limits = payload.get("limits")
     if not isinstance(limits, list):
         return buckets
     for limit in limits:
         if not isinstance(limit, dict) or limit.get("kind") != "weekly_scoped":
-            continue
-        utilization = limit.get("percent")
-        if isinstance(utilization, bool) or not isinstance(utilization, (int, float)):
-            continue
-        if not math.isfinite(utilization):
             continue
         scope = limit.get("scope")
         model = scope.get("model") if isinstance(scope, dict) else None
@@ -358,121 +394,149 @@ def quota_buckets(payload):
         display_name = re.sub(r"[^A-Za-z0-9._ -]", "", display_name).strip()[:80]
         if not display_name:
             continue
-        buckets.append({
-            "name": f"weekly_scoped:{display_name}",
-            "utilization": utilization,
-            "resets_at": canonical_timestamp(limit.get("resets_at")),
-        })
+        built = quota_bucket(
+            f"weekly_scoped:{display_name}", limit.get("percent"), limit.get("resets_at")
+        )
+        if built is not None:
+            buckets.append(built)
     return buckets
 
 
-def snapshot_quota_cache(cache_path, history_path, now_epoch=None):
+def read_quota_cache(cache_path, now_epoch=None):
+    """Read the statusline quota cache; returns (status, the new observation or None)."""
     cache_path = Path(cache_path)
-    history_path = Path(history_path)
     try:
         stat = cache_path.stat()
         payload = json.loads(cache_path.read_text())
     except FileNotFoundError:
-        return {"available": False, "reason": "cache_missing"}
+        return {"available": False, "reason": "cache_missing"}, None
     except (OSError, UnicodeError, json.JSONDecodeError, TypeError):
-        return {"available": False, "reason": "cache_invalid"}
+        return {"available": False, "reason": "cache_invalid"}, None
     if not isinstance(payload, dict):
-        return {"available": False, "reason": "cache_invalid"}
+        return {"available": False, "reason": "cache_invalid"}, None
     buckets = quota_buckets(payload)
     if not buckets:
-        return {"available": False, "reason": "cache_has_no_usage"}
+        return {"available": False, "reason": "cache_has_no_usage"}, None
 
     observed_at = format_timestamp(stat.st_mtime)
     now_epoch = time.time() if now_epoch is None else now_epoch
     age = max(0, int(now_epoch - stat.st_mtime))
-    record = {"observed_at": observed_at, "buckets": buckets}
-    added = False
-    try:
-        history_path.parent.mkdir(parents=True, exist_ok=True)
-        with history_path.open("a+") as fh:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-            fh.seek(0)
-            existing = fh.read()
-            seen = set()
-            for line in existing.splitlines():
-                try:
-                    row = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(row, dict) and isinstance(row.get("observed_at"), str):
-                    seen.add(row["observed_at"])
-            if observed_at not in seen:
-                fh.seek(0, os.SEEK_END)
-                if existing and not existing.endswith("\n"):
-                    fh.write("\n")
-                fh.write(json.dumps(record, separators=(",", ":")) + "\n")
-                fh.flush()
-                added = True
-            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-    except OSError:
-        return {
-            "available": True,
-            "observed_at": observed_at,
-            "age_seconds": age,
-            "stale": age >= QUOTA_CACHE_TTL_SECONDS,
-            "snapshot_added": False,
-            "buckets": buckets,
-            "history_write": "failed",
-        }
-    return {
+    status = {
         "available": True,
         "observed_at": observed_at,
         "age_seconds": age,
         "stale": age >= QUOTA_CACHE_TTL_SECONDS,
-        "snapshot_added": added,
+        "snapshot_added": False,
         "buckets": buckets,
     }
+    return status, {"observed_at": observed_at, "buckets": buckets}
 
 
-def read_quota_history(history_path, cutoff_epoch=0):
-    coverage = {
-        "available": Path(history_path).is_file(),
-        "earliest_retained_at": None,
-        "latest_retained_at": None,
-        "samples_in_period": 0,
-        "malformed_rows": 0,
-    }
-    try:
-        lines = Path(history_path).read_text(errors="replace").splitlines()
-    except OSError:
-        return {"samples": [], "coverage": coverage}
+def parse_quota_history(raw, coverage):
+    """Decode history bytes tolerantly; returns (usable (epoch, row) pairs, instants seen).
 
-    retained = []
-    samples = []
-    for line in lines:
+    Undecodable bytes are replaced for parsing only, so a damaged file is read rather
+    than rewritten. Only a usable row proves an observation was already recorded, so
+    `seen` is filled after validation, and it holds instants rather than the text they
+    were written as: the same instant can be stored under any offset or precision.
+    """
+    rows = []
+    seen = set()
+    for line in raw.decode("utf-8", "replace").splitlines():
         try:
             record = json.loads(line)
         except (json.JSONDecodeError, TypeError):
             coverage["malformed_rows"] += 1
             continue
-        if not isinstance(record, dict) or not isinstance(record.get("buckets"), list):
+        if not isinstance(record, dict):
             coverage["malformed_rows"] += 1
             continue
         epoch = parse_timestamp(record.get("observed_at"))
-        if epoch is None:
+        if epoch is None or not isinstance(record.get("buckets"), list):
             coverage["malformed_rows"] += 1
             continue
-        retained.append((epoch, record["observed_at"]))
-        if not cutoff_epoch or epoch >= cutoff_epoch:
-            samples.append(record)
-    retained.sort()
-    samples.sort(key=lambda record: record["observed_at"])
-    if retained:
-        coverage["earliest_retained_at"] = retained[0][1]
-        coverage["latest_retained_at"] = retained[-1][1]
+        seen.add(epoch)
+        rows.append((epoch, record))
+    return rows, seen
+
+
+def load_quota_history(history_path, record=None, cutoff_epoch=0):
+    """Read the history once, appending `record` under the same lock when it is new.
+
+    Returns (history section, write outcome).
+    """
+    history_path = Path(history_path)
+    coverage = {
+        "available": False,
+        "earliest_retained_at": None,
+        "latest_retained_at": None,
+        "samples_in_period": 0,
+        "malformed_rows": 0,
+    }
+    rows = []
+    write = "skipped"
+    try:
+        if record is None:
+            rows, _ = parse_quota_history(history_path.read_bytes(), coverage)
+        else:
+            history_path.parent.mkdir(parents=True, exist_ok=True)
+            with history_path.open("a+b") as fh:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                try:
+                    fh.seek(0)
+                    raw = fh.read()
+                    rows, seen = parse_quota_history(raw, coverage)
+                    observed_epoch = parse_timestamp(record["observed_at"])
+                    if observed_epoch in seen:
+                        write = "duplicate"
+                    else:
+                        fh.seek(0, os.SEEK_END)
+                        if raw and not raw.endswith(b"\n"):
+                            fh.write(b"\n")
+                        fh.write(json.dumps(record, separators=(",", ":")).encode() + b"\n")
+                        fh.flush()
+                        rows.append((observed_epoch, record))
+                        write = "added"
+                finally:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        # A failed append must not also hide a history the reader can still read.
+        coverage = dict(coverage, malformed_rows=0)
+        try:
+            rows, _ = parse_quota_history(history_path.read_bytes(), coverage)
+        except OSError:
+            return {"samples": [], "coverage": coverage}, "failed"
+        write = "failed"
+
+    # Filter to the period first, then order by instant: timestamp text sorts wrongly
+    # across mixed offsets and mixed sub-second precision.
+    in_period = [pair for pair in rows if not cutoff_epoch or pair[0] >= cutoff_epoch]
+    in_period.sort(key=lambda pair: pair[0])
+    samples = [row for _, row in in_period]
+    if rows:
+        coverage["earliest_retained_at"] = min(rows, key=lambda item: item[0])[1]["observed_at"]
+        coverage["latest_retained_at"] = max(rows, key=lambda item: item[0])[1]["observed_at"]
     coverage["samples_in_period"] = len(samples)
-    return {"samples": samples, "coverage": coverage}
+    coverage["available"] = history_path.is_file()
+    return {"samples": samples, "coverage": coverage}, write
+
+
+def quota_report(cache_path, history_path, cutoff_epoch=0, now_epoch=None):
+    """Snapshot the quota cache and load its history in one locked pass."""
+    current, record = read_quota_cache(cache_path, now_epoch=now_epoch)
+    history, write = load_quota_history(
+        history_path, record=record, cutoff_epoch=cutoff_epoch
+    )
+    if record is not None:
+        current["snapshot_added"] = write == "added"
+        if write == "failed":
+            current["history_write"] = "failed"
+    return {"current": current, "history": history}
 
 
 def model_usage_report(args):
     cutoff_epoch = time.time() - args.days * 86400 if args.days else 0
     cache_path = Path(os.environ.get("TMPDIR", "/tmp/claude")) / QUOTA_CACHE_NAME
-    current_quota = snapshot_quota_cache(cache_path, QUOTA_HISTORY)
     return {
         "period_days": args.days or None,
         "transcript_usage": scan_transcript_model_usage(
@@ -484,22 +548,9 @@ def model_usage_report(args):
             APPROVAL_LOG,
             cutoff_epoch=cutoff_epoch,
         ),
-        "quota": {
-            "current": current_quota,
-            "history": read_quota_history(QUOTA_HISTORY, cutoff_epoch=cutoff_epoch),
-        },
-        "coverage": {
-            "native_auto_mode_classifier": "successful calls unobserved",
-            "approval_classifier": (
-                "direct API USAGE log only; CLI subscription fallback unobserved"
-            ),
-            "project_filter_scope": "transcript only; approval and quota host-wide",
-            "quota_history": (
-                "unattributed; samples may interleave accounts; no identity recorded"
-            ),
-            "non_persisted_calls": "absent",
-        },
-        "notes": ["tokens are not subscription quota"],
+        "quota": quota_report(cache_path, QUOTA_HISTORY, cutoff_epoch=cutoff_epoch),
+        "coverage": dict(REPORT_COVERAGE),
+        "notes": list(REPORT_NOTES),
     }
 
 
@@ -531,6 +582,7 @@ def print_model_usage_report(data, args):
                 f"  {day}: {summary['requests']} responses, "
                 f"{summary['tokens']['total_tokens']} tokens"
             )
+    coverage = data["coverage"]
     approval_coverage = data["approval_classifier_usage"]["coverage"]
     if approval_coverage["earliest_retained_at"]:
         print(
@@ -539,10 +591,7 @@ def print_model_usage_report(data, args):
         )
     else:
         print("Approval log has no retained usage rows (rotating 1 MB log)")
-    print(
-        "Approval coverage is the direct API USAGE log only; "
-        "CLI subscription fallback is unobserved"
-    )
+    print(f"Approval coverage is the {coverage['approval_classifier']}")
     current = data["quota"]["current"]
     if current.get("available"):
         stale = "stale" if current["stale"] else "fresh"
@@ -564,14 +613,17 @@ def print_model_usage_report(data, args):
     history = data["quota"]["history"]
     print(
         f"Quota history: {history['coverage']['samples_in_period']} sampled "
-        "observations in period; sampled only when --model-usage runs, without "
-        "account attribution; samples may interleave accounts and no identity is recorded"
+        f"observations in period; {coverage['quota_history']}"
     )
     if args.project:
-        print("Scope: --project filters transcript usage only; approval and quota are host-wide")
-    print("Coverage: native auto-mode classifier successful calls are unobserved")
-    print("Coverage: non-persisted calls are absent")
-    print("Note: tokens are not subscription quota")
+        print(f"Scope: {coverage['project_filter_scope']}")
+    print(
+        "Coverage: native auto-mode classifier "
+        f"{coverage['native_auto_mode_classifier']}"
+    )
+    print(f"Coverage: non-persisted calls are {coverage['non_persisted_calls']}")
+    for note in data["notes"]:
+        print(f"Note: {note}")
 
 
 def scan_session(filepath, cutoff_ts=0):

--- a/custom_bins/claude-usage-audit
+++ b/custom_bins/claude-usage-audit
@@ -108,9 +108,13 @@ def parse_timestamp(value):
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if parsed.utcoffset() is None:
+        # Reject ambiguous timestamps instead of assuming the host timezone.
+        return None
+    return parsed.timestamp()
 
 
 def format_timestamp(epoch):
@@ -217,7 +221,7 @@ def scan_transcript_model_usage(projects_dir, cutoff_epoch=0, project_filter="")
                 usage = message.get("usage")
                 tokens = numeric_tokens(usage)
                 if tokens is None:
-                    if isinstance(usage, dict):
+                    if "usage" in message:
                         coverage["unusable_usage_rows"] += 1
                     continue
                 epoch = parse_timestamp(entry.get("timestamp"))

--- a/custom_bins/claude-usage-audit
+++ b/custom_bins/claude-usage-audit
@@ -12,7 +12,9 @@ Usage:
 """
 
 import argparse
+import fcntl
 import json
+import math
 import os
 import re
 import sys
@@ -21,10 +23,19 @@ from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
 PLUGINS_FILE = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
 PROFILES_FILE = Path.home() / ".claude" / "templates" / "contexts" / "profiles.yaml"
+APPROVAL_LOG = Path.home() / ".cache" / "claude" / "approval-classifier.log"
+QUOTA_CACHE_NAME = "claude-statusline-usage.json"
+QUOTA_CACHE_TTL_SECONDS = 300
+QUOTA_HISTORY = Path.home() / ".claude" / "usage-data" / "quota-history.jsonl"
+TOKEN_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+)
 
 
 def parse_args():
@@ -33,6 +44,11 @@ def parse_args():
     p.add_argument("--days", type=int, default=0, help="Only scan last N days (0=all)")
     p.add_argument("--project", type=str, default="", help="Filter by project name substring")
     p.add_argument("--verbose", "-v", action="store_true", help="Show per-project breakdown")
+    p.add_argument(
+        "--model-usage",
+        action="store_true",
+        help="Report persisted model tokens and sampled subscription quota",
+    )
     return p.parse_args()
 
 
@@ -86,6 +102,472 @@ def get_profiles():
                 enables = re.findall(r"-\s+([\w-]+)", enables_text)
             profiles[name] = {"enable": enables}
         return base, profiles
+
+
+def parse_timestamp(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def format_timestamp(epoch):
+    dt = datetime.fromtimestamp(epoch, timezone.utc)
+    timespec = "seconds" if dt.microsecond == 0 else "microseconds"
+    return dt.isoformat(timespec=timespec).replace("+00:00", "Z")
+
+
+def canonical_timestamp(value):
+    epoch = parse_timestamp(value)
+    return format_timestamp(epoch) if epoch is not None else None
+
+
+def numeric_tokens(usage):
+    if not isinstance(usage, dict):
+        return None
+    tokens = {}
+    present = False
+    for field in TOKEN_FIELDS:
+        value = usage.get(field, 0)
+        if field in usage:
+            present = True
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            return None
+        tokens[field] = value
+    return tokens if present else None
+
+
+def summarize_usage_records(records):
+    totals = {field: 0 for field in TOKEN_FIELDS}
+    for record in records:
+        for field in TOKEN_FIELDS:
+            totals[field] += record["tokens"][field]
+    totals["total_tokens"] = sum(totals.values())
+    input_side = (
+        totals["input_tokens"]
+        + totals["cache_read_input_tokens"]
+        + totals["cache_creation_input_tokens"]
+    )
+    summary = {
+        "requests": len(records),
+        "tokens": totals,
+        "cache_read_fraction": (
+            totals["cache_read_input_tokens"] / input_side if input_side else 0.0
+        ),
+    }
+    return summary
+
+
+def aggregate_usage_records(records, coverage):
+    summary = summarize_usage_records(records)
+    by_model = defaultdict(list)
+    by_day = defaultdict(list)
+    for record in records:
+        by_model[record["model"]].append(record)
+        by_day[record["timestamp"][:10]].append(record)
+    summary["by_model"] = {
+        key: summarize_usage_records(group) for key, group in sorted(by_model.items())
+    }
+    summary["by_day"] = {
+        key: summarize_usage_records(group) for key, group in sorted(by_day.items())
+    }
+    summary["coverage"] = coverage
+    return summary
+
+
+def scan_transcript_model_usage(projects_dir, cutoff_epoch=0, project_filter=""):
+    coverage = {
+        "earliest_in_period": None,
+        "latest_in_period": None,
+        "malformed_rows": 0,
+        "unusable_usage_rows": 0,
+        "invalid_timestamp_rows": 0,
+        "unkeyed_rows": 0,
+    }
+    snapshots = {}
+    projects_dir = Path(projects_dir)
+    if not projects_dir.is_dir():
+        return aggregate_usage_records([], coverage)
+
+    for path in sorted(projects_dir.rglob("*.jsonl")):
+        relative = path.relative_to(projects_dir)
+        if project_filter and (
+            not relative.parts
+            or project_filter.lower() not in relative.parts[0].lower()
+        ):
+            continue
+        try:
+            lines = path.open(errors="replace")
+        except OSError:
+            continue
+        with lines:
+            for line in lines:
+                try:
+                    entry = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    coverage["malformed_rows"] += 1
+                    continue
+                if not isinstance(entry, dict) or entry.get("type") != "assistant":
+                    continue
+                message = entry.get("message")
+                if not isinstance(message, dict):
+                    continue
+                usage = message.get("usage")
+                tokens = numeric_tokens(usage)
+                if tokens is None:
+                    if isinstance(usage, dict):
+                        coverage["unusable_usage_rows"] += 1
+                    continue
+                epoch = parse_timestamp(entry.get("timestamp"))
+                if epoch is None:
+                    coverage["invalid_timestamp_rows"] += 1
+                    continue
+                if cutoff_epoch and epoch < cutoff_epoch:
+                    continue
+                message_id = message.get("id")
+                request_id = entry.get("requestId")
+                if isinstance(message_id, str) and message_id and isinstance(request_id, str) and request_id:
+                    key = ("request", message_id, request_id)
+                else:
+                    uuid = entry.get("uuid")
+                    if not isinstance(uuid, str) or not uuid:
+                        coverage["unkeyed_rows"] += 1
+                        continue
+                    key = ("uuid", uuid)
+                model = message.get("model")
+                if not isinstance(model, str) or not model:
+                    model = "unknown"
+                record = {
+                    "timestamp": format_timestamp(epoch),
+                    "epoch": epoch,
+                    "model": model,
+                    "tokens": tokens,
+                }
+                input_side = (
+                    tokens["input_tokens"]
+                    + tokens["cache_read_input_tokens"]
+                    + tokens["cache_creation_input_tokens"]
+                )
+                rank = (tokens["output_tokens"], input_side)
+                previous = snapshots.get(key)
+                if previous is None or rank > previous[0]:
+                    snapshots[key] = (rank, record)
+
+    records = [item[1] for item in snapshots.values()]
+    records.sort(key=lambda record: record["epoch"])
+    if records:
+        coverage["earliest_in_period"] = records[0]["timestamp"]
+        coverage["latest_in_period"] = records[-1]["timestamp"]
+    return aggregate_usage_records(records, coverage)
+
+
+APPROVAL_USAGE_RE = re.compile(
+    r"^(\S+) USAGE: model=(\S+) input=(\d+) output=(\d+) "
+    r"cache_read=(\d+) cache_create=(\d+)$"
+)
+
+
+def scan_approval_usage(log_path, cutoff_epoch=0):
+    coverage = {
+        "available": False,
+        "earliest_retained_at": None,
+        "latest_retained_at": None,
+        "malformed_usage_lines": 0,
+        "retention": "rotating_1mb_log",
+    }
+    path = Path(log_path)
+    try:
+        lines = path.read_text(errors="replace").splitlines()
+    except OSError:
+        return aggregate_usage_records([], coverage)
+
+    coverage["available"] = True
+    records = []
+    retained = []
+    for line in lines:
+        if " USAGE:" not in line:
+            continue
+        match = APPROVAL_USAGE_RE.fullmatch(line)
+        if match is None:
+            coverage["malformed_usage_lines"] += 1
+            continue
+        timestamp, model, input_, output, cache_read, cache_create = match.groups()
+        epoch = parse_timestamp(timestamp)
+        if epoch is None:
+            coverage["malformed_usage_lines"] += 1
+            continue
+        retained.append((epoch, timestamp))
+        if cutoff_epoch and epoch < cutoff_epoch:
+            continue
+        records.append({
+            "timestamp": format_timestamp(epoch),
+            "epoch": epoch,
+            "model": model,
+            "tokens": {
+                "input_tokens": int(input_),
+                "output_tokens": int(output),
+                "cache_read_input_tokens": int(cache_read),
+                "cache_creation_input_tokens": int(cache_create),
+            },
+        })
+    if retained:
+        retained.sort()
+        coverage["earliest_retained_at"] = retained[0][1]
+        coverage["latest_retained_at"] = retained[-1][1]
+    return aggregate_usage_records(records, coverage)
+
+
+def quota_buckets(payload):
+    buckets = []
+    for name in ("five_hour", "seven_day"):
+        bucket = payload.get(name)
+        if not isinstance(bucket, dict):
+            continue
+        utilization = bucket.get("utilization")
+        if isinstance(utilization, bool) or not isinstance(utilization, (int, float)):
+            continue
+        if not math.isfinite(utilization):
+            continue
+        buckets.append({
+            "name": name,
+            "utilization": utilization,
+            "resets_at": canonical_timestamp(bucket.get("resets_at")),
+        })
+    limits = payload.get("limits")
+    if not isinstance(limits, list):
+        return buckets
+    for limit in limits:
+        if not isinstance(limit, dict) or limit.get("kind") != "weekly_scoped":
+            continue
+        utilization = limit.get("percent")
+        if isinstance(utilization, bool) or not isinstance(utilization, (int, float)):
+            continue
+        if not math.isfinite(utilization):
+            continue
+        scope = limit.get("scope")
+        model = scope.get("model") if isinstance(scope, dict) else None
+        display_name = model.get("display_name") if isinstance(model, dict) else None
+        if not isinstance(display_name, str) or not display_name.strip():
+            continue
+        display_name = re.sub(r"[^A-Za-z0-9._ -]", "", display_name).strip()[:80]
+        if not display_name:
+            continue
+        buckets.append({
+            "name": f"weekly_scoped:{display_name}",
+            "utilization": utilization,
+            "resets_at": canonical_timestamp(limit.get("resets_at")),
+        })
+    return buckets
+
+
+def snapshot_quota_cache(cache_path, history_path, now_epoch=None):
+    cache_path = Path(cache_path)
+    history_path = Path(history_path)
+    try:
+        stat = cache_path.stat()
+        payload = json.loads(cache_path.read_text())
+    except FileNotFoundError:
+        return {"available": False, "reason": "cache_missing"}
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError):
+        return {"available": False, "reason": "cache_invalid"}
+    if not isinstance(payload, dict):
+        return {"available": False, "reason": "cache_invalid"}
+    buckets = quota_buckets(payload)
+    if not buckets:
+        return {"available": False, "reason": "cache_has_no_usage"}
+
+    observed_at = format_timestamp(stat.st_mtime)
+    now_epoch = time.time() if now_epoch is None else now_epoch
+    age = max(0, int(now_epoch - stat.st_mtime))
+    record = {"observed_at": observed_at, "buckets": buckets}
+    added = False
+    try:
+        history_path.parent.mkdir(parents=True, exist_ok=True)
+        with history_path.open("a+") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.seek(0)
+            existing = fh.read()
+            seen = set()
+            for line in existing.splitlines():
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and isinstance(row.get("observed_at"), str):
+                    seen.add(row["observed_at"])
+            if observed_at not in seen:
+                fh.seek(0, os.SEEK_END)
+                if existing and not existing.endswith("\n"):
+                    fh.write("\n")
+                fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+                fh.flush()
+                added = True
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        return {
+            "available": True,
+            "observed_at": observed_at,
+            "age_seconds": age,
+            "stale": age >= QUOTA_CACHE_TTL_SECONDS,
+            "snapshot_added": False,
+            "buckets": buckets,
+            "history_write": "failed",
+        }
+    return {
+        "available": True,
+        "observed_at": observed_at,
+        "age_seconds": age,
+        "stale": age >= QUOTA_CACHE_TTL_SECONDS,
+        "snapshot_added": added,
+        "buckets": buckets,
+    }
+
+
+def read_quota_history(history_path, cutoff_epoch=0):
+    coverage = {
+        "available": Path(history_path).is_file(),
+        "earliest_retained_at": None,
+        "latest_retained_at": None,
+        "samples_in_period": 0,
+        "malformed_rows": 0,
+    }
+    try:
+        lines = Path(history_path).read_text(errors="replace").splitlines()
+    except OSError:
+        return {"samples": [], "coverage": coverage}
+
+    retained = []
+    samples = []
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            coverage["malformed_rows"] += 1
+            continue
+        if not isinstance(record, dict) or not isinstance(record.get("buckets"), list):
+            coverage["malformed_rows"] += 1
+            continue
+        epoch = parse_timestamp(record.get("observed_at"))
+        if epoch is None:
+            coverage["malformed_rows"] += 1
+            continue
+        retained.append((epoch, record["observed_at"]))
+        if not cutoff_epoch or epoch >= cutoff_epoch:
+            samples.append(record)
+    retained.sort()
+    samples.sort(key=lambda record: record["observed_at"])
+    if retained:
+        coverage["earliest_retained_at"] = retained[0][1]
+        coverage["latest_retained_at"] = retained[-1][1]
+    coverage["samples_in_period"] = len(samples)
+    return {"samples": samples, "coverage": coverage}
+
+
+def model_usage_report(args):
+    cutoff_epoch = time.time() - args.days * 86400 if args.days else 0
+    cache_path = Path(os.environ.get("TMPDIR", "/tmp/claude")) / QUOTA_CACHE_NAME
+    current_quota = snapshot_quota_cache(cache_path, QUOTA_HISTORY)
+    return {
+        "period_days": args.days or None,
+        "transcript_usage": scan_transcript_model_usage(
+            PROJECTS_DIR,
+            cutoff_epoch=cutoff_epoch,
+            project_filter=args.project,
+        ),
+        "approval_classifier_usage": scan_approval_usage(
+            APPROVAL_LOG,
+            cutoff_epoch=cutoff_epoch,
+        ),
+        "quota": {
+            "current": current_quota,
+            "history": read_quota_history(QUOTA_HISTORY, cutoff_epoch=cutoff_epoch),
+        },
+        "coverage": {
+            "native_auto_mode_classifier": "successful calls unobserved",
+            "approval_classifier": (
+                "direct API USAGE log only; CLI subscription fallback unobserved"
+            ),
+            "project_filter_scope": "transcript only; approval and quota host-wide",
+            "quota_history": (
+                "unattributed; samples may interleave accounts; no identity recorded"
+            ),
+            "non_persisted_calls": "absent",
+        },
+        "notes": ["tokens are not subscription quota"],
+    }
+
+
+def print_model_usage_report(data, args):
+    if args.json:
+        print(json.dumps(data, indent=2))
+        return
+    period = f"last {args.days} days" if args.days else "all retained records"
+    print(f"\n=== Claude Model Usage ({period}) ===")
+    for label, key in (
+        ("Transcript", "transcript_usage"),
+        ("Approval classifier", "approval_classifier_usage"),
+    ):
+        section = data[key]
+        tokens = section["tokens"]
+        print(
+            f"{label}: {section['requests']} persisted responses, "
+            f"{tokens['total_tokens']} tokens, "
+            f"cache read {section['cache_read_fraction']:.1%}"
+        )
+        for model, summary in section["by_model"].items():
+            print(
+                f"  {model}: {summary['requests']} responses, "
+                f"{summary['tokens']['total_tokens']} tokens"
+            )
+        print(f"{label} by day:")
+        for day, summary in section["by_day"].items():
+            print(
+                f"  {day}: {summary['requests']} responses, "
+                f"{summary['tokens']['total_tokens']} tokens"
+            )
+    approval_coverage = data["approval_classifier_usage"]["coverage"]
+    if approval_coverage["earliest_retained_at"]:
+        print(
+            f"Approval log retained since {approval_coverage['earliest_retained_at']} "
+            "(rotating 1 MB log)"
+        )
+    else:
+        print("Approval log has no retained usage rows (rotating 1 MB log)")
+    print(
+        "Approval coverage is the direct API USAGE log only; "
+        "CLI subscription fallback is unobserved"
+    )
+    current = data["quota"]["current"]
+    if current.get("available"):
+        stale = "stale" if current["stale"] else "fresh"
+        print(
+            f"Quota cache: observed {current['observed_at']}, "
+            f"age {current['age_seconds']}s ({stale})"
+        )
+        for bucket in current["buckets"]:
+            reset = (
+                f"resets {bucket['resets_at']}"
+                if bucket["resets_at"]
+                else "reset time unavailable"
+            )
+            print(
+                f"  {bucket['name']}: {bucket['utilization']:g}% utilized; {reset}"
+            )
+    else:
+        print(f"Quota cache: unavailable ({current['reason']})")
+    history = data["quota"]["history"]
+    print(
+        f"Quota history: {history['coverage']['samples_in_period']} sampled "
+        "observations in period; sampled only when --model-usage runs, without "
+        "account attribution; samples may interleave accounts and no identity is recorded"
+    )
+    if args.project:
+        print("Scope: --project filters transcript usage only; approval and quota are host-wide")
+    print("Coverage: native auto-mode classifier successful calls are unobserved")
+    print("Coverage: non-persisted calls are absent")
+    print("Note: tokens are not subscription quota")
 
 
 def scan_session(filepath, cutoff_ts=0):
@@ -353,7 +835,7 @@ def print_report(data, args):
     print()
 
     # Installed plugins analysis
-    print("--- Installed Plugins ({}) ---".format(len(all_plugins)))
+    print(f"--- Installed Plugins ({len(all_plugins)}) ---")
     # Categorize
     referenced = set()
     for skill_name in data["total_skills"]:
@@ -501,6 +983,9 @@ def print_report(data, args):
 
 def main():
     args = parse_args()
+    if args.model_usage:
+        print_model_usage_report(model_usage_report(args), args)
+        return
     data = scan_all_sessions(args)
     if data is None:
         sys.exit(1)

--- a/docs/terminal-and-dev-tools.md
+++ b/docs/terminal-and-dev-tools.md
@@ -88,6 +88,12 @@ Context % is color-coded: green <70%, yellow 70–89%, red 90%+. Machine name us
 
 `ccusage statusline` is deliberately not wired into the live Claude hook path because it can OOM on large local histories; guard logic still uses lightweight `ccusage blocks --active --json` where available.
 
+### Model usage is reported from existing records
+
+`claude-usage-audit --model-usage [--days N] [--json]` reports deduplicated token usage from local transcripts, separate direct API usage from the rotating approval-classifier `USAGE:` log lines, and quota snapshots sampled from the existing statusline cache when the command runs. The JSON schema retains the legacy `requests` key, where each count is one persisted response. `--project` filters transcript usage only; approval and quota data remain host-wide. The approval section does not observe CLI subscription fallback calls. The report stores no transcript content, account identity, project path or session identifier; successful native auto-mode classifier calls are unobserved, non-persisted calls are absent, and token counts are not subscription quota.
+
+Quota history is stored at `~/.claude/usage-data/quota-history.jsonl` without account attribution. Samples can interleave accounts because no identity is recorded. Each row contains only the cache observation time and allowlisted quota bucket utilization/reset fields; the current-cache report states its age and whether it exceeds the statusline cache's five-minute freshness window.
+
 ## Ignore Pattern Management
 
 `claude-tools ignore` manages per-repo `.gitignore` and `.ignore` patterns interactively.

--- a/tests/test_claude_usage_audit.py
+++ b/tests/test_claude_usage_audit.py
@@ -83,9 +83,13 @@ def read_jsonl(path: Path) -> list[dict]:
     return records
 
 
-def run_cli(home: Path, tmpdir: Path, *args: str) -> subprocess.CompletedProcess:
+def run_cli(
+    home: Path, tmpdir: Path, *args: str, tz: str | None = None
+) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env.update({"HOME": str(home), "TMPDIR": str(tmpdir)})
+    if tz is not None:
+        env["TZ"] = tz
     return subprocess.run(
         [sys.executable, str(AUDIT), *args],
         capture_output=True,
@@ -131,6 +135,7 @@ def test_transcript_usage_deduplicates_whole_snapshots_globally(tmp_path):
     assert result["by_model"]["claude-test"]["requests"] == 2
     assert result["by_day"]["2026-09-06"]["tokens"]["input_tokens"] == 25
     assert result["coverage"]["malformed_rows"] == 1
+    assert result["coverage"]["unusable_usage_rows"] == 1
 
 
 def test_transcript_usage_tolerates_bad_utf8(tmp_path):
@@ -435,3 +440,143 @@ def test_model_usage_cli_is_metadata_only_and_legacy_json_mode_survives(tmp_path
     legacy_report = json.loads(legacy_result.stdout)
     assert legacy_report["skills"] == {"fixture-skill": 1}
     assert "transcript_usage" not in legacy_report
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-09-06T10:00:00",
+        "2026-09-06T10:00:00.500000",
+        "2026-09-06 10:00:00",
+        "2026-09-06",
+    ],
+)
+def test_parse_timestamp_rejects_a_timestamp_without_an_explicit_offset(value):
+    """A naive stamp has no instant, so neither UTC nor local time may be assumed."""
+    assert audit.parse_timestamp(value) is None
+    assert audit.canonical_timestamp(value) is None
+
+
+def test_parse_timestamp_keeps_offset_aware_stamps_and_canonicalizes_to_utc():
+    assert audit.parse_timestamp("2026-09-06T10:00:00Z") == audit.parse_timestamp(
+        "2026-09-06T05:00:00-05:00"
+    )
+    assert audit.canonical_timestamp("2026-09-06T05:00:00-05:00") == "2026-09-06T10:00:00Z"
+    assert audit.canonical_timestamp("2026-09-06T12:00:00+02:00") == "2026-09-06T10:00:00Z"
+    assert audit.canonical_timestamp("2026-09-06T10:00:00+00:00") == "2026-09-06T10:00:00Z"
+
+
+def usage_row(uuid: str, message: dict) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": "2026-09-06T10:00:00Z",
+        "uuid": uuid,
+        "message": dict(message),
+    }
+
+
+def test_a_present_but_unusable_usage_field_is_counted_and_an_absent_one_is_not(tmp_path):
+    """Only a usage field that is there but unreadable makes the row corrupt."""
+    projects = tmp_path / "projects"
+    unusable_values = [None, "n/a", [], 5, True, {}, {"input_tokens": "x", "output_tokens": 1}]
+    rows = [
+        usage_row(f"unusable-{index}", {"model": "claude-test", "usage": value})
+        for index, value in enumerate(unusable_values)
+    ]
+    rows.append(usage_row("no-usage-field", {"model": "claude-test"}))
+    rows.append(assistant_row("2026-09-06T10:00:00Z", uuid="good", output_tokens=3))
+    write_jsonl(projects / "one" / "session.jsonl", rows)
+
+    result = audit.scan_transcript_model_usage(projects)
+
+    assert result["requests"] == 1
+    assert result["tokens"]["output_tokens"] == 3
+    assert result["coverage"]["unusable_usage_rows"] == len(unusable_values)
+    assert result["coverage"]["malformed_rows"] == 0
+    assert result["coverage"]["invalid_timestamp_rows"] == 0
+    assert result["coverage"]["unkeyed_rows"] == 0
+
+
+def test_transcript_counts_a_naive_timestamp_as_invalid_and_keeps_the_offset_row(tmp_path):
+    projects = tmp_path / "projects"
+    write_jsonl(
+        projects / "one" / "session.jsonl",
+        [
+            assistant_row("2026-09-06T10:00:00", uuid="naive", output_tokens=100),
+            assistant_row("2026-09-06", uuid="date-only", output_tokens=200),
+            assistant_row("2026-09-06T05:00:00-05:00", uuid="offset", output_tokens=7),
+        ],
+    )
+
+    result = audit.scan_transcript_model_usage(projects)
+
+    assert result["requests"] == 1
+    assert result["tokens"]["output_tokens"] == 7
+    assert result["coverage"]["invalid_timestamp_rows"] == 2
+    assert result["coverage"]["earliest_in_period"] == "2026-09-06T10:00:00Z"
+
+
+def test_the_other_parse_timestamp_callers_reject_naive_stamps_the_same_way(tmp_path):
+    """Approval, quota history and reset times must not disagree about what parses."""
+    log = tmp_path / "approval-classifier.log"
+    log.write_text(
+        "2026-09-06T10:00:00 USAGE: model=claude-a input=1 output=1 cache_read=0 cache_create=0\n"
+        "2026-09-06 USAGE: model=claude-a input=1 output=1 cache_read=0 cache_create=0\n"
+        "2026-09-06T05:00:00-05:00 USAGE: model=claude-a input=2 output=3 cache_read=0 cache_create=0\n"
+    )
+    approval = audit.scan_approval_usage(log)
+    assert approval["requests"] == 1
+    assert approval["coverage"]["malformed_usage_lines"] == 2
+    assert approval["coverage"]["earliest_retained_at"] == "2026-09-06T05:00:00-05:00"
+
+    history = tmp_path / "quota-history.jsonl"
+    bucket = [{"name": "five_hour", "utilization": 10, "resets_at": None}]
+    write_jsonl(
+        history,
+        [
+            {"observed_at": "2026-09-06T10:00:00", "buckets": bucket},
+            {"observed_at": "2026-09-06", "buckets": bucket},
+            {"observed_at": "2026-09-06T10:00:00Z", "buckets": bucket},
+        ],
+    )
+    quota_history = audit.read_quota_history(history)
+    assert quota_history["coverage"]["malformed_rows"] == 2
+    assert quota_history["coverage"]["earliest_retained_at"] == "2026-09-06T10:00:00Z"
+
+    assert audit.quota_buckets({
+        "five_hour": {"utilization": 10, "resets_at": "2026-09-07T12:00:00"},
+        "seven_day": {"utilization": 20, "resets_at": "2026-09-07T07:00:00-05:00"},
+    }) == [
+        {"name": "five_hour", "utilization": 10, "resets_at": None},
+        {"name": "seven_day", "utilization": 20, "resets_at": "2026-09-07T12:00:00Z"},
+    ]
+
+
+def test_model_usage_cli_output_does_not_depend_on_the_host_timezone(tmp_path):
+    """Two hosts in different zones must report the same instants from the same records."""
+    home = tmp_path / "home"
+    tmpdir = tmp_path / "tmp"
+    tmpdir.mkdir(parents=True)
+    write_jsonl(
+        home / ".claude" / "projects" / "fixture" / "session.jsonl",
+        [
+            assistant_row("2026-09-06T10:00:00Z", uuid="zulu", output_tokens=5),
+            assistant_row("2026-09-06T05:00:00-05:00", uuid="offset", output_tokens=7),
+            assistant_row("2026-09-06T10:00:00", uuid="naive", output_tokens=900),
+            assistant_row("2026-09-06", uuid="date-only", output_tokens=900),
+        ],
+    )
+
+    utc = run_cli(home, tmpdir, "--model-usage", "--json", tz="UTC0")
+    est = run_cli(home, tmpdir, "--model-usage", "--json", tz="EST5EDT")
+
+    assert utc.returncode == 0, utc.stderr
+    assert est.returncode == 0, est.stderr
+    assert utc.stdout == est.stdout
+    transcript = json.loads(utc.stdout)["transcript_usage"]
+    assert transcript["requests"] == 2
+    assert transcript["tokens"]["output_tokens"] == 12
+    assert transcript["coverage"]["invalid_timestamp_rows"] == 2
+    assert transcript["coverage"]["earliest_in_period"] == "2026-09-06T10:00:00Z"
+    assert transcript["coverage"]["latest_in_period"] == "2026-09-06T10:00:00Z"
+    assert list(transcript["by_day"]) == ["2026-09-06"]

--- a/tests/test_claude_usage_audit.py
+++ b/tests/test_claude_usage_audit.py
@@ -5,6 +5,7 @@ existing quota cache only when the command runs. Fixtures contain no real transc
 content, account identity, project path, or provider request.
 """
 
+import argparse
 import importlib.machinery
 import importlib.util
 import json
@@ -73,7 +74,7 @@ def write_jsonl(path: Path, rows: list[object], malformed: str | None = None) ->
 
 def read_jsonl(path: Path) -> list[dict]:
     records = []
-    for line in path.read_text().splitlines():
+    for line in path.read_bytes().decode("utf-8", "replace").splitlines():
         try:
             record = json.loads(line)
         except json.JSONDecodeError:
@@ -252,15 +253,15 @@ def test_quota_snapshot_uses_cache_mtime_allowlist_and_deduplicates(tmp_path):
     os.utime(cache, (observed.timestamp(), observed.timestamp()))
     now = observed + timedelta(seconds=120)
 
-    first = audit.snapshot_quota_cache(cache, history, now_epoch=now.timestamp())
-    second = audit.snapshot_quota_cache(cache, history, now_epoch=now.timestamp())
+    first = audit.quota_report(cache, history, now_epoch=now.timestamp())
+    second = audit.quota_report(cache, history, now_epoch=now.timestamp())
 
     expected_buckets = [
         {"name": "five_hour", "utilization": 12.5, "resets_at": "2026-09-07T12:00:00Z"},
         {"name": "seven_day", "utilization": 44, "resets_at": None},
         {"name": "weekly_scoped:Fable", "utilization": 33, "resets_at": "2026-09-13T12:00:00Z"},
     ]
-    assert first == {
+    assert first["current"] == {
         "available": True,
         "observed_at": "2026-09-07T10:00:00Z",
         "age_seconds": 120,
@@ -268,12 +269,14 @@ def test_quota_snapshot_uses_cache_mtime_allowlist_and_deduplicates(tmp_path):
         "snapshot_added": True,
         "buckets": expected_buckets,
     }
-    assert second["snapshot_added"] is False
+    assert second["current"]["snapshot_added"] is False
+    expected_row = {"observed_at": "2026-09-07T10:00:00Z", "buckets": expected_buckets}
     rows = read_jsonl(history)
-    assert rows == [{
-        "observed_at": "2026-09-07T10:00:00Z",
-        "buckets": expected_buckets,
-    }]
+    assert rows == [expected_row]
+    # The just-appended observation must still reach the same run's history section.
+    assert first["history"]["samples"] == [expected_row]
+    assert first["history"]["coverage"]["samples_in_period"] == 1
+    assert second["history"]["samples"] == [expected_row]
     stored = history.read_text()
     assert "private@example.test" not in stored
     assert "not-a-real-token" not in stored
@@ -290,16 +293,19 @@ def test_quota_snapshot_keeps_current_buckets_when_history_write_fails(tmp_path)
     observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
     os.utime(cache, (observed.timestamp(), observed.timestamp()))
 
-    status = audit.snapshot_quota_cache(
+    report = audit.quota_report(
         cache,
         blocked_parent / "quota-history.jsonl",
         now_epoch=observed.timestamp(),
     )
 
-    assert status["history_write"] == "failed"
-    assert status["buckets"] == [
+    assert report["current"]["history_write"] == "failed"
+    assert report["current"]["snapshot_added"] is False
+    assert report["current"]["buckets"] == [
         {"name": "five_hour", "utilization": 50, "resets_at": None}
     ]
+    assert report["history"]["samples"] == []
+    assert report["history"]["coverage"]["available"] is False
 
 
 def test_quota_append_separates_a_truncated_tail_and_missing_cache_is_explicit(tmp_path):
@@ -312,16 +318,19 @@ def test_quota_append_separates_a_truncated_tail_and_missing_cache_is_explicit(t
     observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
     os.utime(cache, (observed.timestamp(), observed.timestamp()))
 
-    status = audit.snapshot_quota_cache(cache, history, now_epoch=observed.timestamp() + 300)
+    report = audit.quota_report(cache, history, now_epoch=observed.timestamp() + 300)
 
-    assert status["stale"] is True
+    assert report["current"]["stale"] is True
     assert len(read_jsonl(history)) == 1
     assert "\n{" in history.read_text()
-    missing = audit.snapshot_quota_cache(tmp_path / "absent.json", history, now_epoch=observed.timestamp())
-    assert missing == {"available": False, "reason": "cache_missing"}
+    assert report["history"]["coverage"]["malformed_rows"] == 1
+    missing = audit.quota_report(tmp_path / "absent.json", history, now_epoch=observed.timestamp())
+    assert missing["current"] == {"available": False, "reason": "cache_missing"}
+    # A missing cache must still not suppress the retained history.
+    assert missing["history"]["coverage"]["samples_in_period"] == 1
     invalid = tmp_path / "invalid-cache.json"
     invalid.write_bytes(b"\xff")
-    assert audit.snapshot_quota_cache(invalid, history) == {
+    assert audit.quota_report(invalid, history)["current"] == {
         "available": False,
         "reason": "cache_invalid",
     }
@@ -336,10 +345,11 @@ def test_quota_history_days_filter_keeps_all_time_coverage(tmp_path):
     ]
     write_jsonl(history, rows, malformed="not-json")
 
-    result = audit.read_quota_history(
+    result = audit.quota_report(
+        tmp_path / "absent-cache.json",
         history,
         cutoff_epoch=datetime(2026, 9, 5, tzinfo=timezone.utc).timestamp(),
-    )
+    )["history"]
 
     assert result["samples"] == [rows[1]]
     assert result["coverage"] == {
@@ -403,13 +413,14 @@ def test_model_usage_cli_is_metadata_only_and_legacy_json_mode_survives(tmp_path
     ]
     assert model_report["coverage"]["native_auto_mode_classifier"] == "successful calls unobserved"
     assert model_report["coverage"]["approval_classifier"] == (
-        "direct API USAGE log only; CLI subscription fallback unobserved"
+        "direct API USAGE log only; CLI subscription fallback is unobserved"
     )
     assert model_report["coverage"]["project_filter_scope"] == (
-        "transcript only; approval and quota host-wide"
+        "--project filters transcript usage only; approval and quota are host-wide"
     )
     assert model_report["coverage"]["quota_history"] == (
-        "unattributed; samples may interleave accounts; no identity recorded"
+        "sampled only when --model-usage runs, without account attribution; "
+        "samples may interleave accounts and no identity is recorded"
     )
     assert model_report["coverage"]["non_persisted_calls"] == "absent"
     assert "tokens are not subscription quota" in model_report["notes"]
@@ -539,7 +550,7 @@ def test_the_other_parse_timestamp_callers_reject_naive_stamps_the_same_way(tmp_
             {"observed_at": "2026-09-06T10:00:00Z", "buckets": bucket},
         ],
     )
-    quota_history = audit.read_quota_history(history)
+    quota_history = audit.quota_report(tmp_path / "absent-cache.json", history)["history"]
     assert quota_history["coverage"]["malformed_rows"] == 2
     assert quota_history["coverage"]["earliest_retained_at"] == "2026-09-06T10:00:00Z"
 
@@ -580,3 +591,410 @@ def test_model_usage_cli_output_does_not_depend_on_the_host_timezone(tmp_path):
     assert transcript["coverage"]["earliest_in_period"] == "2026-09-06T10:00:00Z"
     assert transcript["coverage"]["latest_in_period"] == "2026-09-06T10:00:00Z"
     assert list(transcript["by_day"]) == ["2026-09-06"]
+
+
+STAMP = "2026-09-06T10:00:00Z"
+
+
+def test_streamed_rows_sharing_a_message_id_are_one_response(tmp_path):
+    """Content blocks of one streamed response carry distinct row UUIDs and no requestId."""
+    projects = tmp_path / "projects"
+    write_jsonl(
+        projects / "one" / "session.jsonl",
+        [
+            assistant_row(STAMP, message_id="m1", uuid="u1", output_tokens=1, input_tokens=999),
+            assistant_row(STAMP, message_id="m1", uuid="u2", output_tokens=4, input_tokens=10),
+            assistant_row(
+                STAMP, message_id="m1", request_id="r1", uuid="u3", output_tokens=3, input_tokens=50
+            ),
+        ],
+    )
+
+    result = audit.scan_transcript_model_usage(projects)
+
+    assert result["requests"] == 1
+    # The whole highest-output snapshot wins; token fields are never maxed separately.
+    assert result["tokens"]["output_tokens"] == 4
+    assert result["tokens"]["input_tokens"] == 10
+
+
+def test_request_id_keys_a_response_only_when_the_message_id_is_missing(tmp_path):
+    projects = tmp_path / "projects"
+    write_jsonl(
+        projects / "one" / "session.jsonl",
+        [
+            assistant_row(STAMP, message_id="m1", request_id="shared", uuid="a", output_tokens=2),
+            assistant_row(STAMP, message_id="m2", request_id="shared", uuid="b", output_tokens=3),
+            assistant_row(STAMP, request_id="r9", uuid="c", output_tokens=5),
+            assistant_row(STAMP, request_id="r9", uuid="d", output_tokens=7),
+            assistant_row(STAMP, message_id="", request_id="r9", uuid="f", output_tokens=1),
+            assistant_row(STAMP, uuid="e", output_tokens=11),
+            assistant_row(STAMP, output_tokens=13),
+        ],
+    )
+
+    result = audit.scan_transcript_model_usage(projects)
+
+    assert result["requests"] == 4
+    assert result["tokens"]["output_tokens"] == 23
+    assert result["coverage"]["unkeyed_rows"] == 1
+
+
+def test_model_usage_cli_survives_a_history_file_with_undecodable_bytes(tmp_path):
+    """A damaged history must not abort the report, be rewritten, or be resampled."""
+    home = tmp_path / "home"
+    tmpdir = tmp_path / "tmp"
+    cache = tmpdir / "claude-statusline-usage.json"
+    cache.parent.mkdir(parents=True)
+    cache.write_text('{"five_hour":{"utilization":50,"resets_at":null}}')
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+    write_jsonl(
+        home / ".claude" / "projects" / "fixture" / "session.jsonl",
+        [assistant_row(STAMP, uuid="only", input_tokens=4, output_tokens=6)],
+    )
+    history = home / ".claude" / "usage-data" / "quota-history.jsonl"
+    history.parent.mkdir(parents=True)
+    seed = b"\xff\xfe{not json"
+    history.write_bytes(seed)
+
+    first = run_cli(home, tmpdir, "--model-usage", "--json")
+    second = run_cli(home, tmpdir, "--model-usage", "--json")
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    first_report = json.loads(first.stdout)
+    second_report = json.loads(second.stdout)
+    assert first_report["quota"]["current"]["snapshot_added"] is True
+    assert second_report["quota"]["current"]["snapshot_added"] is False
+    assert history.read_bytes().startswith(seed)
+    assert len(read_jsonl(history)) == 1
+    for report in (first_report, second_report):
+        assert report["quota"]["history"]["coverage"]["malformed_rows"] == 1
+        assert report["quota"]["history"]["coverage"]["samples_in_period"] == 1
+        assert report["transcript_usage"]["requests"] == 1
+        assert report["transcript_usage"]["tokens"]["total_tokens"] == 10
+
+
+def test_quota_report_reads_the_history_once_per_run(tmp_path, monkeypatch):
+    cache = tmp_path / "claude-statusline-usage.json"
+    history = tmp_path / "quota-history.jsonl"
+    cache.write_text('{"five_hour":{"utilization":50,"resets_at":null}}')
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+    opened = []
+    real_open = Path.open
+
+    def spy(self, *args, **kwargs):
+        if self == history:
+            opened.append(args[0] if args else kwargs.get("mode", "r"))
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", spy)
+
+    report = audit.quota_report(cache, history, now_epoch=observed.timestamp())
+
+    assert opened == ["a+b"]
+    assert report["current"]["snapshot_added"] is True
+    assert report["history"]["coverage"]["samples_in_period"] == 1
+    assert report["history"]["samples"][0]["observed_at"] == report["current"]["observed_at"]
+
+
+def test_a_damaged_row_does_not_suppress_the_sample_it_shares_a_timestamp_with(tmp_path):
+    """Only a usable row proves an observation was already recorded."""
+    cache = tmp_path / "claude-statusline-usage.json"
+    history = tmp_path / "quota-history.jsonl"
+    cache.write_text('{"five_hour":{"utilization":50,"resets_at":null}}')
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+    damaged = b'{"observed_at":"2026-09-07T10:00:00Z"}\n'
+    history.write_bytes(damaged)
+
+    first = audit.quota_report(cache, history, now_epoch=observed.timestamp())
+    second = audit.quota_report(cache, history, now_epoch=observed.timestamp())
+
+    assert first["current"]["snapshot_added"] is True
+    assert second["current"]["snapshot_added"] is False
+    assert history.read_bytes().startswith(damaged)
+    assert len(read_jsonl(history)) == 2
+    for report in (first, second):
+        assert report["history"]["coverage"]["malformed_rows"] == 1
+        assert report["history"]["coverage"]["samples_in_period"] == 1
+        assert report["history"]["samples"][0]["buckets"] == [
+            {"name": "five_hour", "utilization": 50, "resets_at": None}
+        ]
+
+
+def test_an_equivalent_offset_counts_as_the_same_recorded_observation(tmp_path):
+    """Dedup is about instants, so a differently written same instant is not new."""
+    cache = tmp_path / "claude-statusline-usage.json"
+    history = tmp_path / "quota-history.jsonl"
+    cache.write_text('{"five_hour":{"utilization":50,"resets_at":null}}')
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+    bucket = [{"name": "five_hour", "utilization": 50, "resets_at": None}]
+    write_jsonl(
+        history,
+        [
+            {"observed_at": "2026-09-07T10:00:00+00:00", "buckets": bucket},
+            {"observed_at": "2026-09-07T05:00:00-05:00", "buckets": bucket},
+        ],
+    )
+    seeded = history.read_bytes()
+
+    first = audit.quota_report(cache, history, now_epoch=observed.timestamp())
+    second = audit.quota_report(cache, history, now_epoch=observed.timestamp())
+
+    assert first["current"]["observed_at"] == "2026-09-07T10:00:00Z"
+    assert first["current"]["snapshot_added"] is False
+    assert second["current"]["snapshot_added"] is False
+    assert history.read_bytes() == seeded
+    assert len(read_jsonl(history)) == 2
+    assert first["history"]["coverage"]["samples_in_period"] == 2
+    assert first["history"]["coverage"]["malformed_rows"] == 0
+
+
+def test_history_samples_are_ordered_by_instant_not_by_timestamp_text(tmp_path):
+    """Mixed precision and mixed offsets sort differently as text than as instants."""
+    history = tmp_path / "quota-history.jsonl"
+    absent_cache = tmp_path / "absent-cache.json"
+    bucket = [{"name": "five_hour", "utilization": 10, "resets_at": None}]
+    stamps = [
+        "2026-09-06T10:00:00.500000Z",
+        "2026-09-06T10:00:00Z",
+        "2026-09-06T06:00:00-05:00",
+        "2026-09-06T11:00:00+02:00",
+    ]
+    write_jsonl(history, [{"observed_at": stamp, "buckets": bucket} for stamp in stamps])
+
+    result = audit.quota_report(absent_cache, history)["history"]
+
+    assert [sample["observed_at"] for sample in result["samples"]] == [
+        "2026-09-06T11:00:00+02:00",
+        "2026-09-06T10:00:00Z",
+        "2026-09-06T10:00:00.500000Z",
+        "2026-09-06T06:00:00-05:00",
+    ]
+    assert result["coverage"]["earliest_retained_at"] == "2026-09-06T11:00:00+02:00"
+    assert result["coverage"]["latest_retained_at"] == "2026-09-06T06:00:00-05:00"
+
+    cutoff = datetime(2026, 9, 6, 10, 0, 0, 250000, tzinfo=timezone.utc)
+    filtered = audit.quota_report(
+        absent_cache, history, cutoff_epoch=cutoff.timestamp()
+    )["history"]
+
+    assert [sample["observed_at"] for sample in filtered["samples"]] == [
+        "2026-09-06T10:00:00.500000Z",
+        "2026-09-06T06:00:00-05:00",
+    ]
+    assert filtered["coverage"]["samples_in_period"] == 2
+    # Period filtering must not shrink the retained boundary.
+    assert filtered["coverage"]["earliest_retained_at"] == "2026-09-06T11:00:00+02:00"
+
+
+def test_a_failed_append_still_reports_the_history_it_could_read(tmp_path, monkeypatch):
+    """Losing the write must not also blank the retained history the reader can see."""
+    cache = tmp_path / "claude-statusline-usage.json"
+    history = tmp_path / "quota-history.jsonl"
+    cache.write_text('{"five_hour":{"utilization":50,"resets_at":null}}')
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+    bucket = [{"name": "five_hour", "utilization": 10, "resets_at": None}]
+    write_jsonl(history, [{"observed_at": "2026-09-01T00:00:00Z", "buckets": bucket}])
+    real_open = Path.open
+
+    def refuse_append(self, *args, **kwargs):
+        # Fail only the append handle, so the file stays genuinely readable.
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if self == history and "a" in mode:
+            raise PermissionError(13, "simulated append refusal")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", refuse_append)
+
+    report = audit.quota_report(cache, history, now_epoch=observed.timestamp())
+
+    assert report["current"]["history_write"] == "failed"
+    assert report["current"]["snapshot_added"] is False
+    assert report["history"]["coverage"]["samples_in_period"] == 1
+    assert report["history"]["coverage"]["earliest_retained_at"] == "2026-09-01T00:00:00Z"
+    assert len(read_jsonl(history)) == 1
+
+
+def test_project_filter_never_reads_an_excluded_project_directory(tmp_path, monkeypatch):
+    """Excluding a project must skip its subtree, not read and then discard it."""
+    projects = tmp_path / "projects"
+    write_jsonl(projects / "keep-me" / "s.jsonl", [assistant_row(STAMP, uuid="k", output_tokens=5)])
+    write_jsonl(
+        projects / "skip-me" / "nested" / "s.jsonl",
+        [assistant_row(STAMP, uuid="s", output_tokens=99)],
+    )
+    write_jsonl(projects / "root.jsonl", [assistant_row(STAMP, uuid="r", output_tokens=1)])
+    excluded = str(projects / "skip-me")
+    scanned = []
+    real_scandir = os.scandir
+
+    def spy(path=".", *args, **kwargs):
+        scanned.append(os.path.normpath(os.fspath(path)))
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "scandir", spy)
+
+    filtered = audit.scan_transcript_model_usage(projects, project_filter="keep")
+
+    assert filtered["requests"] == 1
+    assert filtered["tokens"]["output_tokens"] == 5
+    assert [path for path in scanned if path.startswith(excluded)] == []
+
+    monkeypatch.undo()
+    unfiltered = audit.scan_transcript_model_usage(projects)
+    assert unfiltered["requests"] == 3
+    assert unfiltered["tokens"]["output_tokens"] == 105
+
+
+def test_a_project_filter_stays_fail_soft_on_an_unreadable_projects_root(tmp_path, monkeypatch):
+    """Selecting projects must fail soft exactly as the unfiltered glob always did."""
+    projects = tmp_path / "projects"
+    write_jsonl(projects / "keep-me" / "s.jsonl", [assistant_row(STAMP, uuid="k", output_tokens=5)])
+    root = os.path.normpath(str(projects))
+    real_scandir = os.scandir
+
+    def refuse_root(path=".", *args, **kwargs):
+        if os.path.normpath(os.fspath(path)) == root:
+            raise PermissionError(13, "simulated unreadable projects root")
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "scandir", refuse_root)
+
+    result = audit.scan_transcript_model_usage(projects, project_filter="keep")
+
+    assert result["requests"] == 0
+    assert result["coverage"]["earliest_in_period"] is None
+
+
+def test_coverage_endpoints_do_not_depend_on_the_order_rows_are_read(tmp_path):
+    """Only the extreme instants are reported, so aggregation needs no global sort."""
+    projects = tmp_path / "projects"
+    write_jsonl(
+        projects / "one" / "session.jsonl",
+        [
+            assistant_row("2026-09-06T12:00:00Z", uuid="late", output_tokens=1),
+            assistant_row("2026-09-06T08:00:00Z", uuid="early", output_tokens=1),
+            assistant_row("2026-09-06T10:00:00Z", uuid="middle", output_tokens=1),
+        ],
+    )
+    transcript = audit.scan_transcript_model_usage(projects)
+    assert transcript["coverage"]["earliest_in_period"] == "2026-09-06T08:00:00Z"
+    assert transcript["coverage"]["latest_in_period"] == "2026-09-06T12:00:00Z"
+
+    log = tmp_path / "approval.log"
+    log.write_text(
+        "2026-09-06T12:00:00Z USAGE: model=a input=1 output=1 cache_read=0 cache_create=0\n"
+        "2026-09-06T08:00:00Z USAGE: model=a input=1 output=1 cache_read=0 cache_create=0\n"
+        "2026-09-06T10:00:00Z USAGE: model=a input=1 output=1 cache_read=0 cache_create=0\n"
+    )
+    approval = audit.scan_approval_usage(log)
+    assert approval["coverage"]["earliest_retained_at"] == "2026-09-06T08:00:00Z"
+    assert approval["coverage"]["latest_retained_at"] == "2026-09-06T12:00:00Z"
+
+    history = tmp_path / "quota-history.jsonl"
+    bucket = [{"name": "five_hour", "utilization": 10, "resets_at": None}]
+    write_jsonl(
+        history,
+        [
+            {"observed_at": "2026-09-06T12:00:00Z", "buckets": bucket},
+            {"observed_at": "2026-09-06T08:00:00Z", "buckets": bucket},
+            {"observed_at": "2026-09-06T10:00:00Z", "buckets": bucket},
+        ],
+    )
+    quota = audit.quota_report(tmp_path / "absent-cache.json", history)["history"]
+    assert quota["coverage"]["earliest_retained_at"] == "2026-09-06T08:00:00Z"
+    assert quota["coverage"]["latest_retained_at"] == "2026-09-06T12:00:00Z"
+    assert [sample["observed_at"] for sample in quota["samples"]] == [
+        "2026-09-06T08:00:00Z",
+        "2026-09-06T10:00:00Z",
+        "2026-09-06T12:00:00Z",
+    ]
+
+
+def test_human_output_is_rendered_from_the_report_coverage_and_notes(tmp_path, capsys):
+    """Editing an explanation in the report data must change the printed report too."""
+    home = tmp_path / "home"
+    tmpdir = tmp_path / "tmp"
+    tmpdir.mkdir(parents=True)
+    home.mkdir(parents=True)
+
+    result = run_cli(home, tmpdir, "--model-usage", "--json")
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    sentinels = {key: f"sentinel-for-{key}" for key in data["coverage"]}
+    assert set(sentinels) == {
+        "native_auto_mode_classifier",
+        "approval_classifier",
+        "project_filter_scope",
+        "quota_history",
+        "non_persisted_calls",
+    }
+    data["coverage"] = sentinels
+    data["notes"] = ["sentinel-for-notes"]
+
+    audit.print_model_usage_report(
+        data, argparse.Namespace(json=False, days=0, project="fixture")
+    )
+
+    printed = capsys.readouterr().out
+    for sentinel in sentinels.values():
+        assert sentinel in printed
+    assert "sentinel-for-notes" in printed
+
+
+@pytest.mark.parametrize(
+    "value,accepted",
+    [
+        (0, True),
+        (5, True),
+        (12.5, True),
+        (-3, True),
+        (True, False),
+        (False, False),
+        ("5", False),
+        (None, False),
+        (float("inf"), False),
+        (float("nan"), False),
+        ([], False),
+        ({}, False),
+    ],
+)
+def test_plain_and_scoped_buckets_accept_the_same_utilization_values(value, accepted):
+    payload = {
+        "five_hour": {"utilization": value, "resets_at": "2026-09-07T12:00:00Z"},
+        "limits": [
+            {
+                "kind": "weekly_scoped",
+                "percent": value,
+                "resets_at": "2026-09-07T07:00:00-05:00",
+                "scope": {"model": {"display_name": "Fable"}},
+            }
+        ],
+    }
+
+    buckets = audit.quota_buckets(payload)
+
+    assert [bucket["name"] for bucket in buckets] == (
+        ["five_hour", "weekly_scoped:Fable"] if accepted else []
+    )
+    for bucket in buckets:
+        assert list(bucket) == ["name", "utilization", "resets_at"]
+        assert bucket["resets_at"] == "2026-09-07T12:00:00Z"
+
+
+def test_quota_bucket_builds_the_canonical_shape_or_rejects_the_value():
+    assert audit.quota_bucket("five_hour", 12.5, "2026-09-07T07:00:00-05:00") == {
+        "name": "five_hour",
+        "utilization": 12.5,
+        "resets_at": "2026-09-07T12:00:00Z",
+    }
+    assert audit.quota_bucket("five_hour", 0, "2026-09-07T12:00:00")["resets_at"] is None
+    assert audit.quota_bucket("five_hour", True, None) is None
+    assert audit.quota_bucket("five_hour", "50", None) is None
+    assert audit.quota_bucket("five_hour", float("nan"), None) is None

--- a/tests/test_claude_usage_audit.py
+++ b/tests/test_claude_usage_audit.py
@@ -1,0 +1,437 @@
+"""Model-usage reporting from existing Claude Code records.
+
+The audit must read persisted transcript and classifier usage, and may snapshot the
+existing quota cache only when the command runs. Fixtures contain no real transcript
+content, account identity, project path, or provider request.
+"""
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+AUDIT = Path(__file__).resolve().parent.parent / "custom_bins" / "claude-usage-audit"
+_loader = importlib.machinery.SourceFileLoader("claude_usage_audit", str(AUDIT))
+_spec = importlib.util.spec_from_loader(_loader.name, _loader)
+audit = importlib.util.module_from_spec(_spec)
+_loader.exec_module(audit)
+
+
+def iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def assistant_row(
+    timestamp: str,
+    *,
+    message_id: str | None = None,
+    request_id: str | None = None,
+    uuid: str | None = None,
+    model: str = "claude-test",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read: int = 0,
+    cache_create: int = 0,
+) -> dict:
+    row = {
+        "type": "assistant",
+        "timestamp": timestamp,
+        "message": {
+            "model": model,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_create,
+            },
+            "content": [{"type": "text", "text": "fixture text must never enter output"}],
+        },
+    }
+    if message_id is not None:
+        row["message"]["id"] = message_id
+    if request_id is not None:
+        row["requestId"] = request_id
+    if uuid is not None:
+        row["uuid"] = uuid
+    return row
+
+
+def write_jsonl(path: Path, rows: list[object], malformed: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+        if malformed is not None:
+            fh.write(malformed)
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    records = []
+    for line in path.read_text().splitlines():
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def run_cli(home: Path, tmpdir: Path, *args: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "TMPDIR": str(tmpdir)})
+    return subprocess.run(
+        [sys.executable, str(AUDIT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_transcript_usage_deduplicates_whole_snapshots_globally(tmp_path):
+    """A retry snapshot must replace a response whole, not max each token field."""
+    projects = tmp_path / "projects"
+    day = datetime(2026, 9, 6, 10, tzinfo=timezone.utc)
+    write_jsonl(
+        projects / "one" / "a.jsonl",
+        [
+            assistant_row(iso(day), message_id="m1", request_id="r1", input_tokens=999, output_tokens=9),
+            assistant_row(iso(day + timedelta(minutes=1)), message_id="m1", request_id="r1", input_tokens=5, output_tokens=10),
+            assistant_row(iso(day + timedelta(minutes=2)), uuid="u2", input_tokens=10, output_tokens=3, cache_read=90),
+        ],
+    )
+    write_jsonl(
+        projects / "two" / "b.jsonl",
+        [
+            assistant_row(iso(day + timedelta(minutes=3)), message_id="m1", request_id="r1", input_tokens=4, output_tokens=10),
+            assistant_row(iso(day + timedelta(minutes=4)), uuid="u2", input_tokens=20, output_tokens=3, cache_read=90),
+            {"type": "assistant", "timestamp": iso(day), "message": {"usage": "not-an-object"}},
+        ],
+        malformed='{"type":"assistant"',
+    )
+
+    result = audit.scan_transcript_model_usage(projects, cutoff_epoch=0)
+
+    assert result["requests"] == 2
+    assert result["tokens"] == {
+        "input_tokens": 25,
+        "output_tokens": 13,
+        "cache_read_input_tokens": 90,
+        "cache_creation_input_tokens": 0,
+        "total_tokens": 128,
+    }
+    assert result["cache_read_fraction"] == pytest.approx(90 / 115)
+    assert result["by_model"]["claude-test"]["requests"] == 2
+    assert result["by_day"]["2026-09-06"]["tokens"]["input_tokens"] == 25
+    assert result["coverage"]["malformed_rows"] == 1
+
+
+def test_transcript_usage_tolerates_bad_utf8(tmp_path):
+    projects = tmp_path / "projects"
+    path = projects / "one" / "session.jsonl"
+    path.parent.mkdir(parents=True)
+    valid = assistant_row("2026-09-06T00:00:00Z", uuid="valid", output_tokens=2)
+    unusable = assistant_row("2026-09-06T00:01:00Z", uuid="bad", output_tokens=2)
+    unusable["message"]["usage"]["input_tokens"] = -1
+    path.write_bytes(
+        json.dumps(valid).encode()
+        + b"\n"
+        + json.dumps(unusable).encode()
+        + b"\n\xff\n"
+    )
+
+    result = audit.scan_transcript_model_usage(projects)
+
+    assert result["requests"] == 1
+    assert result["coverage"]["malformed_rows"] == 1
+    assert result["coverage"]["unusable_usage_rows"] == 1
+
+
+def test_transcript_equal_rank_dedup_is_path_deterministic(tmp_path):
+    projects = tmp_path / "projects"
+    timestamp = "2026-09-06T00:00:00Z"
+    write_jsonl(
+        projects / "z-created-first" / "session.jsonl",
+        [assistant_row(timestamp, message_id="m", request_id="r", model="z-model", output_tokens=2)],
+    )
+    write_jsonl(
+        projects / "a-created-second" / "session.jsonl",
+        [assistant_row(timestamp, message_id="m", request_id="r", model="a-model", output_tokens=2)],
+    )
+
+    result = audit.scan_transcript_model_usage(projects)
+
+    assert list(result["by_model"]) == ["a-model"]
+
+
+@pytest.mark.parametrize("value", [-1, 1.5, float("inf"), float("nan")])
+def test_numeric_tokens_rejects_invalid_counts(value):
+    usage = {"input_tokens": value, "output_tokens": 1}
+
+    assert audit.numeric_tokens(usage) is None
+
+
+def test_transcript_usage_filters_each_top_level_timestamp_and_uses_uuid_fallback(tmp_path):
+    """A recent file must not pull an old response through a file-mtime shortcut."""
+    projects = tmp_path / "projects"
+    cutoff = datetime(2026, 9, 5, tzinfo=timezone.utc)
+    write_jsonl(
+        projects / "one" / "session.jsonl",
+        [
+            assistant_row("2026-09-04T23:59:59Z", uuid="old", output_tokens=100),
+            assistant_row("2026-09-05T00:00:01Z", uuid="new", output_tokens=7),
+            assistant_row("not-a-date", uuid="bad-date", output_tokens=50),
+            assistant_row("2026-09-06T00:00:00Z", output_tokens=60),
+            ["arbitrary", "json"],
+        ],
+    )
+
+    result = audit.scan_transcript_model_usage(projects, cutoff_epoch=cutoff.timestamp())
+
+    assert result["requests"] == 1
+    assert result["tokens"]["output_tokens"] == 7
+    assert result["coverage"]["invalid_timestamp_rows"] == 1
+    assert result["coverage"]["unkeyed_rows"] == 1
+
+
+def test_approval_usage_is_separate_and_reports_retained_coverage(tmp_path):
+    """The rotating approval log must expose its retained boundary, not claim all time."""
+    log = tmp_path / "approval-classifier.log"
+    log.write_text(
+        "2026-09-04T10:00:00Z USAGE: model=claude-a input=10 output=2 cache_read=90 cache_create=0\n"
+        "2026-09-05T10:00:00Z unrelated diagnostic text\n"
+        "2026-09-06T10:00:00Z USAGE: model=claude-a input=20 output=3 cache_read=80 cache_create=5\n"
+        "2026-09-06T11:00:00Z USAGE: model=claude-b input=x output=3 cache_read=0 cache_create=0\n"
+    )
+
+    result = audit.scan_approval_usage(
+        log,
+        cutoff_epoch=datetime(2026, 9, 5, tzinfo=timezone.utc).timestamp(),
+    )
+
+    assert result["requests"] == 1
+    assert result["tokens"]["total_tokens"] == 108
+    assert result["by_model"]["claude-a"]["tokens"]["cache_creation_input_tokens"] == 5
+    assert result["coverage"] == {
+        "available": True,
+        "earliest_retained_at": "2026-09-04T10:00:00Z",
+        "latest_retained_at": "2026-09-06T10:00:00Z",
+        "malformed_usage_lines": 1,
+        "retention": "rotating_1mb_log",
+    }
+
+
+def test_quota_snapshot_uses_cache_mtime_allowlist_and_deduplicates(tmp_path):
+    """A command rerun must not duplicate one cache observation or leak cache metadata."""
+    cache = tmp_path / "tmp" / "claude-statusline-usage.json"
+    history = tmp_path / "home" / ".claude" / "usage-data" / "quota-history.jsonl"
+    cache.parent.mkdir()
+    cache.write_text(json.dumps({
+        "five_hour": {"utilization": 12.5, "resets_at": "2026-09-07T12:00:00+00:00", "secret": "drop-me"},
+        "seven_day": {"utilization": 44, "resets_at": "private reset text"},
+        "limits": [
+            {"kind": "weekly_scoped", "percent": 33, "resets_at": "2026-09-13T12:00:00Z", "scope": {"model": {"display_name": "Fable"}}},
+            {"kind": "unknown", "percent": 99, "scope": {"email": "private@example.test"}},
+        ],
+        "email": "private@example.test",
+        "token": "not-a-real-token",
+    }))
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+    now = observed + timedelta(seconds=120)
+
+    first = audit.snapshot_quota_cache(cache, history, now_epoch=now.timestamp())
+    second = audit.snapshot_quota_cache(cache, history, now_epoch=now.timestamp())
+
+    expected_buckets = [
+        {"name": "five_hour", "utilization": 12.5, "resets_at": "2026-09-07T12:00:00Z"},
+        {"name": "seven_day", "utilization": 44, "resets_at": None},
+        {"name": "weekly_scoped:Fable", "utilization": 33, "resets_at": "2026-09-13T12:00:00Z"},
+    ]
+    assert first == {
+        "available": True,
+        "observed_at": "2026-09-07T10:00:00Z",
+        "age_seconds": 120,
+        "stale": False,
+        "snapshot_added": True,
+        "buckets": expected_buckets,
+    }
+    assert second["snapshot_added"] is False
+    rows = read_jsonl(history)
+    assert rows == [{
+        "observed_at": "2026-09-07T10:00:00Z",
+        "buckets": expected_buckets,
+    }]
+    stored = history.read_text()
+    assert "private@example.test" not in stored
+    assert "not-a-real-token" not in stored
+    assert "drop-me" not in stored
+    assert "private reset text" not in stored
+    assert str(cache) not in stored
+
+
+def test_quota_snapshot_keeps_current_buckets_when_history_write_fails(tmp_path):
+    cache = tmp_path / "claude-statusline-usage.json"
+    blocked_parent = tmp_path / "not-a-directory"
+    blocked_parent.write_text("block history directory creation")
+    cache.write_text('{"five_hour":{"utilization":50,"resets_at":null}}')
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+
+    status = audit.snapshot_quota_cache(
+        cache,
+        blocked_parent / "quota-history.jsonl",
+        now_epoch=observed.timestamp(),
+    )
+
+    assert status["history_write"] == "failed"
+    assert status["buckets"] == [
+        {"name": "five_hour", "utilization": 50, "resets_at": None}
+    ]
+
+
+def test_quota_append_separates_a_truncated_tail_and_missing_cache_is_explicit(tmp_path):
+    """A broken final row must stay broken rather than consume the next valid snapshot."""
+    cache = tmp_path / "tmp" / "claude-statusline-usage.json"
+    history = tmp_path / "quota-history.jsonl"
+    history.write_text('{"observed_at":"truncated"')
+    cache.parent.mkdir()
+    cache.write_text('{"five_hour":{"utilization":50,"resets_at":null}}')
+    observed = datetime(2026, 9, 7, 10, tzinfo=timezone.utc)
+    os.utime(cache, (observed.timestamp(), observed.timestamp()))
+
+    status = audit.snapshot_quota_cache(cache, history, now_epoch=observed.timestamp() + 300)
+
+    assert status["stale"] is True
+    assert len(read_jsonl(history)) == 1
+    assert "\n{" in history.read_text()
+    missing = audit.snapshot_quota_cache(tmp_path / "absent.json", history, now_epoch=observed.timestamp())
+    assert missing == {"available": False, "reason": "cache_missing"}
+    invalid = tmp_path / "invalid-cache.json"
+    invalid.write_bytes(b"\xff")
+    assert audit.snapshot_quota_cache(invalid, history) == {
+        "available": False,
+        "reason": "cache_invalid",
+    }
+
+
+def test_quota_history_days_filter_keeps_all_time_coverage(tmp_path):
+    """Period filtering must not erase the history's actual retained boundary."""
+    history = tmp_path / "quota-history.jsonl"
+    rows = [
+        {"observed_at": "2026-09-01T00:00:00Z", "buckets": [{"name": "five_hour", "utilization": 10, "resets_at": None}]},
+        {"observed_at": "2026-09-06T00:00:00Z", "buckets": [{"name": "five_hour", "utilization": 20, "resets_at": None}]},
+    ]
+    write_jsonl(history, rows, malformed="not-json")
+
+    result = audit.read_quota_history(
+        history,
+        cutoff_epoch=datetime(2026, 9, 5, tzinfo=timezone.utc).timestamp(),
+    )
+
+    assert result["samples"] == [rows[1]]
+    assert result["coverage"] == {
+        "available": True,
+        "earliest_retained_at": "2026-09-01T00:00:00Z",
+        "latest_retained_at": "2026-09-06T00:00:00Z",
+        "samples_in_period": 1,
+        "malformed_rows": 1,
+    }
+
+
+def test_model_usage_cli_is_metadata_only_and_legacy_json_mode_survives(tmp_path):
+    """The new mode must be explicit; the old component report stays the default."""
+    home = tmp_path / "home"
+    tmpdir = tmp_path / "tmp"
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    quota_cache = tmpdir / "claude-statusline-usage.json"
+    quota_cache.parent.mkdir(parents=True)
+    quota_cache.write_text(json.dumps({
+        "five_hour": {
+            "utilization": 25,
+            "resets_at": iso(now + timedelta(hours=2)),
+        }
+    }))
+    os.utime(quota_cache, (now.timestamp(), now.timestamp()))
+    transcript = home / ".claude" / "projects" / "fixture" / "session.jsonl"
+    write_jsonl(transcript, [
+        assistant_row(iso(now), message_id="m", request_id="r", input_tokens=4, output_tokens=2),
+        {
+            "type": "assistant",
+            "timestamp": iso(now),
+            "message": {"content": [{"type": "tool_use", "name": "Skill", "input": {"skill": "fixture-skill"}}]},
+        },
+    ])
+    approval = home / ".cache" / "claude" / "approval-classifier.log"
+    approval.parent.mkdir(parents=True)
+    approval.write_text(f"{iso(now)} USAGE: model=claude-approval input=1 output=1 cache_read=0 cache_create=0\n")
+
+    model_result = run_cli(home, tmpdir, "--model-usage", "--days", "1", "--json")
+    text_result = run_cli(
+        home,
+        tmpdir,
+        "--model-usage",
+        "--days",
+        "1",
+        "--project",
+        "fixture",
+    )
+    legacy_result = run_cli(home, tmpdir, "--json")
+
+    assert model_result.returncode == 0, model_result.stderr
+    model_report = json.loads(model_result.stdout)
+    assert model_report["transcript_usage"]["requests"] == 1
+    assert model_report["approval_classifier_usage"]["requests"] == 1
+    assert model_report["quota"]["current"]["buckets"] == [
+        {
+            "name": "five_hour",
+            "utilization": 25,
+            "resets_at": iso(now + timedelta(hours=2)),
+        }
+    ]
+    assert model_report["coverage"]["native_auto_mode_classifier"] == "successful calls unobserved"
+    assert model_report["coverage"]["approval_classifier"] == (
+        "direct API USAGE log only; CLI subscription fallback unobserved"
+    )
+    assert model_report["coverage"]["project_filter_scope"] == (
+        "transcript only; approval and quota host-wide"
+    )
+    assert model_report["coverage"]["quota_history"] == (
+        "unattributed; samples may interleave accounts; no identity recorded"
+    )
+    assert model_report["coverage"]["non_persisted_calls"] == "absent"
+    assert "tokens are not subscription quota" in model_report["notes"]
+    serialized = json.dumps(model_report)
+    assert "fixture text" not in serialized
+    assert str(home) not in serialized
+    assert "session.jsonl" not in serialized
+
+    assert text_result.returncode == 0, text_result.stderr
+    assert now.date().isoformat() in text_result.stdout
+    assert "Transcript by day" in text_result.stdout
+    assert "Approval classifier by day" in text_result.stdout
+    assert "persisted responses" in text_result.stdout
+    assert " requests" not in text_result.stdout
+    assert f"Approval log retained since {iso(now)}" in text_result.stdout
+    assert "rotating 1 MB log" in text_result.stdout
+    assert "direct API USAGE log only" in text_result.stdout
+    assert "CLI subscription fallback is unobserved" in text_result.stdout
+    assert "five_hour: 25% utilized" in text_result.stdout
+    assert f"resets {iso(now + timedelta(hours=2))}" in text_result.stdout
+    assert "sampled only when --model-usage runs" in text_result.stdout
+    assert "without account attribution" in text_result.stdout
+    assert "may interleave accounts" in text_result.stdout
+    assert "no identity is recorded" in text_result.stdout
+    assert "--project filters transcript usage only" in text_result.stdout
+
+    assert legacy_result.returncode == 0, legacy_result.stderr
+    legacy_report = json.loads(legacy_result.stdout)
+    assert legacy_report["skills"] == {"fixture-skill": 1}
+    assert "transcript_usage" not in legacy_report

--- a/tests/test_watchdog.sh
+++ b/tests/test_watchdog.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Regression tests for deterministic watchdog warnings.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WATCHDOG="$ROOT/claude/hooks/watchdog.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/watchdog-test.XXXXXX")" || exit 1
+trap 'rm -r "$TMP"' EXIT
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+
+cat > "$BIN/date" <<'STUB'
+#!/usr/bin/env bash
+count=$(cat "$FAKE_DATE_CALLS" 2>/dev/null || echo 0)
+count=$((count + 1))
+printf '%s\n' "$count" > "$FAKE_DATE_CALLS"
+value=$(sed -n "${count}p" "$FAKE_DATES")
+if [[ -z "$value" ]]; then
+  value=$(tail -n 1 "$FAKE_DATES")
+fi
+printf '%s\n' "$value"
+STUB
+
+cat > "$BIN/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+cat > "$BIN/stat" <<'STUB'
+#!/usr/bin/env bash
+count=$(cat "$FAKE_STAT_CALLS" 2>/dev/null || echo 0)
+count=$((count + 1))
+printf '%s\n' "$count" > "$FAKE_STAT_CALLS"
+value=$(sed -n "${count}p" "$FAKE_MTIMES")
+if [[ -z "$value" ]]; then
+  value=$(tail -n 1 "$FAKE_MTIMES")
+fi
+printf '%s\n' "$value"
+STUB
+
+cat > "$BIN/ps" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_RSS_KB:-0}"
+STUB
+
+cat > "$BIN/terminal-notifier" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$NOTIFY_LOG"
+STUB
+
+cat > "$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+printf 'claude %s\n' "$*" >> "$EFFECT_LOG"
+cat >/dev/null
+printf '%s\n' 'STUCK model verdict'
+STUB
+
+cat > "$BIN/timeout" <<'STUB'
+#!/usr/bin/env bash
+printf 'timeout %s\n' "$*" >> "$EFFECT_LOG"
+shift
+exec "$@"
+STUB
+
+cat > "$BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >> "$EFFECT_LOG"
+exit 1
+STUB
+
+chmod +x "$BIN"/*
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf 'FAIL - %s\n' "$1"; }
+
+assert_empty() {
+  local desc=$1 file=$2
+  if [[ ! -s "$file" ]]; then ok "$desc"; else fail "$desc"; fi
+}
+
+assert_count() {
+  local desc=$1 expected=$2 file=$3
+  local actual=0
+  if [[ -f "$file" ]]; then actual=$(wc -l < "$file" | tr -d ' '); fi
+  if [[ "$actual" == "$expected" ]]; then ok "$desc"; else fail "$desc (expected $expected, got $actual)"; fi
+}
+
+assert_contains() {
+  local desc=$1 needle=$2 file=$3
+  if grep -qF -- "$needle" "$file" 2>/dev/null; then ok "$desc"; else fail "$desc"; fi
+}
+
+run_case() {
+  local name=$1 marker=$2 mtime=$3 rss=$4 pid=$5
+  shift 5
+  local dir="$TMP/$name"
+  mkdir -p "$dir"
+  printf '%s\n' '{"type":"assistant","message":"still working"}' > "$dir/transcript.jsonl"
+  : > "$dir/notifications"
+  : > "$dir/effects"
+  printf '%s\n' "$mtime" | tr ',' '\n' > "$dir/mtimes"
+  printf '%s\n' "$@" > "$dir/dates"
+  if [[ "$marker" == working ]]; then
+    : > "$dir/claude-watchdog-${name}.working"
+  fi
+
+  PATH="$BIN:/usr/bin:/bin" \
+    TMPDIR="$dir" \
+    FAKE_DATES="$dir/dates" \
+    FAKE_DATE_CALLS="$dir/date-calls" \
+    FAKE_MTIMES="$dir/mtimes" \
+    FAKE_STAT_CALLS="$dir/stat-calls" \
+    FAKE_RSS_KB="$rss" \
+    NOTIFY_LOG="$dir/notifications" \
+    EFFECT_LOG="$dir/effects" \
+    CLAUDE_WATCHDOG_TIMEOUT=100 \
+    CLAUDE_WATCHDOG_INTERVAL=1 \
+    CLAUDE_WATCHDOG_MAX_LIFE=500 \
+    CLAUDE_WATCHDOG_MEM_LIMIT_MB=100 \
+    bash "$WATCHDOG" "$name" "$dir/transcript.jsonl" "/projects/example" "$pid"
+}
+
+echo '=== stale working session ==='
+run_case stale working 900 0 '' 1000 1100 1150 2000
+assert_empty "does not invoke claude, timeout, or curl" "$TMP/stale/effects"
+assert_count "warns once during the inactivity cooldown" 1 "$TMP/stale/notifications"
+assert_contains "warning describes uncertainty" \
+  "No recent output for 3m — session may still be running or waiting" \
+  "$TMP/stale/notifications"
+
+run_case repeated working 900 0 '' 1000 1100 1150 1200 2000
+assert_count "warns again when the inactivity cooldown expires" 2 "$TMP/repeated/notifications"
+assert_empty "does not invoke external triage for repeated warnings" "$TMP/repeated/effects"
+
+run_case recovered working 900,1240 0 '' 1000 1100 1250 2000
+assert_count "does not warn again after transcript output resumes" 1 "$TMP/recovered/notifications"
+assert_contains "checks transcript mtime again after the first warning" "2" "$TMP/recovered/stat-calls"
+assert_empty "does not invoke external triage after output resumes" "$TMP/recovered/effects"
+
+echo '=== active and idle states ==='
+run_case active working 1099 0 '' 1000 1100 2000
+assert_empty "does not warn when working transcript has new output" "$TMP/active/notifications"
+assert_empty "does not run external triage for new output" "$TMP/active/effects"
+run_case idle idle 900 0 '' 1000 1100 2000
+assert_empty "does not warn while session is idle" "$TMP/idle/notifications"
+assert_empty "does not run external triage while idle" "$TMP/idle/effects"
+
+echo '=== process health ==='
+run_case memory idle 1099 204800 "$$" 1000 1100 1150 2000
+assert_count "retains one memory warning per threshold crossing" 1 "$TMP/memory/notifications"
+assert_contains "memory warning reports measured RSS" "Memory: 200MB (limit: 100MB)" "$TMP/memory/notifications"
+run_case dead idle 1099 0 99999999 1000 1100
+assert_count "retains process-death warning" 1 "$TMP/dead/notifications"
+assert_contains "process-death warning names the PID" "Claude process (PID 99999999) died" "$TMP/dead/notifications"
+
+echo
+printf 'passed: %s  failed: %s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Remove model-based watchdog triage. Stale working sessions get deterministic, rate-limited inactivity warnings; existing memory and process-death checks remain.
- Extend the existing `claude-usage-audit --model-usage` command to report deduplicated recorded response tokens by model and day, separately from approval-hook API usage.
- Sample the existing quota cache when the command runs. Store only quota metadata locally; add no provider requests, daemon, statusline work, or duplicate response ledger.

## Accounting boundaries
- Token totals are not subscription quota. Successful native safety-classifier calls and the approval hook subscription fallback are unobserved.
- Approval usage comes from a rotating API log. Project filters affect transcripts only; approval and quota data are host-wide.
- Quota history is sampled on demand, unattributed, and can interleave accounts. Cache age and missing data are explicit.

## Verification
- 48 synthetic usage tests passed, including CLI compatibility, whole-snapshot deduplication, invalid token counts, malformed UTF-8, quota history, timestamp equivalence and chronology, and output coverage.
- 16 watchdog checks passed, including no model/API invocation, cooldown expiry, resumed output, memory, and process death.
- Ruff, ShellCheck, and whitespace checks passed.
- High-effort re-review closed all seven original findings. Independent quota write-safety review identified two further timestamp bugs; regression tests and a final focused recheck closed both, with no introduced blocker found.
- The planned four-transcript real-data smoke test was blocked by the permission classifier before execution. It was not bypassed; no full real-data smoke result is claimed.
- Final reviewed commit: ed43991ed48f48c00bb2c9c1966f762dc40bf1f6.

## Deployment and review notes
- No live settings or services changed; no Rust source or platform assets changed.
- The Linux watchdog notification fallback can remain invisible because the existing launcher discards its terminal bell. This pre-existing delivery limitation is unchanged, not claimed fixed.
- This draft is not merged. Existing watchdog processes do not adopt new code until restarted by the session-start flow.
- No private transcripts, investigation reports, or personal usage data are included.

## Residual fixes
- Count every present-but-unusable usage value, including null and non-object values; distinguish a genuinely absent field.
- Reject timestamps without an explicit timezone across transcript, approval-log, quota-history, and quota-reset parsing instead of inferring local time.
- Preserve valid Z and numeric-offset timestamps. Synthetic CLI tests verify byte-identical output under UTC and US Eastern time.
- These initial residual fixes were committed in 253bedd.

## High-effort review fixes
- Prefer message ID, then request ID, then row UUID for response identity; missing request IDs no longer inflate streamed-response totals. Keep whole-snapshot usage selection.
- Read quota history once under the append lock, tolerate corrupt UTF-8 without rewriting damaged bytes, and let only usable rows suppress new observations.
- Deduplicate quota observations by parsed instant and sort samples chronologically across timestamp precisions and offsets. Preserve all-retained coverage boundaries.
- Filter project directories before recursion, retain soft failure for unreadable roots, compute coverage endpoints without sorting responses, and share coverage text and bucket normalization.
