### PR TITLE
tests: fail if the attribution opt-out returns to settings

### DIFF
--- a/.github/workflows/settings-guards.yml
+++ b/.github/workflows/settings-guards.yml
@@ -1,0 +1,59 @@
+name: Settings guards
+
+# Answers "when does this test run?" for tests/test_no_attribution_optout.sh. This repo has no suite runner, so each test names its own trigger; this is that test's. The pre-commit hook in config/git-hooks/pre-commit runs the same test locally on a staged settings.json, and CI is the leg that survives --no-verify and a second machine.
+#
+# Only first-party actions (actions/*), matching this repo's supply-chain posture (no third-party GHA actions).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'claude/settings.json'
+      - 'tests/test_no_attribution_optout.sh'
+      - 'config/git-hooks/pre-commit'
+      - '.github/workflows/settings-guards.yml'
+  pull_request:
+    paths:
+      - 'claude/settings.json'
+      - 'tests/test_no_attribution_optout.sh'
+      - 'config/git-hooks/pre-commit'
+      - '.github/workflows/settings-guards.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: settings-guards-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  attribution-optout:
+    name: No CLAUDE_CODE_ATTRIBUTION_HEADER opt-out
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # A runner has no ~/.claude/settings.json, so the deployed leg reports a skip and the committed copy is what is asserted on. Pointed at a path that cannot exist so the skip is deterministic rather than incidental.
+      - name: Committed settings carry no attribution opt-out
+        run: bash tests/test_no_attribution_optout.sh
+        env:
+          CLAUDE_SETTINGS_DEPLOYED: ${{ runner.temp }}/no-deployed-copy.json
+
+      # A guard that cannot fail proves nothing. Reintroduce the exact key on a fixture and require the test to catch it.
+      - name: Mutation check — the guard must still be able to fail
+        run: |
+          python3 - "$RUNNER_TEMP/mutated-settings.json" <<'PY'
+          import json, sys
+          json.dump({"env": {"CLAUDE_CODE_ATTRIBUTION_HEADER": "0"}}, open(sys.argv[1], "w"))
+          PY
+          if CLAUDE_SETTINGS_COMMITTED="$RUNNER_TEMP/mutated-settings.json" \
+             CLAUDE_SETTINGS_DEPLOYED="$RUNNER_TEMP/no-deployed-copy.json" \
+             bash tests/test_no_attribution_optout.sh > "$RUNNER_TEMP/mutation.log" 2>&1; then
+            cat "$RUNNER_TEMP/mutation.log"
+            echo "::error::The guard passed against a settings file that sets the opt-out — it is vacuous."
+            exit 1
+          fi
+          echo "Guard correctly caught the reintroduced opt-out:"
+          cat "$RUNNER_TEMP/mutation.log"

--- a/config/git-hooks/pre-commit
+++ b/config/git-hooks/pre-commit
@@ -238,8 +238,9 @@ _validate_no_attribution_optout() {
     guard="${repo_root}/tests/test_no_attribution_optout.sh"
     [ -n "${repo_root}" ] && [ -f "${guard}" ] || return 0
 
+    # Template ends in the X run, with no extension: BSD mktemp on macOS wants a trailing X run, and a suffix after it is a GNU extension. The guard only parses the path as JSON, so the name carries nothing.
     local staged
-    staged=$(mktemp "${TMPDIR:-/tmp}/staged-settings.XXXXXX.json") || return 0
+    staged=$(mktemp "${TMPDIR:-/tmp}/staged-settings.XXXXXX") || return 0
     if ! git show ":${file}" > "${staged}" 2>/dev/null; then
         rm -f "${staged}"
         return 0

--- a/config/git-hooks/pre-commit
+++ b/config/git-hooks/pre-commit
@@ -224,11 +224,52 @@ if found:
     return 1
 }
 
