### PR TITLE
docs: design a snapshot-before-refuse net for the destructive-git hook

### DIFF
--- a/docs/design-snapshot-before-refuse.md
+++ b/docs/design-snapshot-before-refuse.md
@@ -1,0 +1,47 @@
+# Snapshot before refusing a destructive git command
+
+Status: design for review, 2026-09-11. Not implemented.
+
+## What exists today
+
+`claude/hooks/block_destructive_git.sh` (153 lines) is a PreToolUse Bash hook. It splits compound commands into segments, and `deny()` exits 2 with a reason and a suggested alternative. It refuses `git reset --hard`, `git checkout -- <path>`, `git checkout .`, `git clean -f`, bare `git stash` and `git stash pop`.
+
+## Why add a snapshot
+
+The refusal protects work by preventing the command, which is the right default and should stay. But it protects nothing once the command is reworded into a form the matcher does not catch — `git restore --worktree <path>`, `git checkout HEAD -- <path>` and `git reset --keep` all discard uncommitted work and none are blocked today. A snapshot turns the caught cases into recoverable ones, and costs nothing when it is never needed.
+
+## The mechanism: a snapshot that never touches the shared stash stack
+
+`git stash create [<message>]` builds a stash commit object and prints its SHA **without** storing a ref, touching the working tree, or pushing onto the stack. `git stash store` can file it later. That matters here because this repo's rules already name the hazard: the stash stack is shared across every worktree, so an auto-`git stash push` could be popped by another session.
+
+So, before `deny()` returns:
+
+1. `sha=$(git stash create "blocked: <segment>")` — empty output means a clean tree, so skip.
+2. `git update-ref refs/snapshots/<utc-timestamp>-<reason-slug> "$sha"` — files it where nothing else looks, invisible to `git stash list`.
+3. The refusal message names the recovery: `git stash apply <sha>`.
+
+## The untracked-file gap needs a decision
+
+`stash create` captures tracked modifications only. `git clean -f` destroys **untracked** files exclusively — so for the one command where recovery matters most, the snapshot would capture nothing. Three options:
+
+- **(a) Accept the gap** and say so plainly in the `clean -f` refusal. Cheapest, honest, leaves the worst case uncovered.
+- **(b) Temp-index snapshot.** Point `GIT_INDEX_FILE` at a throwaway index, stage the untracked files, `write-tree`, then `commit-tree`. Covers untracked files without touching the real index or the stash stack. Stage them from an explicit list — `git ls-files --others --exclude-standard` — and never `git add -A`, which under the sandbox stages denied paths as phantom character devices (already a documented rule in `claude/rules/safety.md`).
+- **(c) Copy untracked files** to `~/.cache/claude/git-snapshots/`. Simple, but puts repo content outside the repo and needs its own cleanup.
+
+Lean: **(b) with the explicit pathspec**, falling back to (a) when the file list is empty.
+
+## Failure modes the implementation must honour
+
+- A snapshot failure must **never** turn a refusal into an allow. Refuse first, snapshot best-effort.
+- Not a git repository, or a clean tree: skip silently, still refuse.
+- Hook latency is bounded by the PreToolUse timeout. Snapshot cost scales with the diff, so give it a time budget and skip with a note in the refusal rather than blowing the timeout on a huge tree.
+- `refs/snapshots/` accumulates. Prune with the existing weekly `dotfiles-prune` job: drop refs older than 90 days, keep at most 100.
+
+## Test plan
+
+There is no test for this hook today, which is its own gap. `tests/test_block_destructive_git.sh` should feed the hook its JSON input in a scratch repo and assert: each blocked form still exits 2; a ref appears under `refs/snapshots/`; the snapshot actually restores the discarded modification; a clean tree creates no ref; a non-repo working directory still refuses; and a forced snapshot failure still refuses.
+
+## Explicitly not proposed
+
+- **Auto-stash and allow.** That changes policy from "refuse" to "permit with a net", and re-introduces the shared-stack hazard.
+- **Snapshotting on every Bash call.** The cost is real and the benefit is confined to the handful of destructive forms.

