### PR TITLE
skills: write-prose routes human-facing prose to the designated writer

### DIFF
--- a/claude/skills/write-prose/SKILL.md
+++ b/claude/skills/write-prose/SKILL.md
@@ -1,45 +1,35 @@
 ---
 name: write-prose
-description: Use when drafting or revising human-facing prose — artifacts, reports, specs, skills, rules and PR descriptions. Delegate the draft to the designated writer.
+description: Use when drafting or revising human-facing prose — artifacts, reports, specs, skills, rules and PR descriptions. Select the writer from the router config.
 ---
 
-# Delegate the draft, not the polish
+# Commission prose before drafting it
 
-For in-scope prose, commission the writing instead of doing it yourself. The owner's standing judgement is that Opus 5 and Fable 5/5.1 write unclear prose; do not reopen that decision. Send source material before drafting so the writer chooses the structure. Polishing your draft preserves the structure this rule is meant to replace.
-
-## In scope
-
-- Artifacts, reports and specs
-- Skill and rule text
-- PR bodies and descriptions
-
-## Out of scope
+Use this workflow for the document types above. Keep these inline:
 
 - Chat replies
 - Commit messages
 - Code comments
-- Anything under about 150 words
+- Text under about 150 words
 
-## Seats, in order
+## Select writers from one source
 
-1. `sol(high)` — GPT-5.6 Sol: default writer.
-2. `astra(high)` — GPT-6 Astra: second writer; preferred reviewer and restructurer.
-3. `kimi` — Kimi K3: cross-family fallback.
+Read `config/model-router.toml` in the dotfiles repo. Select an eligible writer by `writer-priority` and follow the fallback and quota guidance there. Use the selected model's generated agent in `claude/agents/`; never hand-write a foreign-model agent. If this session already runs the selected writer, write directly.
 
-On a quota or cooldown failure, move to the next available seat; the failure is not a finding. Sol and Astra share Codex OAuth credentials, so a quota failure can block both. If the error names `usage_limit_reached ... via provider codex`, use Kimi, which runs on OpenRouter.
+## Brief the writer with sources
 
-## Brief requirements
+Send source material before drafting so the writer can choose the structure. Include:
 
-- Supply the findings, constraints, decisions and numbers. Raw material is fine; the brief must stand alone.
-- Name the audience and what they will do with the text.
-- Include reviewer comments verbatim for revisions.
-- Include the applicable conventions from `~/.claude/checklists/writing.md`: one line per paragraph; headings assert a point in 4–7 words; results belong in figures; sourced claims link to sources; no checkbox syntax outside working todo lists.
-- Set a length target.
-- Require: "Return only the markdown, no preamble, no outer code fence. Do not write any file."
+- Findings, decisions, constraints and source paths or links.
+- The audience, intended action and length target.
+- Reviewer comments verbatim when revising.
+- `~/.claude/CLAUDE.md` and `~/.claude/checklists/writing.md` for the current standards; do not restate them here.
+- The output contract: return only the document text, without a preamble or outer code fence; do not write files.
 
-## Verify before writing the file
+## Verify the text before delivery
 
-- Read the returned text. Check for invented claims, numbers that differ from their sources and omitted scope. You remain responsible for accuracy.
-- Write the verified text to the file.
-- Show the diff.
-- Tell the user which exact model produced the text.
+- Check claims and numbers against the sources.
+- Confirm the requested scope.
+- Return substantive corrections to the writer.
+- Save the verified text and inspect the diff.
+- Name the exact model that wrote it.

