### PR TITLE
gmail-connector: add --timezone to build.py

### DIFF
--- a/claude/skills/gmail-connector/SKILL.md
+++ b/claude/skills/gmail-connector/SKILL.md
@@ -54,10 +54,12 @@ HTML-only receipts: `_body.txt` (or the `html_body` from `FULL_CONTENT`) is a wo
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --print-to-pdf=out.pdf file:///abs/path/receipt.html
 ```
 
+**Set `--timezone` to the zone of the events, not your own and not UTC.** It defaults to UTC, which is wrong for an evidence pack: a message received at 16:08 Pacific carries a `00:08Z` header the following day, so a UTC render puts a purchase on the wrong calendar date and can contradict the filing it is attached to (observed 2026-09-10 on a RentalCover pack, where the purchase confirmation read 10 December for a 9 December purchase). The flag takes an IANA name and handles DST, so `America/Los_Angeles` yields PST in December and PDT in July. Re-rendering with a different zone is legitimate — it is the same generator over the same source data, and the page declares itself a reconstruction in its footer — but the native Gmail print is stronger still where the user can produce it.
+
 For a whole thread the two scripts in `scripts/` do it end to end: `build.py` turns a `get_thread` result (`messageFormat: FULL_CONTENT`, so `htmlBody` is present; save the spilled JSON as `<basename>.txt`, the output takes the file stem) or the delimited `threads.txt` capture (format in its docstring) into a Gmail-print-style page — account header, subject, message count, each message boxed with From/To/Cc/Date/Attachments, tracking pixels and tokenised links stripped; `render.py` prints those pages to PDF and reports bytes and page count:
 
 ```bash
-python3 ~/.claude/skills/gmail-connector/scripts/build.py work/threads.txt work/<basename>.txt --out work/html --account lin.yulong@gmail.com
+python3 ~/.claude/skills/gmail-connector/scripts/build.py work/threads.txt work/<basename>.txt --out work/html --account lin.yulong@gmail.com --timezone America/Los_Angeles
 python3 ~/.claude/skills/gmail-connector/scripts/render.py work/html/*.html --out work/pdf   # sandbox off
 ```
 

--- a/claude/skills/gmail-connector/scripts/build.py
+++ b/claude/skills/gmail-connector/scripts/build.py
@@ -9,6 +9,11 @@ Inputs, any mix:
     starts "--- MESSAGE ---", then From/To/Cc/Date/Subject/Attachments header lines, then a line
     "--- HTML ---" or "--- TEXT ---" and the body up to the next marker; dates are UTC "Z"
 
+Displayed message times default to UTC. Pass --timezone to render them in the zone of the
+events instead, which is what an evidence pack wants: a message received at 16:08 Pacific is
+stamped 00:08 UTC the following day, so a UTC render can contradict a filing that states the
+local date.
+
 Writes <out>/<basename>.html (headers, message count, each message boxed, tracking pixels and
 tokenised links stripped) and prints one line per thread. Feed the result to render.py.
 Exit 1 if any input fails to parse.
@@ -21,14 +26,18 @@ import sys
 import urllib.parse
 from datetime import datetime, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 TRACKING_HOSTS = ("unsubscribe", "track", "click", "pixel", "beacon", "open.")
 TOKEN_PARAM = re.compile(r"[?&][^=&]*=([A-Za-z0-9_\-%.,]{20,})")
 
 
+TZ = timezone.utc  # display timezone for message headers; set from --timezone
+
+
 def fmt_date(z: str) -> str:
     dt = datetime.strptime(z, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-    return dt.strftime("%a, %d %b %Y %H:%M UTC")
+    return dt.astimezone(TZ).strftime("%a, %d %b %Y %H:%M %Z")
 
 
 def clean_href(href: str) -> str:
@@ -165,10 +174,20 @@ def main() -> int:
     ap.add_argument("--out", type=Path, required=True, help="directory for the .html files")
     ap.add_argument("--account", required=True, help="mailbox address shown in the page header")
     ap.add_argument("--footer", default=None,
-                    help='footer text; default "Printed from Gmail via the Gmail API on <today> (UTC)"')
+                    help='footer text; default "Printed from Gmail via the Gmail API on <today> (<zone>)"')
+    ap.add_argument("--timezone", default="UTC", metavar="ZONE",
+                    help="IANA zone for displayed message times, e.g. America/Los_Angeles. "
+                         "Default UTC. For an evidence pack set the zone of the events: a UTC "
+                         "render can show a different calendar day from the one the recipient saw.")
     a = ap.parse_args()
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    footer = a.footer or f"Printed from Gmail via the Gmail API on {today} (UTC)"
+    global TZ
+    try:
+        TZ = timezone.utc if a.timezone.upper() == "UTC" else ZoneInfo(a.timezone)
+    except Exception as e:
+        print(f"!! unknown timezone {a.timezone!r}: {e}", file=sys.stderr)
+        return 1
+    now = datetime.now(TZ)
+    footer = a.footer or f"Printed from Gmail via the Gmail API on {now:%Y-%m-%d} ({now:%Z})"
     a.out.mkdir(parents=True, exist_ok=True)
 
     threads: dict[str, dict] = {}


### PR DESCRIPTION
## Why

`build.py` hardcoded UTC for displayed message times. A message received at 16:08 Pacific carries a `00:08Z` header the next day, so a UTC render puts it on the wrong calendar date.

That is not cosmetic in an evidence pack. On a RentalCover insurance pack built today, the purchase-confirmation printout read **10 December** for a **9 December** purchase — a day *after* the car rental it was bought for, contradicting the complaint it was attached to. The same artefact had already caused a separate round of confusion over the vendor invoice, which is UTC-stamped and cannot be re-rendered.

## What

- `--timezone ZONE` takes an IANA name and handles DST: `America/Los_Angeles` gives PST in December and PDT in July.
- Default stays `UTC`, so existing behaviour is unchanged.
- Footer now reports the zone actually used instead of always claiming UTC.
- `SKILL.md` says to set it to the zone of the **events**, with the failure it prevents, and notes that re-rendering is legitimate — same generator, same source data, and the page declares itself a reconstruction — while a native Gmail print is stronger where the user can produce one.

## Testing

```
default (UTC):    Wed, 10 Dec 2025 00:08 UTC
America/LA (Dec): Tue, 09 Dec 2025 16:08 PST
America/LA (Jul): Tue, 14 Jul 2026 19:41 PDT
Asia/Singapore:   Wed, 10 Dec 2025 08:08 +08
```

Unknown zone exits 1 with a message rather than traceback. Zones without an abbreviation render the offset (`+08`), which is Python's `%Z` behaviour.