--- a/docs/design-snapshot-before-refuse.md
+++ b/docs/design-snapshot-before-refuse.md
@@ -1,47 +1,91 @@
 # Snapshot before refusing a destructive git command
 
-Status: design for review, 2026-09-11. Not implemented.
+Status: design for review, 2026-09-11. **Not implemented.** Nothing in `claude/hooks/block_destructive_git.sh` takes a snapshot today.
+
+## Design doc beats rule or skill
+
+A reviewer asked whether this belongs in `claude/rules/` or `claude/skills/` instead. It belongs in neither, because nothing here is a procedure Claude follows. The hook runs the snapshot in its own process before `deny()` returns; the agent never chooses to take one, never needs to remember the commands, and cannot skip it.
+
+A rule is always-loaded context that costs budget every session. `claude/rules/safety.md` already carries the only sentence a session needs — that `block_destructive_git.sh` refuses these forms — and the recovery instruction reaches the agent through the hook's own refusal text at the exact moment it is refused, at zero always-on cost. A skill is activity-scoped procedure, and there is no activity: "recover from a snapshot I did not know existed" is not something a session goes looking for.
+
+So the durable prose after implementation is one added clause in `claude/rules/safety.md` and the refusal string inside the hook. This file is the design, and it stays a design until the hook carries the mechanism.
 
 ## What exists today
 
-`claude/hooks/block_destructive_git.sh` (153 lines) is a PreToolUse Bash hook. It splits compound commands into segments, and `deny()` exits 2 with a reason and a suggested alternative. It refuses `git reset --hard`, `git checkout -- <path>`, `git checkout .`, `git clean -f`, bare `git stash` and `git stash pop`.
+`claude/hooks/block_destructive_git.sh` (153 lines) is a PreToolUse Bash hook. It splits compound commands on unquoted separators, and `deny()` exits 2 with a reason and a suggested alternative. It refuses `git reset --hard`, `git checkout -- <path>`, `git checkout .`, `git clean -f[d]`, bare `git stash` and `git stash pop`.
 
-## Why add a snapshot
+## A snapshot makes caught refusals recoverable
 
 The refusal protects work by preventing the command, which is the right default and should stay. But it protects nothing once the command is reworded into a form the matcher does not catch — `git restore --worktree <path>`, `git checkout HEAD -- <path>` and `git reset --keep` all discard uncommitted work and none are blocked today. A snapshot turns the caught cases into recoverable ones, and costs nothing when it is never needed.
 
-## The mechanism: a snapshot that never touches the shared stash stack
+## The snapshot never touches the stash stack
 
-`git stash create [<message>]` builds a stash commit object and prints its SHA **without** storing a ref, touching the working tree, or pushing onto the stack. `git stash store` can file it later. That matters here because this repo's rules already name the hazard: the stash stack is shared across every worktree, so an auto-`git stash push` could be popped by another session.
+This repo's rules already name the hazard: the stash stack is shared across every worktree, so an auto-`git stash push` could be popped by another session. Every mechanism below writes objects and one ref and nothing else — verified with `git stash list`, which stayed empty through the whole experiment, and `git status --porcelain`, which was byte-identical before and after a snapshot.
 
-So, before `deny()` returns:
+## Only a temp index captures untracked files
 
-1. `sha=$(git stash create "blocked: <segment>")` — empty output means a clean tree, so skip.
-2. `git update-ref refs/snapshots/<utc-timestamp>-<reason-slug> "$sha"` — files it where nothing else looks, invisible to `git stash list`.
-3. The refusal message names the recovery: `git stash apply <sha>`.
+The open question was whether `git stash create` covers `git clean -f`, the one refusal where recovery matters most. It does not, and the obvious fix does not either. Measured on git 2.43.0 in a scratch repo with one modified tracked file (`tracked.txt`), two untracked files (`untracked.txt`, `sub/nested.txt`) and one gitignored file (`ignored.log`).
 
-## The untracked-file gap needs a decision
+`git stash create "blocked: git clean -f"` printed `ffe0eff97f4f…`, and `git ls-tree -r --name-only ffe0eff` printed exactly `.gitignore` and `tracked.txt`. Both untracked files were absent. `git show --stat` confirmed a one-file change.
 