+# === ATTRIBUTION OPT-OUT CHECK ===
+#
+# Blocks CLAUDE_CODE_ATTRIBUTION_HEADER=0 coming back to a settings file. The opt-out plus a non-api.anthropic.com base URL makes every auto-mode classifier request return a bare 429, which denies every tool call with no local log line to explain it. See tests/test_no_attribution_optout.sh for the mechanism and the upstream references.
+#
+# Delegates to that test rather than restating the rule, so there is one implementation. The test lives in the dotfiles repo only, so every other repo skips this silently. The staged blob goes in as the committed copy, because that is what the commit would publish; the deployed copy is left at its real path, because that is what this machine is running.
+
+_validate_no_attribution_optout() {
+    local file="$1"
+
+    local repo_root guard
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    guard="${repo_root}/tests/test_no_attribution_optout.sh"
+    [ -n "${repo_root}" ] && [ -f "${guard}" ] || return 0
+
+    local staged
+    staged=$(mktemp "${TMPDIR:-/tmp}/staged-settings.XXXXXX.json") || return 0
+    if ! git show ":${file}" > "${staged}" 2>/dev/null; then
+        rm -f "${staged}"
+        return 0
+    fi
+
+    # Explicit status capture: the hook runs under `set -e`, and a bare assignment from a failing command substitution would abort it.
+    local output status
+    output=$(CLAUDE_SETTINGS_COMMITTED="${staged}" bash "${guard}" 2>&1) && status=0 || status=$?
+    rm -f "${staged}"
+    [ "${status}" -eq 0 ] && return 0
+
+    echo ""
+    echo "⛔  Pre-commit: attribution opt-out guard FAILED for ${file}"
+    while IFS= read -r _guard_line; do echo "    ${_guard_line}"; done <<< "${output}"
+    echo ""
+    echo "    Remove env.CLAUDE_CODE_ATTRIBUTION_HEADER from the file(s) named above."
+    echo "    Background: artifacts/auto-mode-classifier-429/report.md"
+    echo ""
+    echo "    To bypass (only if you have verified the classifier still answers):"
+    echo "      git commit --no-verify"
+    echo ""
+    return 1
+}
+
 while IFS= read -r _staged_file; do
     case "${_staged_file}" in
         claude/settings.json|.claude/settings.json)
             _validate_claude_settings "${_staged_file}" || exit 1
             _validate_no_local_gateway "${_staged_file}" || exit 1
+            _validate_no_attribution_optout "${_staged_file}" || exit 1
             ;;
     esac
 done < <(git diff --cached --name-only 2>/dev/null)