--- a/claude/skills/write-prose/SKILL.md
+++ b/claude/skills/write-prose/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: write-prose
+description: Use when drafting or revising prose a human will read — artifacts, reports, specs, skill and rule text, PR bodies. Routes the writing to the designated writing model instead of writing it yourself.
+---
+
+# Route prose to the writing model
+
+Opus 5 and Fable 5/5.1 write unclear, abstruse prose. That is a standing judgement in global CLAUDE.md, not a preference to re-litigate. So for anything in scope below, you do not write the prose — you commission it.
+
+Draft time, not polish time. Sending your own draft out for polishing preserves your structure and your phrasing, which is the part that was wrong. Send the *material* and let the writing model choose the shape.
+
+## In scope
+
+- Artifacts, reports and specs
+- Skill and rule text
+- PR bodies and descriptions
+
+Out of scope, because the round trip costs more than it returns: chat replies, commit messages, code comments, and anything under about 150 words.
+
+## The seats, in order
+
+1. `sol(high)` — GPT-5.6 Sol, the default writer
+2. `astra(high)` — GPT-6 Astra, also the reviewer and the polisher of choice for restructuring
+3. `kimi` — Kimi K3, the cross-family fallback
+
+Seats 1 and 2 share one credential pool (Codex OAuth), so a quota failure usually takes out both — the error reads `usage_limit_reached ... via provider codex`. Seat 3 is on OpenRouter and survives that. A quota or cooldown failure is transient and owes no finding: move down the list and say which seat produced the text.
+
+## What to send
+
+The brief must stand alone, because the agent has none of your context.
+
+- The material: findings, constraints, the decision, the numbers. Raw is fine.
+- The audience and what they will do with it.
+- Any reviewer comments verbatim, when this is a revision — quote them, do not summarise them into "make it clearer".
+- The conventions that apply, from `~/.claude/checklists/writing.md`: one paragraph is one line, headings assert a point in 4-7 words, results belong in figures, every sourced claim links to its source, no checkbox syntax outside working todo lists.
+- A length target. Without one you get more words, not better ones.
+- "Return only the markdown, no preamble, no outer code fence. Do not write any file."
+
+## After it returns
+
+Read it before you ship it. You are accountable for the claims, and a writing model will not catch a fact you got wrong — it will state it more fluently. Check that no claim was invented, that every number still matches its source, and that nothing in scope was dropped.
+
+Then write the file yourself and show the diff. Name the seat in your message to the user, so a weak result is attributable.

--- a/claude/skills/write-prose/SKILL.md
+++ b/claude/skills/write-prose/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: write-prose
-description: Use when drafting or revising prose a human will read — artifacts, reports, specs, skill and rule text, PR bodies. Routes the writing to the designated writing model instead of writing it yourself.
+description: Use when drafting or revising human-facing prose — artifacts, reports, specs, skills, rules and PR descriptions. Delegate the draft to the designated writer.
 ---
 
-# Route prose to the writing model
+# Delegate the draft, not the polish
 
-Opus 5 and Fable 5/5.1 write unclear, abstruse prose. That is a standing judgement in global CLAUDE.md, not a preference to re-litigate. So for anything in scope below, you do not write the prose — you commission it.
-
-Draft time, not polish time. Sending your own draft out for polishing preserves your structure and your phrasing, which is the part that was wrong. Send the *material* and let the writing model choose the shape.
+For in-scope prose, commission the writing instead of doing it yourself. The owner's standing judgement is that Opus 5 and Fable 5/5.1 write unclear prose; do not reopen that decision. Send source material before drafting so the writer chooses the structure. Polishing your draft preserves the structure this rule is meant to replace.
 
 ## In scope
 
@@ -15,29 +13,33 @@ Draft time, not polish time. Sending your own draft out for polishing preserves 
 - Skill and rule text
 - PR bodies and descriptions
 
-Out of scope, because the round trip costs more than it returns: chat replies, commit messages, code comments, and anything under about 150 words.
+## Out of scope
 
-## The seats, in order
+- Chat replies
+- Commit messages
+- Code comments
+- Anything under about 150 words
 
-1. `sol(high)` — GPT-5.6 Sol, the default writer
-2. `astra(high)` — GPT-6 Astra, also the reviewer and the polisher of choice for restructuring
-3. `kimi` — Kimi K3, the cross-family fallback
+## Seats, in order
 
-Seats 1 and 2 share one credential pool (Codex OAuth), so a quota failure usually takes out both — the error reads `usage_limit_reached ... via provider codex`. Seat 3 is on OpenRouter and survives that. A quota or cooldown failure is transient and owes no finding: move down the list and say which seat produced the text.
+1. `sol(high)` — GPT-5.6 Sol: default writer.
+2. `astra(high)` — GPT-6 Astra: second writer; preferred reviewer and restructurer.
+3. `kimi` — Kimi K3: cross-family fallback.
 