-`stash create` captures tracked modifications only. `git clean -f` destroys **untracked** files exclusively — so for the one command where recovery matters most, the snapshot would capture nothing. Three options:
+`git stash create -u "msg-u"` looks like the fix and is not. It exits 0 and prints a SHA, so a hook that trusted the exit code would silently ship nothing: `git log -1 --format=%s` on the result printed `On main: -u msg-u`, and `git rev-list --parents -n1` returned two parents rather than the three a `-u` stash carries. The `-u` was swallowed as message text. The synopsis in `git stash --help` is `git stash create [<message>]` — the subcommand takes no options at all.
 
-- **(a) Accept the gap** and say so plainly in the `clean -f` refusal. Cheapest, honest, leaves the worst case uncovered.
-- **(b) Temp-index snapshot.** Point `GIT_INDEX_FILE` at a throwaway index, stage the untracked files, `write-tree`, then `commit-tree`. Covers untracked files without touching the real index or the stash stack. Stage them from an explicit list — `git ls-files --others --exclude-standard` — and never `git add -A`, which under the sandbox stages denied paths as phantom character devices (already a documented rule in `claude/rules/safety.md`).
-- **(c) Copy untracked files** to `~/.cache/claude/git-snapshots/`. Simple, but puts repo content outside the repo and needs its own cleanup.
+What works is a throwaway index, which never touches the real one:
 
-Lean: **(b) with the explicit pathspec**, falling back to (a) when the file list is empty.
+```sh
+idx=$(mktemp -u); export GIT_INDEX_FILE="$idx"
+git read-tree HEAD
+git ls-files --others --exclude-standard -z | git update-index --add -z --stdin
+git ls-files --modified --exclude-standard -z | git update-index --add -z --stdin
+tree=$(git write-tree)
+commit=$(git commit-tree "$tree" -p HEAD -m "blocked: <segment>")
+rm -f "$idx"
+git update-ref "refs/snapshots/<utc-timestamp>-<reason-slug>" "$commit"
+```
+
+`git ls-tree -r --name-only` on the result printed `.gitignore`, `sub/nested.txt`, `tracked.txt` and `untracked.txt`, and `git diff --stat HEAD <commit>` printed `3 files changed, 3 insertions(+), 1 deletion(-)`. Untracked and modified in one commit, no `git add -A`, explicit pathspecs only.
+
+The gitignored `ignored.log` was absent, and that is the right coverage rather than a gap: `git clean -f` honours the standard ignore rules, so the snapshot covers exactly what the refused command would have deleted. `git clean -fx` reaches further — per `git-clean(1)`, `-x` means "don't use the standard ignore rules" — so that one form is snapshotted incompletely and its refusal text must say so.
+
+## Recovery is git restore, not git stash apply
+
+The earlier draft named `git stash apply <sha>` as the recovery. That is wrong for a temp-index commit: `git stash apply refs/snapshots/<ref>` printed `fatal: 'refs/snapshots/…' is not a stash-like commit`, because the commit has one parent, not the two or three `apply` expects.
+
+The verified recovery is `git restore --source=<ref> --worktree -- .`. Round trip: deleting `untracked.txt` and `sub/`, and reverting `tracked.txt`, left `find` reporting only `.gitignore`, `ignored.log` and `tracked.txt`; after the restore, `git status --short` printed ` M tracked.txt`, `?? sub/` and `?? untracked.txt`, and the three files held `tracked-v2`, `nested` and `untracked-content` again.
+
+## The hook blocks its own recovery command
+
+`git checkout <ref> -- .` is the reflexive way to restore from a ref, and this hook refuses it. Running it against the snapshot ref produced `BLOCKED — destructive git command … git checkout -- <path> overwrites the working-tree copy with HEAD` — the `checkout` matcher fires on the bare `--` without checking whether a source ref precedes it, so a read-only restore reads as a discard.
+
+Two things follow. The refusal text must offer the `git restore --source=` form, which the hook does not match and which was verified to work. Separately, the `checkout` matcher should learn to allow a `<tree-ish> --` form; that is a fix to the existing hook and is out of scope for this design.
+
+## What the snapshot costs
+
+Measured with `/usr/bin/time` on scratch repos, cold meaning the objects were not yet in the store.
+
+| Working tree | Cold | Warm | Peak RSS |
+|---|---|---|---|
+| Clean (nothing to capture) | 0.01 s | — | — |
+| 2000 untracked files, 24 MB | 0.66 s | 0.11 s | 5.2 MB |
+| 10 untracked files, 250 MB | 6.64 s | — | 30 MB |
+
+Throughput is roughly 38 MB/s, and the warm case is near-free because identical content hashes to the same SHA — the second run of the 2000-file snapshot returned the same commit id, `18cf0646…`, and the object store did not grow. Gitignored paths are excluded, so the usual blowup cases (`node_modules`, `out/`, `.venv`) never enter the count.
+
+A clean tree needs an explicit check rather than an empty-output test. `git stash create` prints nothing on a clean tree, but the temp-index path still produces a commit whose tree equals `HEAD^{tree}` — verified equal on a clean repo. So the skip condition is comparing `git write-tree` against `git rev-parse HEAD^{tree}`, before `commit-tree`.
 
 ## Failure modes the implementation must honour
 