--- a/tests/test_no_attribution_optout.sh
+++ b/tests/test_no_attribution_optout.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Guards against CLAUDE_CODE_ATTRIBUTION_HEADER=0 returning to settings.
+#
+# Why this exists: the opt-out silently broke auto mode behind the gateway.
+# Claude Code re-adds the billing attribution block for classifier calls only
+# when ANTHROPIC_BASE_URL is unset or api.anthropic.com; behind the model-router
+# the opt-out is honoured and every classifier request comes back a bare 429.
+# Measured 8 Sep 2026: 15 requests, 15 x 429, every Bash call denied. Removed in
+# b2868c8; artifacts/auto-mode-classifier-429/report.md has the mechanism.
+#
+# The failure leaves no local log line, so nothing surfaces it except a session
+# that stops working. Hence a test rather than a note.
+#
+# Both copies are checked because they differ by design: the deployed file is
+# claude/settings.json through the ~/.claude symlink, and it carries local
+# gateway keys the committed copy must never have. The bug lived in that gap.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+KEY="CLAUDE_CODE_ATTRIBUTION_HEADER"
+# Overridable so the test can be pointed at a fixture and shown to fail; a test
+# that has only ever passed has not been tested.
+DEPLOYED="${CLAUDE_SETTINGS_DEPLOYED:-$HOME/.claude/settings.json}"
+COMMITTED="${CLAUDE_SETTINGS_COMMITTED:-$REPO_ROOT/claude/settings.json}"
+
+fails=0
+checked=0
+
+report_fail() {
+    printf 'FAIL: %s\n' "$1"
+    fails=$((fails + 1))
+}
+
+# Reads the key out of the env block only. A grep would also match the word in a
+# comment or in this file's own path, and jq is not guaranteed present.
+env_value() {
+    python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        settings = json.load(fh)
+except FileNotFoundError:
+    print("ABSENT-FILE"); sys.exit(0)
+except json.JSONDecodeError as exc:
+    print("BAD-JSON " + str(exc)); sys.exit(0)
+env = settings.get("env")
+if not isinstance(env, dict):
+    print("NO-ENV"); sys.exit(0)
+print(env.get(sys.argv[2], "UNSET"))
+' "$1" "$2"
+}
+
+check_file() {
+    local label="$1" path="$2" required="$3" value
+    value=$(env_value "$path" "$KEY")
+    case "$value" in
+        ABSENT-FILE)
+            if [ "$required" = "required" ]; then
+                report_fail "$label missing at $path"
+            else
+                printf 'skip: %s not present at %s\n' "$label" "$path"
+            fi
+            return ;;
+        BAD-JSON*)
+            report_fail "$label is not valid JSON at $path: ${value#BAD-JSON }" ; return ;;
+        UNSET|NO-ENV)
+            checked=$((checked + 1))
+            printf 'ok:   %s carries no %s\n' "$label" "$KEY" ; return ;;
+        *)
+            checked=$((checked + 1))
+            report_fail "$label sets $KEY=$value at $path — this breaks the auto-mode classifier behind the gateway (see artifacts/auto-mode-classifier-429/report.md). Remove the key."
+            return ;;
+    esac
+}
+
+check_file "committed settings" "$COMMITTED" required
+# Optional: a fresh clone or a CI checkout has no deployed copy to inspect.
+check_file "deployed settings" "$DEPLOYED" optional
+
+if [ "$fails" -ne 0 ]; then
+    printf '\n%d check(s) failed\n' "$fails"
+    exit 1
+fi
+printf '\nPASS: %d settings file(s) carry no %s\n' "$checked" "$KEY"

--- a/tests/test_no_attribution_optout.sh
+++ b/tests/test_no_attribution_optout.sh
@@ -71,7 +71,7 @@ check_file() {
             printf 'ok:   %s carries no %s\n' "$label" "$KEY" ; return ;;
         *)
             checked=$((checked + 1))
-            report_fail "$label sets $KEY=$value at $path — this breaks the auto-mode classifier behind the gateway (see artifacts/auto-mode-classifier-429/report.md). Remove the key."
+            report_fail "$label sets $KEY=$value at $path — the key must not be present at all, whatever its value. Remove it. (The value that broke auto mode behind the gateway was 0; see artifacts/auto-mode-classifier-429/report.md.)"
             return ;;
     esac
 }

--- a/tests/test_no_attribution_optout.sh
+++ b/tests/test_no_attribution_optout.sh
@@ -1,25 +1,29 @@
 #!/usr/bin/env bash
-# Guards against CLAUDE_CODE_ATTRIBUTION_HEADER=0 returning to settings.
+# Fails if CLAUDE_CODE_ATTRIBUTION_HEADER=0 returns to a Claude Code settings file.
 #
-# Why this exists: the opt-out silently broke auto mode behind the gateway.
-# Claude Code re-adds the billing attribution block for classifier calls only
-# when ANTHROPIC_BASE_URL is unset or api.anthropic.com; behind the model-router
-# the opt-out is honoured and every classifier request comes back a bare 429.
-# Measured 8 Sep 2026: 15 requests, 15 x 429, every Bash call denied. Removed in
-# b2868c8; artifacts/auto-mode-classifier-429/report.md has the mechanism.
+# When this runs:
+#   - GitHub Actions, .github/workflows/settings-guards.yml, on every push to main and every pull request touching claude/settings.json, this test, or the pre-commit hook. A runner has no deployed copy, so that leg reports a skip and the committed copy is what CI asserts on.
+#   - The pre-commit hook, config/git-hooks/pre-commit, whenever claude/settings.json or .claude/settings.json is staged. The hook passes the staged blob in as the committed copy and leaves the deployed copy at its real path, so one run covers both what the commit would publish and what this machine is running right now.
+#   - By hand: bash tests/test_no_attribution_optout.sh
 #
