### PR TITLE
hooks: give auto-opened PRs a real title on multi-commit pushes

### DIFF
--- a/claude/hooks/pr_after_push.sh
+++ b/claude/hooks/pr_after_push.sh
@@ -101,7 +101,16 @@ if [ -n "$EXISTING" ]; then
     emit "Pushed $BRANCH; PR #$EXISTING is already open for it. $NEXT"
 fi
 
-if ! CREATED=$(cd "$CWD" && gh pr create --draft --fill --head "$BRANCH" 2>&1); then
+# --fill takes the title from the commit only when the branch is exactly one
+# commit ahead of base; with more commits it humanises the BRANCH NAME instead.
+# That is how background jobs produced PRs titled "worktree agent <hex>" — and
+# why any two-commit push got a title like "gateway dropin rebase". gh's own
+# help: alongside --fill, a value given by --title takes precedence, so the body
+# stays autofilled from the commits.
+TITLE=$(git -C "$CWD" log -1 --format=%s 2>/dev/null)
+TITLE_ARG=()
+[ -n "$TITLE" ] && TITLE_ARG=(--title "$TITLE")
+if ! CREATED=$(cd "$CWD" && gh pr create --draft --fill "${TITLE_ARG[@]}" --head "$BRANCH" 2>&1); then
     emit "Pushed $BRANCH but no PR exists and \`gh pr create --draft --fill\` failed: ${CREATED//$'\n'/ }. Open one with gh pr create (title + body), then: $NEXT"
 fi
 URL=$(grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' <<< "$CREATED" | head -1)


### PR DESCRIPTION
gh --fill takes the title from the commit only when the branch is exactly one
commit ahead of base; past that it humanises the branch name. That is the whole
mechanism behind the draft PRs titled 'worktree agent <hex>' — measured on this
repo: PRs created from a single commit got proper titles, while every two- or
three-commit push got its branch name, including two opened by this session.

Passes the tip commit subject as --title, which gh's help says takes precedence
over --fill while the body stays autofilled. No policy change: a PR is still
opened for every non-main branch.