-## What to send
+On a quota or cooldown failure, move to the next available seat; the failure is not a finding. Sol and Astra share Codex OAuth credentials, so a quota failure can block both. If the error names `usage_limit_reached ... via provider codex`, use Kimi, which runs on OpenRouter.
 
-The brief must stand alone, because the agent has none of your context.
+## Brief requirements
 
-- The material: findings, constraints, the decision, the numbers. Raw is fine.
-- The audience and what they will do with it.
-- Any reviewer comments verbatim, when this is a revision — quote them, do not summarise them into "make it clearer".
-- The conventions that apply, from `~/.claude/checklists/writing.md`: one paragraph is one line, headings assert a point in 4-7 words, results belong in figures, every sourced claim links to its source, no checkbox syntax outside working todo lists.
-- A length target. Without one you get more words, not better ones.
-- "Return only the markdown, no preamble, no outer code fence. Do not write any file."
+- Supply the findings, constraints, decisions and numbers. Raw material is fine; the brief must stand alone.
+- Name the audience and what they will do with the text.
+- Include reviewer comments verbatim for revisions.
+- Include the applicable conventions from `~/.claude/checklists/writing.md`: one line per paragraph; headings assert a point in 4–7 words; results belong in figures; sourced claims link to sources; no checkbox syntax outside working todo lists.
+- Set a length target.
+- Require: "Return only the markdown, no preamble, no outer code fence. Do not write any file."
 
-## After it returns
+## Verify before writing the file
 
-Read it before you ship it. You are accountable for the claims, and a writing model will not catch a fact you got wrong — it will state it more fluently. Check that no claim was invented, that every number still matches its source, and that nothing in scope was dropped.
-
-Then write the file yourself and show the diff. Name the seat in your message to the user, so a weak result is attributable.
+- Read the returned text. Check for invented claims, numbers that differ from their sources and omitted scope. You remain responsible for accuracy.
+- Write the verified text to the file.
+- Show the diff.
+- Tell the user which exact model produced the text.

--- a/config/model-router.toml
+++ b/config/model-router.toml
@@ -40,6 +40,15 @@
 #   picker          default true: a row in /model
 #   agent           default true: an agent file; a string sets the effort
 #                   (low|medium|high|xhigh) for models that honour it; false = none
+#   writer-priority optional positive integer: eligible writers, lowest first.
+#                   Used by write-prose, not emitted into generated router files.
+#                   Only enabled models with an agent qualify; omit to opt out.
+#
+# Writer fallback: try the next eligible priority on quota or cooldown failure.
+# All provider = "codex" models use the same OAuth account and share its quota;
+# a provider-wide quota/cooldown error skips the remaining writers on that
+# provider. Other failures skip only the failed writer. If no writer remains,
+# report the blocker rather than silently choosing an unlisted model.
 
 # What Claude Code believes every routed model's window is (set in settings env
 # as CLAUDE_CODE_MAX_CONTEXT_TOKENS); 258400 is the Codex backend's input limit.
@@ -62,6 +71,7 @@ provider = "anthropic"
 [[models]]
 id = "gpt-6-astra"
 aliases = ["astra"]
+writer-priority = 2
 name = "GPT-6 Astra"
 provider = "codex"
 context-window = 258400
@@ -70,6 +80,7 @@ agent = "high"
 [[models]]
 id = "gpt-5.6-sol"
 aliases = ["sol"]
+writer-priority = 1
 name = "GPT-5.6 Sol"
 provider = "codex"
 context-window = 258400
@@ -100,6 +111,7 @@ agent = false
 [[models]]
 id = "kimi-k3"
 aliases = ["kimi"]
+writer-priority = 3
 name = "Kimi K3"
 provider = "openrouter"
 slug = "moonshotai/kimi-k3"