-# The failure leaves no local log line, so nothing surfaces it except a session
-# that stops working. Hence a test rather than a note.
+# There is no suite runner in this repo. tests/ is a directory of standalone scripts, each wired to whatever triggers it (test_no_stall.sh has a workflow, test_pre_commit_gateway_guard.sh has nothing), so "wire it in" means naming the trigger, which the two entries above now do.
 #
-# Both copies are checked because they differ by design: the deployed file is
-# claude/settings.json through the ~/.claude symlink, and it carries local
-# gateway keys the committed copy must never have. The bug lived in that gap.
+# Why this exists: the opt-out silently broke auto mode behind the gateway. Claude Code re-adds the billing attribution block for classifier calls only when ANTHROPIC_BASE_URL is unset or api.anthropic.com; behind the model-router the opt-out is honoured and every classifier request comes back a bare 429. Measured 8 Sep 2026: 15 requests, 15 x 429, every Bash call denied. Removed in b2868c8; artifacts/auto-mode-classifier-429/report.md has the mechanism.
+#
+# The failure leaves no local log line, so nothing surfaces it except a session that stops working. Hence a test rather than a note.
+#
+# Both copies are checked because they differ by design: the deployed file is claude/settings.json through the ~/.claude symlink, and it carries local gateway keys the committed copy must never have. The bug lived in that gap.
+#
+# References:
+#   - Upstream bug, open since 16 Apr 2026: https://github.com/anthropics/claude-code/issues/49535
+#   - The comment on it that names this opt-out as the cause: https://github.com/anthropics/claude-code/issues/49535#issuecomment-5491600660
+#   - Claude Code 2.1.229 shipped the partial repair: "Fixed auto mode failing on every tool call for users who disable the attribution header via CLAUDE_CODE_ATTRIBUTION_HEADER (direct Anthropic API connections)". The parenthesis is the whole problem — the repair covers direct connections only, so a gateway session stays broken, which is why removing the key is the fix rather than upgrading. Entry under "## 2.1.229" at https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+#   - The CLI ships that same changelog locally at ~/.claude/cache/changelog.md (gitignored); the 2.1.229 entry sat at line 1133 on 2026-09-11, matching the published file byte for byte.
 set -uo pipefail
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 KEY="CLAUDE_CODE_ATTRIBUTION_HEADER"
-# Overridable so the test can be pointed at a fixture and shown to fail; a test
-# that has only ever passed has not been tested.
+# Overridable so the test can be pointed at a fixture and shown to fail, and so the pre-commit hook can point it at the staged blob. A test that has only ever passed has not been tested.
 DEPLOYED="${CLAUDE_SETTINGS_DEPLOYED:-$HOME/.claude/settings.json}"
 COMMITTED="${CLAUDE_SETTINGS_COMMITTED:-$REPO_ROOT/claude/settings.json}"
 
@@ -31,8 +35,7 @@ report_fail() {
     fails=$((fails + 1))
 }
 