-- A snapshot failure must **never** turn a refusal into an allow. Refuse first, snapshot best-effort.
-- Not a git repository, or a clean tree: skip silently, still refuse.
-- Hook latency is bounded by the PreToolUse timeout. Snapshot cost scales with the diff, so give it a time budget and skip with a note in the refusal rather than blowing the timeout on a huge tree.
-- `refs/snapshots/` accumulates. Prune with the existing weekly `dotfiles-prune` job: drop refs older than 90 days, keep at most 100.
+- A snapshot failure must never turn a refusal into an allow. Refuse first, snapshot best-effort, and check the tree rather than the exit code, since `stash create -u` proved an exit code can be 0 for a snapshot that captured nothing.
+- Not a git repository, or a tree whose snapshot equals `HEAD^{tree}`: skip silently, still refuse.
+- Give the snapshot a time budget and skip with a note in the refusal rather than blowing the PreToolUse timeout. At 38 MB/s the budget is the thing that matters for a large untracked tree.
+- `refs/snapshots/` accumulates, and so do its objects — the 24 MB tree left a 17 MB `.git`. Prune with the existing weekly `dotfiles-prune` job: drop refs older than 90 days, keep at most 100, then let `git gc` reclaim the objects.
 
 ## Test plan
 
-There is no test for this hook today, which is its own gap. `tests/test_block_destructive_git.sh` should feed the hook its JSON input in a scratch repo and assert: each blocked form still exits 2; a ref appears under `refs/snapshots/`; the snapshot actually restores the discarded modification; a clean tree creates no ref; a non-repo working directory still refuses; and a forced snapshot failure still refuses.
+There is no test for this hook today, which is its own gap. `tests/test_block_destructive_git.sh` should feed the hook its JSON input in a scratch repo and assert: each blocked form still exits 2; a ref appears under `refs/snapshots/` and nothing appears in `git stash list`; the snapshot restores a deleted untracked file through `git restore --source=`; a gitignored file is absent from the snapshot tree; a clean tree creates no ref; a non-repo working directory still refuses; and a forced snapshot failure still refuses.
 
 ## Explicitly not proposed
 
 - **Auto-stash and allow.** That changes policy from "refuse" to "permit with a net", and re-introduces the shared-stack hazard.
 - **Snapshotting on every Bash call.** The cost is real and the benefit is confined to the handful of destructive forms.
+- **Copying untracked files outside the repo**, to `~/.cache/` or similar. The temp index keeps everything in the object store, where `gc` already knows how to reclaim it.


### PR DESCRIPTION
Designs a snapshot net that `claude/hooks/block_destructive_git.sh` would take before refusing a destructive git command, so a caught `reset --hard`, `checkout -- <path>` or `clean -f` becomes recoverable instead of merely prevented. The design lives at `docs/design-snapshot-before-refuse.md` and is labelled **not implemented** — no hook code changes in this PR.