--- a/tests/test_write_prose_policy.py
+++ b/tests/test_write_prose_policy.py
@@ -1,0 +1,67 @@
+"""Check writer metadata against the real router source without applying it."""
+
+import copy
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+loader = importlib.machinery.SourceFileLoader(
+    "writer_policy_wire", str(ROOT / "custom_bins/model-router-wire")
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+wire = importlib.util.module_from_spec(spec)
+loader.exec_module(wire)
+wire.SOURCE = ROOT / "config/model-router.toml"
+wire.AGENTS_DIR = ROOT / "claude/agents"
+
+
+class WriterPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.source = wire.load_source()
+        self.writers = [
+            model
+            for model in wire.enabled(self.source)
+            if "writer-priority" in model and wire.effort_of(model) is not None
+        ]
+
+    def test_priorities_are_positive_and_unique(self):
+        self.assertTrue(self.writers, "At least one writer must be available")
+        priorities = []
+        for model in self.source["models"]:
+            if "writer-priority" not in model:
+                continue
+            priority = model["writer-priority"]
+            self.assertIs(type(priority), int)
+            self.assertGreater(priority, 0)
+            self.assertNotEqual(model["provider"], "anthropic")
+            priorities.append(priority)
+        self.assertEqual(len(priorities), len(set(priorities)))
+
+    def test_eligible_writers_have_matching_generated_agents(self):
+        for model in self.writers:
+            with self.subTest(model=model["id"]):
+                self.assertEqual(
+                    wire.agent_path(model).read_text(), wire.render_agent(model)
+                )
+
+    def test_writer_metadata_does_not_change_generated_output(self):
+        without_policy = copy.deepcopy(self.source)
+        for model in without_policy["models"]:
+            model.pop("writer-priority", None)
+        self.assertEqual(
+            wire.render_router_config(self.source),
+            wire.render_router_config(without_policy),
+        )
+        self.assertEqual(
+            wire.render_settings(self.source, {}, "test-only"),
+            wire.render_settings(without_policy, {}, "test-only"),
+        )
+        for model, plain in zip(self.source["models"], without_policy["models"]):
+            if wire.effort_of(model) is not None:
+                self.assertEqual(wire.render_agent(model), wire.render_agent(plain))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Writer policy has one home

This PR adds `write-prose`, a thin workflow for commissioning human-facing documents before drafting them. GPT-6 Astra wrote the final skill and this PR description.

- `config/model-router.toml` owns writer eligibility, priority and shared-quota fallback guidance. Adding, removing or reordering a writer changes only that file.
- The skill selects an existing generated agent and points to global `CLAUDE.md` and the writing checklist instead of copying their standards.
- The workflow retains source-first briefing, accuracy checks and exact-model attribution.

## A skill selects generated agents

Keep the skill: it selects among existing generated agents and handles fallback, whereas a dedicated writer agent would pin one model and still need a selector. Foreign-model agents are generated from `config/model-router.toml` by `model-router-wire apply`; a dedicated role would require extending that source schema and generator rather than hand-writing an agent file.

## Evidence comes from local checks

- Read `model-router:choosing-models`, the router source and the wire tool before choosing the design.
- `uv run --no-sync python -m unittest discover -s tests -p 'test_write_prose_policy.py' -v`: all three tests pass against the real config and generated writer agents.
- Tests check positive, unique priorities, exact agreement with generated agents, and unchanged router, picker and agent output when writer metadata is removed.
- Ruff lint and format checks pass. The first lint run found an import-order error, which was fixed before rerunning.
- `git diff --check` and focused checks for skill headings, checkbox/link rules, absence of a copied model roster and unchanged settings pass.
- No live delegation, router apply or service restart was run. These checks establish config compatibility, not live quota handling or prose quality.

## Review these three files together

- `claude/skills/write-prose/SKILL.md`: selection and briefing mechanics only; no copied roster or writing standards.
- `config/model-router.toml`: writer metadata beside the existing model entries, with fallback guidance in the key documentation. The skill reads this metadata; the router does not implement automatic writer failover.
- `tests/test_write_prose_policy.py`: policy checks without a second hard-coded writer roster or writes to settings.

## OAuth checks remain separate work

`gh pr list --limit 40 --search codex` found [PR #123](https://github.com/yulonglin/dotfiles/pull/123). Its diff addresses stale local Codex cooldowns; it does not check OAuth token expiry or refresh. That is related work, not proof that credential-staleness checks are covered: keep those checks as a separate follow-up, with no implementation here.

No settings, hooks, secrets or generated agent files changed.