-# Reads the key out of the env block only. A grep would also match the word in a
-# comment or in this file's own path, and jq is not guaranteed present.
+# Reads the key out of the env block only. A grep would also match the word in a comment or in this file's own path, and jq is not guaranteed present.
 env_value() {
     python3 -c '
 import json, sys


### PR DESCRIPTION
`CLAUDE_CODE_ATTRIBUTION_HEADER=0` sat in settings since 31 March and silently broke auto mode behind the model-router gateway: every classifier request came back a bare 429, so every Bash, Edit and Write call was denied with no local log line to explain it. The key was removed in b2868c8. This PR stops it coming back, and ships the diagnosis it came from.

## What this PR does

- `tests/test_no_attribution_optout.sh` fails if the key returns to a Claude Code settings file. It checks the committed copy and the deployed copy, which differ by design — the deployed file is `claude/settings.json` through the `~/.claude` symlink and carries machine-local gateway keys the committed copy must never have. The bug lived in exactly that gap. Both paths are overridable by environment variable, so the test can be pointed at a fixture and shown to fail.
- `.github/workflows/settings-guards.yml` runs the test on every push to `main` and every pull request touching `claude/settings.json`, the test, or the pre-commit hook. A second step reintroduces the key on a fixture and fails the job if the guard does not catch it, so the guard cannot go vacuous unnoticed.
- `config/git-hooks/pre-commit` runs the same test whenever `claude/settings.json` or `.claude/settings.json` is staged. It passes the staged blob in as the committed copy and leaves the deployed copy at its real path, so one run covers both what the commit would publish and what the machine is running. The hook delegates to the test rather than restating the rule, and returns silently in any repo that does not carry the test file.
- `artifacts/auto-mode-classifier-429/` is the diagnosis: the report source, the built HTML, and the `ARTIFACTS.md` row. `claude/skills/gmail-connector/SKILL.md` gains the RAW size ceiling found while gathering evidence for it.

## When the test runs, since review asked

There is no suite runner in this repo. `tests/` is a directory of standalone scripts and each one is wired to whatever triggers it — `test_no_stall.sh` has a workflow, `test_pre_commit_gateway_guard.sh` has nothing and nothing runs it. Before this change the attribution test was in the second group. It is now in the first, through the workflow and the pre-commit hook above, and the test's own header names both triggers so the next reader does not have to ask again.

## References

- Upstream bug, open since 16 April 2026: https://github.com/anthropics/claude-code/issues/49535
- The comment on it that names this opt-out as the cause, and asks for the changelog link: https://github.com/anthropics/claude-code/issues/49535#issuecomment-5491600660
- That changelog entry is Claude Code 2.1.229: "Fixed auto mode failing on every tool call for users who disable the attribution header via `CLAUDE_CODE_ATTRIBUTION_HEADER` (direct Anthropic API connections)". The parenthesis is the whole problem — the repair covers direct connections only, so a gateway session stays broken, and removing the key is the fix rather than upgrading. Under the `## 2.1.229` heading at https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
- The published changelog was checked against the copy the CLI ships locally at `~/.claude/cache/changelog.md` (gitignored). Same text, line 1133 on 11 September 2026.

## Evidence

Every command below was run on this branch on 11 September 2026.

- `bash tests/test_no_attribution_optout.sh` — passes, 2 files checked, committed and deployed.
- Same test with `CLAUDE_SETTINGS_DEPLOYED` pointed at a missing path — passes, 1 file checked, deployed leg reports a skip. This is the CI shape.
- The workflow's mutation step, extracted from the YAML and run verbatim — the guard fails on a fixture carrying `CLAUDE_CODE_ATTRIBUTION_HEADER: "0"`, so the step reports the catch and exits 0.
- The pre-commit hook driven end to end in a throwaway repo with `core.hooksPath` pointed at this branch: committing a staged `claude/settings.json` that sets the key is blocked with the guard's own message; removing the key and re-staging commits cleanly.
- `shellcheck tests/test_no_attribution_optout.sh config/git-hooks/pre-commit` — clean.

## Wrapping

Review also asked to drop manual line-wrapping. Fixed in this PR's own files: the test's header comment and inline comments are one line per paragraph, and so are the new hook and workflow comments. The Markdown this PR adds or changes was already unwrapped and was re-checked — `ARTIFACTS.md`, `artifacts/auto-mode-classifier-429/report.md` and `claude/skills/gmail-connector/SKILL.md` have no hard-wrapped paragraphs. The repo-wide sweep is a sibling branch, deliberately not done here.

## Second review round closed two findings

Review approved the wiring and verified end to end that a repo without the test file skips silently. Two things were raised; both are fixed in 3fe91ca.

- **`mktemp` portability — the one with a real consequence.** The guard called `mktemp "${TMPDIR:-/tmp}/staged-settings.XXXXXX.json"`, with the suffix *after* the trailing X run. GNU coreutils accepts that — its own man page documents `--suffix` as implied when the template does not end in X, which is the GNU extension doing the work — but BSD `mktemp` on macOS wants the template to end in X characters. Had it failed there, the guard's `|| return 0` would have made it a silent no-op on every macOS commit, and the Mac is the machine whose deployed settings actually carried the bug this guard exists to catch. The template now ends in the X run and drops the extension, which was decorative: the guard only ever parses the path as JSON, never by name. **This fix is for BSD `mktemp` compatibility and was verified on GNU coreutils 9.4 only — no macOS was reachable from this worktree.**
- **A failure message that asserted something untrue for one input.** It said the setting "breaks the auto-mode classifier behind the gateway". That holds for the value `0` and not for `1`, yet the guard fails on any value — correctly, because the policy is that the key must be absent, not that it must be set to the right thing. The message now states the policy and attributes the breakage to the value that has it: "the key must not be present at all, whatever its value. Remove it. (The value that broke auto mode behind the gateway was 0; see `artifacts/auto-mode-classifier-429/report.md`.)"

On the repo's own `mktemp` convention, counted rather than assumed: 45 templates in the repo, 42 end in the X run. The three that do not were this one and two in `claude/skills/mats-slurm/templates/slurm_aliases.sh` (`/tmp/gbatch_XXXXXX.sh`, `/tmp/lbatch_XXXXXX.sh`), which run only on the MATS Linux cluster. So the review's "the only one of roughly twenty" was two off and undercounted the total, but its conclusion held for every call that can reach a Mac, and this was the only one of those.

Re-verified after the change, all on 11 September 2026: the guard fails on a fixture setting the key to `1` and on one setting it to `0`, with the new wording; it passes on the real committed and deployed copies; `shellcheck` is clean on both changed files; `tests/test_pre_commit_gateway_guard.sh` still passes; and the hook driven end to end in a scratch repo blocks a staged `claude/settings.json` carrying the key, then commits cleanly once the key is removed, leaving no `staged-settings.*` file behind in `$TMPDIR`.

## What a reviewer should look at

- `config/git-hooks/pre-commit`, `_validate_no_attribution_optout`. This hook is global and runs in every repo, so the early return when `tests/test_no_attribution_optout.sh` is absent is the load-bearing line. The status capture is written `&& status=0 || status=$?` because the hook runs under `set -e`.
- Whether blocking a commit on the *deployed* copy is wanted. The deployed leg can fail a commit that cannot itself fix the problem — deliberate, since that copy is where the bug actually lived and the fix is one key, but it is the one judgement call here.
- The workflow's `paths:` filter. A pull request that reintroduces the key necessarily touches `claude/settings.json`, so it triggers; nothing else does.

## Follow-ups, not in this PR

- Neither trigger catches Claude Code writing the key back into the deployed `~/.claude/settings.json` between commits. A `SessionStart` hook would close that, and `claude/hooks/` is out of scope for this branch.
- Pre-existing bug in `config/git-hooks/pre-commit` line 105, confirmed again for the second review round: under `pipefail`, `prev_lines=$(git show "HEAD:${file}" 2>/dev/null | wc -l || echo 0)` yields `"0\n0"` when the file is new to the repo, because `wc -l` has already printed `0` before `|| echo 0` adds another. Line 105 then prints `[: 0\n0: integer expression expected` to stderr on every commit of a settings file new to that repo — reproduced live on 11 September 2026 while driving this branch's hook in a scratch repo, where it fires just before the attribution guard. It dates to ab6753b (5 April 2026), is unrelated to this PR's subject, and is left alone here.
- `artifacts/auto-mode-classifier-429/report.md` still says the gateway gap "is worth filing upstream". It was, on 1 September, in issue 49535. Updating the report means rebuilding and republishing the live artifact, which belongs in its own change.