## Placement: it stays a design doc, not a rule or skill

The review asked whether this should be a rule or a skill instead. Neither fits, because nothing in it is a procedure Claude follows: the hook runs the snapshot in its own process before `deny()` returns, so the agent never chooses to take one and cannot skip it. A rule is always-loaded context that costs budget every session, and `claude/rules/safety.md` already carries the only always-on sentence that matters — that this hook refuses these forms — while the recovery instruction reaches the session through the hook's own refusal text at the moment it is needed, at zero standing cost. A skill is activity-scoped procedure, and "recover from a snapshot I did not know existed" is not an activity a session goes looking for. So the behaviour belongs in the hook, the durable prose after implementation is one clause in `safety.md` plus the refusal string, and until then a design doc in `docs/` is the right home.

## The untracked-file question is resolved, with measurements

The previous body flagged an open question: `git stash create` captures tracked files only, so `clean -f` would snapshot nothing. Verified on git 2.43.0 in a throwaway repo, and written into the design.

`git stash create` does capture tracked files only — `git ls-tree -r --name-only` on the resulting commit listed `.gitignore` and `tracked.txt`, with both untracked files absent. The tempting fix is worse than useless: `git stash create -u "msg-u"` exits 0 and prints a SHA, so a hook trusting the exit code ships an empty snapshot, but `git log -1 --format=%s` on the result reads `On main: -u msg-u` and `git rev-list --parents -n1` returns two parents, not the three a `-u` stash carries. The `-u` was swallowed as message text; `git stash --help` gives the synopsis as `git stash create [<message>]`, with no options.

What works is a throwaway `GIT_INDEX_FILE` seeded with `read-tree HEAD`, fed explicit pathspecs from `git ls-files --others --exclude-standard` and `--modified` through `update-index --add -z --stdin`, then `write-tree` and `commit-tree`. `ls-tree` on that commit listed `.gitignore`, `sub/nested.txt`, `tracked.txt` and `untracked.txt`, and `git diff --stat HEAD <commit>` printed `3 files changed, 3 insertions(+), 1 deletion(-)`. The real index and working tree were untouched (`git status --porcelain` byte-identical before and after) and `git stash list` stayed empty throughout, which is the whole point given that the stash stack is shared across worktrees. Gitignored files are excluded, which matches `git clean -f` scope exactly; only `git clean -fx` reaches further, and the design says that refusal must admit the gap.

Three corrections to the earlier draft came out of the same run. Recovery is `git restore --source=<ref> --worktree -- .`, verified end to end: after deleting `untracked.txt` and `sub/` and reverting `tracked.txt`, the restore brought back all three with their original contents. The draft's `git stash apply <sha>` does not work — it prints `fatal: 'refs/snapshots/…' is not a stash-like commit`. And `git checkout <ref> -- .`, the reflexive alternative, is refused by this very hook, whose `checkout` matcher fires on the bare `--` without checking for a preceding tree-ish; fixing that matcher is noted as out of scope.

Cost is measured rather than guessed: 0.66 s cold and 0.11 s warm for 2000 untracked files across 24 MB, 6.64 s for 250 MB, roughly 38 MB/s, peak RSS 30 MB, and the warm case re-derives the same commit id for free. A clean tree also needs an explicit check — unlike `stash create`, the temp-index path still emits a commit, so the skip test is `git write-tree` against `git rev-parse HEAD^{tree}`, verified equal on a clean repo.

## What a reviewer should look at

The placement argument in the doc's first section, since that is the decision being made and it is reversible only by moving the file. The temp-index snippet and its explicit-pathspec discipline, because `git add -A` is forbidden here for a reason and this is the shape that avoids it. The failure-mode list, especially "check the tree, not the exit code", which exists because `stash create -u` demonstrated a 0 exit on a snapshot that captured nothing. And the test plan, which covers a hook that has no test today.

Follow-up, not in this PR: the `checkout` matcher's false positive on `git checkout <tree-ish> -- <path>` is a live bug in the shipped hook independent of any snapshot work.
