### PR TITLE
Enforce one-paragraph-one-line in Markdown, then sweep claude/

### DIFF
--- a/.github/workflows/md-no-hard-wrap.yml
+++ b/.github/workflows/md-no-hard-wrap.yml
@@ -54,8 +54,10 @@ jobs:
       # The checker asks markdown-it-py where the paragraphs are rather than
       # re-deriving CommonMark block structure, so the dependency is real. uv is
       # what its PEP 723 shebang runs under when it is invoked as a command.
+      # cmarkgfm is the reference implementation the HTML-block matrix measures
+      # markdown-it against; without it that test falls back to a uv subprocess.
       - name: Install the checker's dependencies
-        run: python3 -m pip install --upgrade markdown-it-py uv
+        run: python3 -m pip install --upgrade markdown-it-py uv cmarkgfm
 
       - name: Unit tests for the checker
         run: python3 -m unittest tests.test_md_unwrap -v

--- a/.github/workflows/md-no-hard-wrap.yml
+++ b/.github/workflows/md-no-hard-wrap.yml
@@ -1,0 +1,74 @@
+name: Markdown paragraphs stay on one line
+
+# One paragraph is ONE line in Markdown (claude/rules/communication.md). The
+# pre-commit hook enforces this locally, but a hook is opt-in — --no-verify, a
+# fresh clone with no core.hooksPath, or an edit made through the GitHub web UI
+# all get past it. This workflow is the copy that cannot be skipped.
+#
+# Scoped to the Markdown the PR actually changes under claude/, so an unrelated
+# branch is never blocked by pre-existing wrapping somewhere else in the tree.
+#
+# Only first-party actions (actions/*), matching this repo's supply-chain posture.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'claude/**/*.md'
+      - 'custom_bins/md-unwrap'
+      - 'tests/test_md_unwrap.py'
+      - 'tests/test_pre_commit_md_wrap_guard.sh'
+      - 'config/git-hooks/pre-commit'
+      - '.github/workflows/md-no-hard-wrap.yml'
+  pull_request:
+    paths:
+      - 'claude/**/*.md'
+      - 'custom_bins/md-unwrap'
+      - 'tests/test_md_unwrap.py'
+      - 'tests/test_pre_commit_md_wrap_guard.sh'
+      - 'config/git-hooks/pre-commit'
+      - '.github/workflows/md-no-hard-wrap.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: md-no-hard-wrap-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Checker tests, then the changed Markdown
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Unit tests for the checker
+        run: python3 -m unittest tests.test_md_unwrap -v
+
+      - name: Pre-commit guard test
+        run: bash tests/test_pre_commit_md_wrap_guard.sh
+
+      - name: Changed Markdown under claude/ has no hard-wrapped paragraphs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "No usable base commit; checking all Markdown under claude/."
+            exec custom_bins/md-unwrap --check claude
+          fi
+          mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "$base" HEAD -- 'claude/**/*.md' 'claude/*.md')
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No Markdown under claude/ changed."
+            exit 0
+          fi
+          printf 'Checking %d file(s):\n' "${#changed[@]}"
+          printf '  %s\n' "${changed[@]}"
+          custom_bins/md-unwrap --check "${changed[@]}"

--- a/.github/workflows/md-no-hard-wrap.yml
+++ b/.github/workflows/md-no-hard-wrap.yml
@@ -47,6 +47,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # The checker asks markdown-it-py where the paragraphs are rather than
+      # re-deriving CommonMark block structure, so the dependency is real. uv is
+      # what its PEP 723 shebang runs under when it is invoked as a command.
+      - name: Install the checker's dependencies
+        run: python3 -m pip install --upgrade markdown-it-py uv
+
       - name: Unit tests for the checker
         run: python3 -m unittest tests.test_md_unwrap -v
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Dotfiles for ZSH, Tmux, Vim, SSH and dev tools across macOS, Linux and RunPod, d
 | Add an encrypted secret | `secrets edit` (interactive fzf editor) |
 | Add, remove or switch off a foreign model (picker row, agent, route), or put an older Claude model in `/model` (`provider = "anthropic"`) | Edit `config/model-router.toml` → `model-router-wire apply` (renders router config, picker rows and `claude/agents/` files; `status` shows drift) → `tests/test_model_router_gateway.sh` |
 | Run an experiment with resource caps | `jexp uv run python -m ...` (Linux: needs pueue + systemd user session) |
+| Check or repair hard-wrapped Markdown | `md-unwrap --check claude/` (gated in pre-commit and CI); `md-unwrap --fix <path>` |
 | Commit / commit + push + PR | `/commit` skill or `/commit-push-sync` |
 | Merge worktree → parent branch | `cwmerge` (or `git merge <branch>` from the parent if the branch isn't `worktree-` prefixed) |
 

--- a/claude/agents/application-writer.md
+++ b/claude/agents/application-writer.md
@@ -231,13 +231,4 @@ Track what works:
 
 Before finalizing any response:
 
-✓ **Directly answers the question asked**
-✓ **Within word limit (with 5-10 word buffer)**
-✓ **Concrete examples, not vague claims**
-✓ **Authentic voice maintained**
-✓ **Consistent with past applications**
-✓ **All claims verifiable from CV/past work**
-✓ **Strategic positioning for this org/program**
-✓ **Front-loaded (key info in first half)**
-✓ **No generic corporate language**
-✓ **Grammar and clarity polished**
+✓ **Directly answers the question asked** ✓ **Within word limit (with 5-10 word buffer)** ✓ **Concrete examples, not vague claims** ✓ **Authentic voice maintained** ✓ **Consistent with past applications** ✓ **All claims verifiable from CV/past work** ✓ **Strategic positioning for this org/program** ✓ **Front-loaded (key info in first half)** ✓ **No generic corporate language** ✓ **Grammar and clarity polished**

--- a/claude/agents/code-reviewer.md
+++ b/claude/agents/code-reviewer.md
@@ -116,10 +116,4 @@ Your goal is to help ship high-quality, research-valid code while fostering a cu
 
 # COMPLEMENTARY REVIEW
 
-For significant changes (multi-file, auth, concurrency, data mutations), run
-`codex-companion review` (via the Monitor tool) in parallel for a second-model
-opinion. Codex reasoning models find concrete bugs (off-by-one, race
-conditions, logic errors) that complement the design/quality/CLAUDE.md focus of
-this reviewer. Use `codex-companion adversarial-review` to challenge design
-choices and assumptions. codex-companion is harness-tracked and orphan-safe,
-and runs from the main context — it cannot be wrapped by a subagent.
+For significant changes (multi-file, auth, concurrency, data mutations), run `codex-companion review` (via the Monitor tool) in parallel for a second-model opinion. Codex reasoning models find concrete bugs (off-by-one, race conditions, logic errors) that complement the design/quality/CLAUDE.md focus of this reviewer. Use `codex-companion adversarial-review` to challenge design choices and assumptions. codex-companion is harness-tracked and orphan-safe, and runs from the main context — it cannot be wrapped by a subagent.

--- a/claude/agents/context-fetcher.md
+++ b/claude/agents/context-fetcher.md
@@ -40,5 +40,4 @@ If multiple threads, lead with the most recent or most action-requiring. Cap at 
 
 ## If you find nothing
 
-Say: "No recent Gmail/Slack/Granola thread with [name] in last 60 days. Ask Yulong for context."
-Do not fabricate or speculate.
+Say: "No recent Gmail/Slack/Granola thread with [name] in last 60 days. Ask Yulong for context." Do not fabricate or speculate.

--- a/claude/agents/data-analyst.md
+++ b/claude/agents/data-analyst.md
@@ -261,11 +261,7 @@ When engaged to analyze results:
 
 7. **Assess Practical Significance**: Beyond statistical significance, are differences meaningful? Large enough to matter?
 
-8. **Sensitivity Check** (MANDATORY for every main finding): Run at least one:
-   (a) Drop top/bottom 5% outliers — does conclusion hold?
-   (b) Alternative aggregation (median vs mean, or different grouping) — same direction?
-   (c) Subset analysis — consistent across subgroups (models, datasets, time periods)?
-   If conclusion changes under any check, flag as FRAGILE in Trust Calibration.
+8. **Sensitivity Check** (MANDATORY for every main finding): Run at least one: (a) Drop top/bottom 5% outliers — does conclusion hold? (b) Alternative aggregation (median vs mean, or different grouping) — same direction? (c) Subset analysis — consistent across subgroups (models, datasets, time periods)? If conclusion changes under any check, flag as FRAGILE in Trust Calibration.
 
 9. **Document Analysis**: Save scripts, note random seeds, document choices made.
 
@@ -325,13 +321,11 @@ Structure analysis as:
 **Key Findings**
 1. [Main result with CI and significance test]
 2. [Secondary result with CI and significance test]
-3. [Additional findings]
-[Ordered by importance]
+3. [Additional findings] [Ordered by importance]
 
 **Visualizations**
 - [Plot 1 description]
-- [Plot 2 description]
-[Attached or described]
+- [Plot 2 description] [Attached or described]
 
 **Surprising/Concerning Patterns**
 - [Pattern 1]: Why it's surprising, what to investigate

--- a/claude/agents/debugger.md
+++ b/claude/agents/debugger.md
@@ -59,9 +59,4 @@ You are patient, thorough, and educational in your approach. You don't just fix 
 
 # COMPLEMENTARY DEBUGGING
 
-For bugs with clear reproduction steps and concrete error output, consider
-also delegating to `codex-companion` (via the Monitor tool). Codex reasoning
-models excel at tracing execution paths and finding off-by-one errors, race
-conditions, and logic bugs when given stack traces and minimal repro code. Use
-`debugger` (Claude) for systematic investigation; use `codex-companion` for
-focused execution-path analysis.
+For bugs with clear reproduction steps and concrete error output, consider also delegating to `codex-companion` (via the Monitor tool). Codex reasoning models excel at tracing execution paths and finding off-by-one errors, race conditions, and logic bugs when given stack traces and minimal repro code. Use `debugger` (Claude) for systematic investigation; use `codex-companion` for focused execution-path analysis.

--- a/claude/agents/efficient-explorer.md
+++ b/claude/agents/efficient-explorer.md
@@ -69,7 +69,7 @@ Explore codebases efficiently without polluting context. Uses a strict "search-f
 
 Return findings as:
 
-```markdown
+````markdown
 ## Summary
 [2-3 sentence answer to the question]
 
@@ -92,7 +92,7 @@ Return findings as:
 
 ## Not Explored (for follow-up)
 - [Areas that might need deeper investigation]
-```
+````
 
 # EXAMPLE INTERACTIONS
 

--- a/claude/agents/llm-billing.md
+++ b/claude/agents/llm-billing.md
@@ -8,8 +8,7 @@ tools: ["Bash"]
 
 You are an LLM billing analyst. Run the billing script and present results.
 
-For process details, environment variables, and troubleshooting, see:
-`~/.claude/docs/llm-billing-process.md`
+For process details, environment variables, and troubleshooting, see: `~/.claude/docs/llm-billing-process.md`
 
 **Quick start:** Run `cd "${DOT_DIR:-$HOME/code/dotfiles}" && uv run claude/agents/llm-billing.py` and show the output directly. Do not reformat or summarize.
 

--- a/claude/agents/research-skeptic.md
+++ b/claude/agents/research-skeptic.md
@@ -171,8 +171,7 @@ Structure critique as:
 **Critical Questions**
 1. [Assumption or confound to check]
 2. [Alternative explanation to rule out]
-3. [Validity concern to address]
-[Prioritized by severity]
+3. [Validity concern to address] [Prioritized by severity]
 
 **Specific Concerns**
 - [Concrete issue with evidence]
@@ -181,8 +180,7 @@ Structure critique as:
 
 **Suggested Validation Tests**
 - [Test 1]: What it checks, why it matters
-- [Test 2]: What it checks, why it matters
-[Ordered by importance/ease]
+- [Test 2]: What it checks, why it matters [Ordered by importance/ease]
 
 **Bottom Line**
 - Confidence level in findings (low/medium/high)

--- a/claude/docs/llm-billing-process.md
+++ b/claude/docs/llm-billing-process.md
@@ -31,11 +31,7 @@ If all providers show errors or missing keys, inform the user which environment 
 
 ### No org-admin access (common — not a bug)
 
-If you (the user) only have a project-scoped OpenAI key or a non-admin Anthropic key, the script will print
-`No data — needs an org/admin key` for that provider plus a manual dashboard URL. This is an API-level
-restriction, not something the script or agent can work around — there is no read-only "check my balance"
-endpoint for non-admin keys on either provider. The agent should relay this immediately and stop; it should
-not spend extra tool calls (e.g. probing `/v1/models`) trying to re-derive what's already a known limitation.
+If you (the user) only have a project-scoped OpenAI key or a non-admin Anthropic key, the script will print `No data — needs an org/admin key` for that provider plus a manual dashboard URL. This is an API-level restriction, not something the script or agent can work around — there is no read-only "check my balance" endpoint for non-admin keys on either provider. The agent should relay this immediately and stop; it should not spend extra tool calls (e.g. probing `/v1/models`) trying to re-derive what's already a known limitation.
 
 Manual balance/usage checks:
 - OpenAI: https://platform.openai.com/settings/organization/billing/overview (requires org owner/admin role)

--- a/claude/hooks/README.md
+++ b/claude/hooks/README.md
@@ -72,10 +72,7 @@ Hooks for automating task and agent management workflows.
 
 **Purpose:** Repair ignored plugin-cache problems before a session uses them.
 
-**Behavior:** Preserves marketplace shell executable bits and converts Ralph
-Loop 1.0.0's two plain-text successful `Stop` messages into JSON
-`systemMessage` objects. The Ralph repair validates both exact upstream lines,
-is atomic and idempotent, and refuses partial or unknown source drift.
+**Behavior:** Preserves marketplace shell executable bits and converts Ralph Loop 1.0.0's two plain-text successful `Stop` messages into JSON `systemMessage` objects. The Ralph repair validates both exact upstream lines, is atomic and idempotent, and refuses partial or unknown source drift.
 
 **Tests:** `test_patch_ralph_loop_stop_hook.sh`.
 

--- a/claude/rules/communication.md
+++ b/claude/rules/communication.md
@@ -2,7 +2,7 @@
 
 ## Writing
 
-One paragraph is ONE line in `.md` files — never a hard newline inside a paragraph. Blank lines separate paragraphs; readers soft-wrap. This covers prose, bullet bodies and table cells.
+One paragraph is ONE line in `.md` files — never a hard newline inside a paragraph. Blank lines separate paragraphs; readers soft-wrap. This covers prose, bullet bodies and table cells. `md-unwrap --check <path>` finds violations and `md-unwrap --fix <path>` repairs them; it gates staged Markdown under `claude/` in pre-commit and CI.
 
 **Todos and separate points are bullet lists, one item per line, sub-points nested** — in notes, plans, schedules and replies alike. Several items packed into one line with commas, semicolons or "then" is a list you have not drawn yet; a todo is its own `- [ ]` line so it can be ticked on its own. Bear-specific mechanics: `bear`.
 

--- a/claude/skills/deslop/SKILL.md
+++ b/claude/skills/deslop/SKILL.md
@@ -17,8 +17,7 @@ Check the diff in the working directory against the current branch, and remove a
 - Casts to `any` to get around type issues.
 - Any other style that is inconsistent with the file.
 
-**Report:**
-At the end, provide only a 1-3 sentence summary of what you changed.
+**Report:** At the end, provide only a 1-3 sentence summary of what you changed.
 
 ## Reach for a neighbour instead when
 

--- a/claude/skills/house-plots/references/matplotlib.md
+++ b/claude/skills/house-plots/references/matplotlib.md
@@ -85,32 +85,18 @@ ax.text(x, y, label, ha="center", va="bottom", fontweight="normal", fontsize=9)
 
 ### Plan the visual before you draw it
 
-This applies to every annotation, callout, ordering, and color choice — not
-just arrows. **Before writing any code**, write down the answers to:
+This applies to every annotation, callout, ordering, and color choice — not just arrows. **Before writing any code**, write down the answers to:
 
-1. **What single point does this make?** One sentence, the way you'd say it
-   out loud. *"On MATH, C³ catches sandbagging where TM misses — 51 pp gap."*
-   If you can't say it in one sentence, you're trying to make several points
-   at once; pick the one that matters most or split into multiple visuals.
-2. **What would a reader miss without this callout?** If the answer is
-   "nothing — they'd see it from the bars alone", drop the callout. Don't
-   annotate the obvious.
-3. **What's the most direct visual encoding of that point?** The answer falls
-   out of step 1. *"The gap is 51 pp"* → an object whose **length is the gap**.
-   *"This is the headline number"* → one arrow from a label to that number.
-   *"This region is special"* → shading, not an arrow.
-4. **Reading distance and time?** Poster-from-6ft and paper-from-1ft have
-   different budgets. A poster reader scans for ~3 seconds — the callout has
-   to register at a glance. A paper reader will study the figure; subtler
-   callouts work.
+1. **What single point does this make?** One sentence, the way you'd say it out loud. *"On MATH, C³ catches sandbagging where TM misses — 51 pp gap."* If you can't say it in one sentence, you're trying to make several points at once; pick the one that matters most or split into multiple visuals.
+2. **What would a reader miss without this callout?** If the answer is "nothing — they'd see it from the bars alone", drop the callout. Don't annotate the obvious.
+3. **What's the most direct visual encoding of that point?** The answer falls out of step 1. *"The gap is 51 pp"* → an object whose **length is the gap**. *"This is the headline number"* → one arrow from a label to that number. *"This region is special"* → shading, not an arrow.
+4. **Reading distance and time?** Poster-from-6ft and paper-from-1ft have different budgets. A poster reader scans for ~3 seconds — the callout has to register at a glance. A paper reader will study the figure; subtler callouts work.
 
-Only after answering 1–3 do you pick a shape. The table below is the lookup,
-not the thinking — don't skip the thinking.
+Only after answering 1–3 do you pick a shape. The table below is the lookup, not the thinking — don't skip the thinking.
 
 ### Callout shape lookup
 
-Pick the shape that encodes the claim directly. Don't reach for `arc3` curved
-arrows by default — they're for one specific case.
+Pick the shape that encodes the claim directly. Don't reach for `arc3` curved arrows by default — they're for one specific case.
 
 | Claim | Right shape | Wrong shape |
 |---|---|---|
@@ -119,9 +105,7 @@ arrows by default — they're for one specific case.
 | "This region matters" | Filled `axvspan` / shaded box | Arrow |
 | "These two things differ" | Bracket spanning both, label outside | Two separate annotations |
 
-For the **gap** case (most common in comparison bar charts), the double-headed
-arrow's *length* literally encodes the value. The reader sees "+51 pp" and the
-arrow length agreeing — that's the strongest possible visual:
+For the **gap** case (most common in comparison bar charts), the double-headed arrow's *length* literally encodes the value. The reader sees "+51 pp" and the arrow length agreeing — that's the strongest possible visual:
 
 ```python
 # Gap callout: arrow IS the gap.
@@ -136,28 +120,19 @@ ax.text(gap_x, c3_top + 3, "+51 pp gap",
         fontsize=13, fontweight="bold", color=CLAY)
 ```
 
-Place `gap_x` in the visually-empty band beside the bar pair (not on top of
-bars, not in another group's column). For grouped bars, that's typically just
-to the right of the second bar in the pair.
+Place `gap_x` in the visually-empty band beside the bar pair (not on top of bars, not in another group's column). For grouped bars, that's typically just to the right of the second bar in the pair.
 
 ### Curved callout arrows (`ax.annotate` with `connectionstyle`)
 
-Use these only when pointing *at* a single mark from a label sitting in empty
-space — not for showing a gap. Rules:
+Use these only when pointing *at* a single mark from a label sitting in empty space — not for showing a gap. Rules:
 
-1. **Never cross unrelated bars/lines/marks.** Locate the empty quadrant
-   above/beside/below the target first.
-2. **Anchor the text in that empty area**, with `ha`/`va` chosen so the text
-   block stays clear of bars.
-3. **`connectionstyle="arc3,rad=±N"`** — the rad sign chooses bulge direction;
-   pick whichever bulges *away* from any bar between start and end.
-4. **One arrow per claim.** Two arrows from the same label fan-out and read as
-   two separate annotations sharing a label — confusing.
-5. **Verify visually** at print scale. Curve fragility is invisible in code
-   review; a screenshot or PDF preview is mandatory before commit.
+1. **Never cross unrelated bars/lines/marks.** Locate the empty quadrant above/beside/below the target first.
+2. **Anchor the text in that empty area**, with `ha`/`va` chosen so the text block stays clear of bars.
+3. **`connectionstyle="arc3,rad=±N"`** — the rad sign chooses bulge direction; pick whichever bulges *away* from any bar between start and end.
+4. **One arrow per claim.** Two arrows from the same label fan-out and read as two separate annotations sharing a label — confusing.
+5. **Verify visually** at print scale. Curve fragility is invisible in code review; a screenshot or PDF preview is mandatory before commit.
 
-If text would clip a tall bar or whisker, **raise `ax.set_ylim` headroom**
-instead of squeezing the text into the bar.
+If text would clip a tall bar or whisker, **raise `ax.set_ylim` headroom** instead of squeezing the text into the bar.
 
 ### Multi-series line plot
 ```python

--- a/claude/skills/server-storage-tiering/SKILL.md
+++ b/claude/skills/server-storage-tiering/SKILL.md
@@ -5,27 +5,19 @@ description: "Relieve a full root disk on a server or cloud box with an attached
 
 # Server Storage Tiering
 
-Two jobs, often at once: **(A) organize storage with portable conventions**, and **(B) place
-each thing where its access pattern wants it.** The forcing function differs by platform but the
-method is the same: measure, exclude what's live, relocate cold data to the volume with a
-symlink left behind, verify.
+Two jobs, often at once: **(A) organize storage with portable conventions**, and **(B) place each thing where its access pattern wants it.** The forcing function differs by platform but the method is the same: measure, exclude what's live, relocate cold data to the volume with a symlink left behind, verify.
 
 ## Cardinal rules
 
-- **Never `rm` user data.** Relocate with `mv` (or `rsync --remove-source-files`), leave a
-  symlink at the original path, archive with `mv` to `/workspace/archive/`. `rmdir` (empty dirs
-  only) and `unlink` (a single symlink you created) are the only deletions allowed.
-- **Exclude live/hot directories first** — see [Live-writer gate](#the-live-writer-gate). This is
-  the rule that prevents the worst failures.
-- **Verify every relocation** before the next: the symlink resolves, the target is readable, the
-  live job is still alive, `df` moved the right way.
+- **Never `rm` user data.** Relocate with `mv` (or `rsync --remove-source-files`), leave a symlink at the original path, archive with `mv` to `/workspace/archive/`. `rmdir` (empty dirs only) and `unlink` (a single symlink you created) are the only deletions allowed.
+- **Exclude live/hot directories first** — see [Live-writer gate](#the-live-writer-gate). This is the rule that prevents the worst failures.
+- **Verify every relocation** before the next: the symlink resolves, the target is readable, the live job is still alive, `df` moved the right way.
 
 ---
 
 ## Pillar A — Conventions (portable layout)
 
-Goal: the same paths resolve on every box, so projects and configs don't care which machine
-they're on.
+Goal: the same paths resolve on every box, so projects and configs don't care which machine they're on.
 
 ### Expose the volume at `/workspace`
 ```bash
@@ -36,58 +28,38 @@ mkdir -p /workspace/{cache,share,outputs,archive,hf,torch,bun,projects-data}
 `/workspace` is the RunPod convention; adopting it everywhere gives path parity.
 
 ### Code/projects parity (direction flips by platform)
-- **Hetzner / bare-metal (root persists):** real dirs live in `$HOME`, add forward links for parity:
-  `ln -s ~/code /workspace/code`, `ln -s ~/projects /workspace/projects`.
-- **RunPod (container disk is ephemeral, `/workspace` persists):** real dirs live under
-  `/workspace`, and `~/code` → `/workspace/code`. The direction is reversed but **both paths
-  resolve in both environments.**
+- **Hetzner / bare-metal (root persists):** real dirs live in `$HOME`, add forward links for parity: `ln -s ~/code /workspace/code`, `ln -s ~/projects /workspace/projects`.
+- **RunPod (container disk is ephemeral, `/workspace` persists):** real dirs live under `/workspace`, and `~/code` → `/workspace/code`. The direction is reversed but **both paths resolve in both environments.**
 
 ### Relocate-with-symlink-back (the core move)
 ```bash
 mv  <src>           <dest-on-volume>
 ln -s <dest-on-volume> <src>
 ```
-Apps keep using their default path (`~/.cache/inspect_ai`, `~/.bun/install`); the symlink
-transparently redirects both old and new I/O to the volume. **No config edits, no env changes.**
-Store a relocated repo at `/workspace/<name>` (not under `/workspace/code`) so it doesn't form a
-loop with the `/workspace/code -> ~/code` link.
+Apps keep using their default path (`~/.cache/inspect_ai`, `~/.bun/install`); the symlink transparently redirects both old and new I/O to the volume. **No config edits, no env changes.** Store a relocated repo at `/workspace/<name>` (not under `/workspace/code`) so it doesn't form a loop with the `/workspace/code -> ~/code` link.
 
 ### Persistence
-- The **volume** must be in `/etc/fstab` (cloud providers usually add it; confirm). Look for the
-  `by-id` mount line; `nofail` is good practice so a missing volume doesn't block boot.
-- **Symlinks** at `$HOME`/`/` persist inherently (they live on the root fs). `chown` on the
-  volume persists (stored in the volume's own fs). So once fstab has the volume, nothing else
-  needs persisting.
+- The **volume** must be in `/etc/fstab` (cloud providers usually add it; confirm). Look for the `by-id` mount line; `nofail` is good practice so a missing volume doesn't block boot.
+- **Symlinks** at `$HOME`/`/` persist inherently (they live on the root fs). `chown` on the volume persists (stored in the volume's own fs). So once fstab has the volume, nothing else needs persisting.
 
 ### Forward env vars (optional, for *future* growth only)
-Set in the shell profile so new downloads land on the volume; needs a fresh shell to take effect.
-Not required for any relocation above.
+Set in the shell profile so new downloads land on the volume; needs a fresh shell to take effect. Not required for any relocation above.
 ```bash
 export HF_HOME=/workspace/hf
 export TORCH_HOME=/workspace/torch
 # Leave UV_CACHE_DIR / PIP_CACHE_DIR at local defaults — they're latency-sensitive and may host live venvs.
 ```
 
-**Already in dotfiles:** `config/aliases/storage.sh` (sourced by zshrc on every interactive
-shell) does this automatically when the volume exists — no manual profile edit needed. It
-deliberately **skips the export when the default cache path is already a symlink onto the
-volume** (a relocated `~/.cache/huggingface` redirects transparently; re-pointing `HF_HOME`
-would orphan the moved cache and force re-downloads), so an unset `HF_HOME` on a tiered box
-is correct, not a gap. The same file prints a one-line warning on shell start when root runs
-low. Scope boundary: zshrc-sourced env reaches interactive shells only — pueue daemons, cron
-and systemd services won't see it.
+**Already in dotfiles:** `config/aliases/storage.sh` (sourced by zshrc on every interactive shell) does this automatically when the volume exists — no manual profile edit needed. It deliberately **skips the export when the default cache path is already a symlink onto the volume** (a relocated `~/.cache/huggingface` redirects transparently; re-pointing `HF_HOME` would orphan the moved cache and force re-downloads), so an unset `HF_HOME` on a tiered box is correct, not a gap. The same file prints a one-line warning on shell start when root runs low. Scope boundary: zshrc-sourced env reaches interactive shells only — pueue daemons, cron and systemd services won't see it.
 
-**The mount point and the warning threshold are per-machine**, not hardcoded — boxes differ
-(`/workspace` on RunPod, `/mnt/<volume>` elsewhere, nothing on a laptop). They come from
-`config/storage.conf` (gitignored; `config/storage.conf.example` documents both keys):
+**The mount point and the warning threshold are per-machine**, not hardcoded — boxes differ (`/workspace` on RunPod, `/mnt/<volume>` elsewhere, nothing on a laptop). They come from `config/storage.conf` (gitignored; `config/storage.conf.example` documents both keys):
 
 | Key | Default | Meaning |
 |---|---|---|
 | `STORAGE_VOLUME` | `/workspace` | Volume mount point; every export is skipped when the path is absent |
 | `STORAGE_ROOT_WARN_GB` | `20` | Warn under this many GB free on `/`; `0` disables the warning |
 
-Write it with **`storage-setup`** (`custom_bins/`, on PATH), which `./deploy.sh --only storage`
-also runs on every Linux box:
+Write it with **`storage-setup`** (`custom_bins/`, on PATH), which `./deploy.sh --only storage` also runs on every Linux box:
 
 ```bash
 storage-setup                     # detect the volume, write config/storage.conf if absent
@@ -95,20 +67,13 @@ storage-setup --show              # what the shell fragment will actually use
 storage-setup --volume /mnt/data --threshold-gb 50 --force
 ```
 
-Detection prefers an existing `/workspace`, else the mounted block-device filesystem with the
-most free space, requiring at least 2x root's free space and at least 50G — so a second small
-disk or `/boot` never wins. It writes config only, never touching data, is idempotent (an
-existing config is left alone without `--force`), and treats "no volume here" as success.
+Detection prefers an existing `/workspace`, else the mounted block-device filesystem with the most free space, requiring at least 2x root's free space and at least 50G — so a second small disk or `/boot` never wins. It writes config only, never touching data, is idempotent (an existing config is left alone without `--force`), and treats "no volume here" as success.
 
 ---
 
 ## Pillar B — Latency-aware placement (tier by access pattern)
 
-An attached/network volume is **slower than local NVMe** — Hetzner Ceph is roughly ~10× slower
-in IOPS than local SSD; RunPod network volumes run ~200–400 MB/s vs local NVMe's GB/s. Both
-*persist*, so on persistent-root boxes (Hetzner, bare-metal) the move is purely a **capacity +
-latency** decision. On RunPod the container disk is *ephemeral*, so persistence is the forcing
-function instead — but the placement table is the same.
+An attached/network volume is **slower than local NVMe** — Hetzner Ceph is roughly ~10× slower in IOPS than local SSD; RunPod network volumes run ~200–400 MB/s vs local NVMe's GB/s. Both *persist*, so on persistent-root boxes (Hetzner, bare-metal) the move is purely a **capacity + latency** decision. On RunPod the container disk is *ephemeral*, so persistence is the forcing function instead — but the placement table is the same.
 
 | Keep on **local NVMe** (hot / latency-sensitive) | Move to **volume** (cold / sequential / at-rest) |
 |---|---|
@@ -117,10 +82,7 @@ function instead — but the placement table is the same.
 | Small hot tool caches (uv, pip, ruff) | Checkpoints, regenerable caches not in active use |
 | **Random-access hot dataloader** | Cold/sequential write-once data |
 
-**The staging rule (don't get this wrong):** symlink-in-place over the volume is correct *only
-for cold/sequential data*. A **hot random-access dataloader** symlinked to the volume bottlenecks
-on every read crossing the network. For those, **stage to local NVMe for the run** (`cp` the
-active shard local, train, delete the copy after) — keep the at-rest copy on the volume.
+**The staging rule (don't get this wrong):** symlink-in-place over the volume is correct *only for cold/sequential data*. A **hot random-access dataloader** symlinked to the volume bottlenecks on every read crossing the network. For those, **stage to local NVMe for the run** (`cp` the active shard local, train, delete the copy after) — keep the at-rest copy on the volume.
 
 ---
 
@@ -135,11 +97,7 @@ active shard local, train, delete the copy after) — keep the at-rest copy on t
 
 ### The live-writer gate
 
-**A directory with a live writer cannot be safely symlink-swapped.** Replacing a directory with a
-symlink is not atomic; if a process writes to it during the swap, you lose the race — new files
-reappear, `rmdir` fails, and a stray nested symlink gets created inside. Worse, a cross-filesystem
-`mv` changes inodes, so any process whose **cwd** is inside the dir, or which holds an **open file
-handle**, breaks.
+**A directory with a live writer cannot be safely symlink-swapped.** Replacing a directory with a symlink is not atomic; if a process writes to it during the swap, you lose the race — new files reappear, `rmdir` fails, and a stray nested symlink gets created inside. Worse, a cross-filesystem `mv` changes inodes, so any process whose **cwd** is inside the dir, or which holds an **open file handle**, breaks.
 
 Check immediately before each move — and know the check goes **stale in minutes**:
 ```bash
@@ -149,27 +107,18 @@ fd -t f --changed-within 15min . "$dir" | head        # recent writes
 ```
 Rules of thumb:
 - **Any open handle or cwd, or recent writes → do NOT move it.** Leave it local; revisit when idle.
-- A clean snapshot (0 handles, 0 recent writes) is necessary but **not a guarantee** — re-check
-  right before the move, and if the one-shot `mv` doesn't complete cleanly the first time
-  (rmdir-not-empty, stray nested symlink), the dir is hot: **stop and leave it local.** Don't
-  retry into a race.
-- Common live dirs to exclude on an ML box: the running launcher's interpreter
-  (`~/.local/share/uv`), live MCP/tool venvs (`~/.cache/uv`), any repo with an active editor/agent
-  session or running eval (writes to `~/.cache/<tool>`, `~/.local/share/<tool>`).
+- A clean snapshot (0 handles, 0 recent writes) is necessary but **not a guarantee** — re-check right before the move, and if the one-shot `mv` doesn't complete cleanly the first time (rmdir-not-empty, stray nested symlink), the dir is hot: **stop and leave it local.** Don't retry into a race.
+- Common live dirs to exclude on an ML box: the running launcher's interpreter (`~/.local/share/uv`), live MCP/tool venvs (`~/.cache/uv`), any repo with an active editor/agent session or running eval (writes to `~/.cache/<tool>`, `~/.local/share/<tool>`).
 
 ### Interrupted-move recovery
 
-A cross-fs `mv` killed mid-copy (e.g. a tool timeout) is **safe**: GNU `mv` copies the whole tree
-first and unlinks the source only after, so the source stays 100% intact and the dest holds a
-partial copy. Resume idempotently instead of restarting:
+A cross-fs `mv` killed mid-copy (e.g. a tool timeout) is **safe**: GNU `mv` copies the whole tree first and unlinks the source only after, so the source stays 100% intact and the dest holds a partial copy. Resume idempotently instead of restarting:
 ```bash
 rsync -a --remove-source-files "$src/" "$dest/"      # skips already-copied, unlinks source per-file after transfer
 fd -t d . "$src" | sort -r | xargs -r rmdir          # remove now-empty dirs deepest-first (children sort after parents)
 rmdir "$src" && ln -s "$dest" "$src"                 # if rmdir fails "not empty", a writer is active → it's hot (see gate)
 ```
-For dirs known to hold **many small files**, skip the foreground `mv` entirely and run the
-`rsync` in the background from the start — small-file copies over a network volume are slow and
-will blow a foreground timeout.
+For dirs known to hold **many small files**, skip the foreground `mv` entirely and run the `rsync` in the background from the start — small-file copies over a network volume are slow and will blow a foreground timeout.
 
 ---
 
@@ -184,6 +133,4 @@ will blow a foreground timeout.
 
 ## Outcome shape (what "done" looks like)
 
-Freed root by relocating cold data to the volume; left a symlink at every original path so apps
-need no reconfiguration; left every live/hot dir local and untouched. Anything not safely movable
-now (live writers) is documented for a later pass when those sessions are idle.
+Freed root by relocating cold data to the volume; left a symlink at every original path so apps need no reconfiguration; left every live/hot dir local and untouched. Anything not safely movable now (live writers) is documented for a later pass when those sessions are idle.

--- a/claude/skills/strategic-communication/SKILL.md
+++ b/claude/skills/strategic-communication/SKILL.md
@@ -79,21 +79,15 @@ After acknowledging emotions, use "How" and "What" questions:
 
 ## Key Principles From Voss
 
-**1. Label Emotions Constantly**
-Pattern: "It seems like..." / "It sounds like..." / "You're probably..."
-Then **pause** and let them respond.
+**1. Label Emotions Constantly** Pattern: "It seems like..." / "It sounds like..." / "You're probably..." Then **pause** and let them respond.
 
-**2. Accusation Audit - Name The Worst First**
-Say what they might think about you before they can: "You're going to think I'm being flaky..."
+**2. Accusation Audit - Name The Worst First** Say what they might think about you before they can: "You're going to think I'm being flaky..."
 
-**3. "I'm Sorry" Is a Tool, Not Weakness**
-Apologize for your impact on them, not for having needs.
+**3. "I'm Sorry" Is a Tool, Not Weakness** Apologize for your impact on them, not for having needs.
 
-**4. Three Types of "Yes"**
-Only Commitment Yes matters. Use no-oriented questions: "Would it be crazy to...?"
+**4. Three Types of "Yes"** Only Commitment Yes matters. Use no-oriented questions: "Would it be crazy to...?"
 
-**5. Slow Down and Smile**
-Creates trustworthiness and combats defensiveness.
+**5. Slow Down and Smile** Creates trustworthiness and combats defensiveness.
 
 ## Reference Files
 

--- a/claude/skills/strategic-communication/references/frameworks.md
+++ b/claude/skills/strategic-communication/references/frameworks.md
@@ -61,8 +61,7 @@ Example:
 
 Your BATNA is your walk-away power. Know it before negotiating, but don't lead with it in collaborative contexts.
 
-Strong BATNA example: "I have 3 other viewings this weekend"
-Weak BATNA example: "I desperately need a place by Monday"
+Strong BATNA example: "I have 3 other viewings this weekend" Weak BATNA example: "I desperately need a place by Monday"
 
 **In collaborative mode**: Use BATNA internally to know your limits, but don't weaponize it.
 **In competitive mode**: Reveal strong BATNAs to create urgency.
@@ -108,9 +107,7 @@ Questions that give the other person control while guiding the conversation towa
 
 Repeat their last 2-3 words as a question to encourage elaboration.
 
-Them: "This deadline is going to be really tight with current resources"
-You: "Current resources?"
-Them: [Usually explains the real constraint]
+Them: "This deadline is going to be really tight with current resources" You: "Current resources?" Them: [Usually explains the real constraint]
 
 **Warning**: Overuse makes you sound like a parrot. Use sparingly when you genuinely need more information.
 
@@ -122,8 +119,7 @@ Being warm doesn't mean being unclear. You can be both kind and direct.
 
 **Pattern**: [Warm acknowledgment] + [Clear request] + [Easy response option]
 
-**Example:**
-"I know you're swamped - could you send me the retention data by Friday? If that's too tight, let me know what works."
+**Example:** "I know you're swamped - could you send me the retention data by Friday? If that's too tight, let me know what works."
 
 **NOT**: "Sorry to bother you, I was wondering if maybe when you get a chance you could possibly..."
 
@@ -133,8 +129,7 @@ Sometimes you need to hold a boundary or be clear about limits:
 
 **Pattern**: [Acknowledge their position] + [State your reality] + [Offer what you can]
 
-**Example:**
-"I totally get that 6 months works better for you. I can only commit through February, but I'm happy to help you find the next tenant before I leave if that helps."
+**Example:** "I totally get that 6 months works better for you. I can only commit through February, but I'm happy to help you find the next tenant before I leave if that helps."
 
 **What this does**: 
 - Shows you heard them
@@ -145,8 +140,7 @@ Sometimes you need to hold a boundary or be clear about limits:
 
 When you need to back out or change plans:
 
-**Your original instinct was right:**
-"I previously said yes, but this other place with 2 toilets is just too hard to give up. You're obviously annoyed by this, but I hope you understand."
+**Your original instinct was right:** "I previously said yes, but this other place with 2 toilets is just too hard to give up. You're obviously annoyed by this, but I hope you understand."
 
 **Why this works:**
 1. Honest about what changed

--- a/claude/skills/sweep-ai-safety/SKILL.md
+++ b/claude/skills/sweep-ai-safety/SKILL.md
@@ -68,29 +68,15 @@ The script does NOT trust `rss:` blindly — on first run, it reports which feed
 
 Most curated orgs do **not** expose a working RSS feed. Live-verified state:
 
-- **RSS lane** (have a real feed, fetched by the feed reader): `openai-blog`,
-  `openai-alignment`, `metr`, `redwood`. These are the only sources that produce
-  items from a plain `sweep.py` run.
-- **Scrape lane** (`rss: null`, no usable feed — fetched via WebFetch on the landing
-  url): `anthropic-alignment`, `anthropic-redteam`, `anthropic-research`, `openai-safety`,
-  `apollo`, `transluce`, `deepmind-safety`, `far-ai`, `truthful-ai`, `owain-evans`,
-  `alphaxiv-safety`. Anthropic (both blogs) and Apollo are SPAs/404 — their `/rss.xml`
-  serves HTML, not XML.
-- **arXiv** (`arxiv-terms`): scrape-lane by the rss-null convention, but fetched by the
-  script's dedicated arXiv export-API path, not the generic WebFetch scrape step.
+- **RSS lane** (have a real feed, fetched by the feed reader): `openai-blog`, `openai-alignment`, `metr`, `redwood`. These are the only sources that produce items from a plain `sweep.py` run.
+- **Scrape lane** (`rss: null`, no usable feed — fetched via WebFetch on the landing url): `anthropic-alignment`, `anthropic-redteam`, `anthropic-research`, `openai-safety`, `apollo`, `transluce`, `deepmind-safety`, `far-ai`, `truthful-ai`, `owain-evans`, `alphaxiv-safety`. Anthropic (both blogs) and Apollo are SPAs/404 — their `/rss.xml` serves HTML, not XML.
+- **arXiv** (`arxiv-terms`): scrape-lane by the rss-null convention, but fetched by the script's dedicated arXiv export-API path, not the generic WebFetch scrape step.
 
-**A scrape-lane source returning 0 items is EXPECTED** from a plain `sweep.py` run —
-the script only reads RSS feeds. Those sources surface only when the scrape step runs
-(WebFetch the `url`). Treat "0 items from a scrape-lane source" as "not fetched", not
-"nothing published". The scrape-lane fetch implementation lands in a later phase; until
-then, scrape-lane sources are checked manually via WebFetch (see reference-mode workflow).
+**A scrape-lane source returning 0 items is EXPECTED** from a plain `sweep.py` run — the script only reads RSS feeds. Those sources surface only when the scrape step runs (WebFetch the `url`). Treat "0 items from a scrape-lane source" as "not fetched", not "nothing published". The scrape-lane fetch implementation lands in a later phase; until then, scrape-lane sources are checked manually via WebFetch (see reference-mode workflow).
 
 ### Zotero (dedup + sink)
 
-Zotero is **not** a fetch source. It's the dedup reference (what's already been
-collected) and the storage sink (where surfaced items land). It's handled by the
-downstream pipeline, not by the sweep fetch itself — `sweep.py` neither reads from
-nor writes to Zotero.
+Zotero is **not** a fetch source. It's the dedup reference (what's already been collected) and the storage sink (where surfaced items land). It's handled by the downstream pipeline, not by the sweep fetch itself — `sweep.py` neither reads from nor writes to Zotero.
 
 ### Topic glossary (`terms.md`)
 
@@ -143,8 +129,4 @@ This skill surfaces candidates. **Always verify before acting on a finding:**
 - **Add a tracked term**: append to `terms.md` with a one-line definition; optionally add to `sources.yaml` `arxiv_search_terms:` for arXiv inclusion
 - **Different cadence**: pass `--since 14d` / `--since 30d`; or schedule via `/loop 14d /sweep-ai-safety` (or as a routine via `/schedule`)
 - **JSON output for programmatic use**: pass `--json` (emits one item per line, NDJSON)
-- **Conference papers**: the weekly sweep relies on arXiv catching venue cross-posts —
-  tag an item with its venue when the arXiv `comment` field names one (e.g. "Accepted at
-  NeurIPS 2025"). A separate episodic `--conference <venue>` roundup mode (scraping
-  accepted-paper lists plus safety workshops like SoLaR) is planned for when proceedings
-  drop — NeurIPS/ICLR/ICML land ~3x/year, not weekly, so it doesn't belong in the weekly cadence.
+- **Conference papers**: the weekly sweep relies on arXiv catching venue cross-posts — tag an item with its venue when the arXiv `comment` field names one (e.g. "Accepted at NeurIPS 2025"). A separate episodic `--conference <venue>` roundup mode (scraping accepted-paper lists plus safety workshops like SoLaR) is planned for when proceedings drop — NeurIPS/ICLR/ICML land ~3x/year, not weekly, so it doesn't belong in the weekly cadence.

--- a/claude/skills/sweep-ai-safety/terms.md
+++ b/claude/skills/sweep-ai-safety/terms.md
@@ -1,8 +1,6 @@
 # AI safety topic glossary
 
-Terms tracked by `sweep-ai-safety`. Each entry is a one-sentence working definition
-plus a seminal-or-canonical anchor (paper, blog post, or research group). These are
-*starting points* — verify the anchor before citing.
+Terms tracked by `sweep-ai-safety`. Each entry is a one-sentence working definition plus a seminal-or-canonical anchor (paper, blog post, or research group). These are *starting points* — verify the anchor before citing.
 
 > Format: **term** (aliases) — definition. *Anchor:* link / org.
 

--- a/claude/templates/research-spec.md
+++ b/claude/templates/research-spec.md
@@ -49,8 +49,7 @@
 ## 1. Problem Statement & Theory of Change
 
 ### Core Research Question
-[What specific question are you trying to answer? Be precise, measurable, and action-relevant.
-Ask yourself: "If I answer this, what will change?"]
+[What specific question are you trying to answer? Be precise, measurable, and action-relevant. Ask yourself: "If I answer this, what will change?"]
 
 ### Theory of Change
 [How will answering this question lead to real-world impact? What's your causal chain from research → knowledge → action → impact?]

--- a/config/git-hooks/pre-commit
+++ b/config/git-hooks/pre-commit
@@ -233,11 +233,65 @@ while IFS= read -r _staged_file; do
     esac
 done < <(git diff --cached --name-only 2>/dev/null)
 
+# === MARKDOWN HARD-WRAP CHECK ===
+#
+# One paragraph is ONE line in Markdown (claude/rules/communication.md). A hard
+# newline inside a paragraph turns every later edit into a reflow diff, so the
+# rule is gated rather than merely written down.
+#
+# Scoped deliberately to staged Markdown under claude/, because this hook is
+# global (core.hooksPath) and must never block work in an unrelated repo. The
+# STAGED content is what is checked — `git show :file` — so a fixed working tree
+# with a stale index still fails, which is the point of a pre-commit gate.
+
+_check_markdown_hard_wrap() {
+    local repo_root="$1"
+
+    local checker=""
+    if [ -x "${repo_root}/custom_bins/md-unwrap" ]; then
+        checker="${repo_root}/custom_bins/md-unwrap"
+    elif command -v md-unwrap &>/dev/null; then
+        checker="md-unwrap"
+    else
+        return 0  # not this repo, or not deployed yet — nothing to enforce
+    fi
+
+    local staged_md
+    staged_md=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null \
+        | grep -E '^claude/.*\.md$' || true)
+    [ -z "${staged_md}" ] && return 0
+
+    local offenders=""
+    while IFS= read -r _md; do
+        [ -z "${_md}" ] && continue
+        if ! git show ":${_md}" 2>/dev/null | "${checker}" --check --quiet - 2>/dev/null; then
+            offenders="${offenders}      ${_md}\n"
+        fi
+    done <<< "${staged_md}"
+
+    [ -z "${offenders}" ] && return 0
+
+    echo ""
+    echo "⛔  Pre-commit: hard-wrapped Markdown paragraphs staged"
+    printf "%b" "${offenders}"
+    echo ""
+    echo "    One paragraph is ONE line — no hard newline inside a paragraph."
+    echo "    Fix and re-stage:"
+    echo ""
+    echo "      ${checker} --fix <file> && git add <file>"
+    echo ""
+    echo "    To bypass: git commit --no-verify"
+    echo ""
+    return 1
+}
+
 # === REPO-SPECIFIC HOOKS (Additive) ===
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
 if [ -n "$REPO_ROOT" ]; then
+    _check_markdown_hard_wrap "$REPO_ROOT" || exit 1
+
     # Check for pre-commit framework config
     if [ -f "$REPO_ROOT/.pre-commit-config.yaml" ] && command -v pre-commit &> /dev/null; then
         echo "Running repo's pre-commit framework hooks..."

--- a/custom_bins/md-unwrap
+++ b/custom_bins/md-unwrap
@@ -16,7 +16,8 @@ corrupts documentation:
   - fenced code blocks (``` and ~~~) and indented code blocks (4+ spaces)
   - raw HTML blocks for <pre>, <script>, <style> and <textarea>, protected all
     the way to their closing tag (a blank line inside one does not end it)
-  - tables (any line carrying a pipe)
+  - tables (any line carrying a pipe) — but a block start is recognised first,
+    so an opening <pre> or <!-- carrying a pipe still enters its block
   - YAML frontmatter
   - headings (ATX and setext), thematic breaks, blockquotes
   - link reference definitions and HTML blocks
@@ -123,11 +124,13 @@ def merge_indices(lines: list[str]) -> list[int]:
             index += 1
             continue
 
-        if "|" in stripped:  # table row, or prose too pipe-heavy to risk
-            prev_text = False
-            index += 1
-            continue
-
+        # An HTML block start is recognised BEFORE the pipe-and-table exclusion
+        # below, because it is the guard that installs protection STATE. While
+        # the pipe heuristic ran first, an opening tag carrying a pipe — in an
+        # attribute value, or in content on the same line — was taken by the
+        # heuristic and returned early, so the block was never entered and every
+        # line of it was joined as ordinary prose. The exclusion below only ever
+        # skips one line, so losing it to an HTML start costs nothing.
         if HTML_START_RE.match(line):
             raw = HTML_RAW_RE.match(line)
             if stripped.startswith("<!--"):
@@ -142,6 +145,11 @@ def merge_indices(lines: list[str]) -> list[int]:
                 html_end = None if closer in line.lower() else closer
             else:
                 html_end = "blank"
+            prev_text = False
+            index += 1
+            continue
+
+        if "|" in stripped:  # table row, or prose too pipe-heavy to risk
             prev_text = False
             index += 1
             continue

--- a/custom_bins/md-unwrap
+++ b/custom_bins/md-unwrap
@@ -46,8 +46,9 @@ text rather than structure:
 
 A one-line paragraph is never a violation — shortness is not wrapping.
 
-If the document ends inside a code fence or a raw HTML block, its structure was
-not understood: it is reported and left untouched.
+If the document ends inside a code fence, or holds an HTML block whose closing
+delimiter is nowhere to be found, its structure was not understood: the file is
+reported and left untouched rather than rewritten around a guess.
 
 Exit codes: 0 clean (or fixed), 1 violations found under --check, 2 usage error.
 """
@@ -65,6 +66,8 @@ HARD_BREAK_RE = re.compile(r"(?:  +|\\)$")
 LABEL_RE = re.compile(r"^ {0,3}(?:\*\*|__)[^*_]+(?:\*\*|__)\s*:")
 LIST_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
 RAW_HTML_RE = re.compile(r"^<(script|pre|style|textarea)\b", re.IGNORECASE)
+DECLARATION_RE = re.compile(r"^<![A-Za-z]")
+RAW_CLOSERS = ("</script>", "</pre>", "</style>", "</textarea>")
 
 DEFAULT_EXCLUDES = (".git", "node_modules", ".venv", "__pycache__")
 
@@ -101,67 +104,101 @@ def _frontmatter_end(lines: list[str]) -> int:
     return min(index + 1, len(lines))
 
 
-def _html_terminator(content: str) -> str | None:
-    """The closing delimiter an HTML block needs, or None if a blank line ends it."""
+def _html_enders(content: str) -> tuple[str, ...] | None:
+    """The delimiters that close this HTML block, or None if a blank line does.
+
+    CommonMark gives five of its seven HTML block types an explicit end
+    condition — a line CONTAINING the delimiter — and ends the other two at a
+    blank line, which cannot go missing. All five are listed here, the block's
+    own closer first so a refusal can name it. Recognising only two of them
+    (raw tags and comments) is what let a list-contained CDATA section,
+    processing instruction or markup declaration be read as blank-line
+    terminated and have its second half joined as prose.
+    """
     opening = content.split("\n", 1)[0].lstrip()
-    if opening.startswith("<!--"):
-        return "-->"
-    raw = RAW_HTML_RE.match(opening)
-    # CommonMark HTML block type 1: <pre>, <script>, <style> and <textarea> run
-    # to their closing tag. Every other type ends at a blank line, which cannot
-    # go missing.
-    return f"</{raw.group(1).lower()}>" if raw else None
+    if opening.startswith("<!--"):                       # type 2
+        return ("-->",)
+    if opening.startswith("<![CDATA["):                   # type 5
+        return ("]]>",)
+    if opening.startswith("<?"):                          # type 3
+        return ("?>",)
+    if DECLARATION_RE.match(opening):                     # type 4
+        return (">",)
+    raw = RAW_HTML_RE.match(opening)                      # type 1
+    if raw:
+        own = f"</{raw.group(1).lower()}>"
+        return (own, *(closer for closer in RAW_CLOSERS if closer != own))
+    return None                                           # types 6 and 7
 
 
-def _refusal(tokens, lines: list[str], offset: int) -> str | None:
-    """Why the document ran off the end of a block, or None if it did not."""
+def _ends_in(text: str, enders: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(ender in lowered for ender in enders)
+
+
+def _closed_by_its_container(tokens, position: int) -> bool:
+    """Whether the block at `position` was the last thing inside its container.
+
+    A container ends the block it holds, so a raw HTML block whose closing
+    delimiter never appears still has a known extent when markdown-it closed
+    the list item or blockquote around it on the next token: cmark-gfm reads
+    `> <pre>` followed by unquoted prose the same way.
+    """
+    following = tokens[position + 1] if position + 1 < len(tokens) else None
+    return following is not None and following.type in (
+        "list_item_close", "bullet_list_close", "ordered_list_close", "blockquote_close",
+    )
+
+
+def _unterminated_fence(tokens, lines: list[str], offset: int) -> str | None:
+    """Why the document ran off the end of a code fence, or None if it did not."""
     total = len(lines)
     for token in tokens:
-        if token.map is None or token.map[1] + offset != total:
+        if token.type != "fence" or token.map is None or token.map[1] + offset != total:
             continue
-        opened = token.map[0] + offset + 1
-        if token.type == "fence":
-            char = re.escape(token.markup[0])
-            closer = re.compile(rf"^[ \t>]*{char}{{{len(token.markup)},}}[ \t]*$")
-            if not closer.match(lines[total - 1]):
-                return f"unterminated code fence opened at line {opened}"
-        elif token.type == "html_block":
-            end = _html_terminator(token.content)
-            if end and end not in token.content.lower():
-                return f"unterminated HTML block ({end}) opened at line {opened}"
+        char = re.escape(token.markup[0])
+        closer = re.compile(rf"^[ \t>]*{char}{{{len(token.markup)},}}[ \t]*$")
+        if not closer.match(lines[total - 1]):
+            return f"unterminated code fence opened at line {token.map[0] + offset + 1}"
     return None
 
 
-def _raw_html_continuations(tokens, lines: list[str], offset: int) -> set[int]:
-    """Lines markdown-it cut out of a raw HTML block that CommonMark keeps in it.
+def _html_block_extents(tokens, lines: list[str], offset: int) -> tuple[set[int], str | None]:
+    """(lines markdown-it cut out of an HTML block CommonMark keeps in it, refusal).
 
     Measured on 2026-09-11 against reference cmark-gfm (cmarkgfm 2025.10.22):
-    markdown-it ends an HTML block at a blank line even for <pre>, <script>,
-    <style>, <textarea> and comments, which CommonMark runs to their closing
-    delimiter — measured on markdown-it-py 3.0.0 and 4.2.0. The divergence needs a
-    genuinely blank line inside a LIST item — a fence, a blockquote alone, or a
-    blank-terminated block type is unaffected — and it splits one block into a
-    block plus a paragraph, which would then be joined.
+    markdown-it ends an HTML block at a blank line even for the five types
+    CommonMark runs to a closing delimiter — measured on markdown-it-py 3.0.0
+    and 4.2.0. The divergence needs a genuinely blank line inside a LIST item —
+    a fence, a blockquote alone, or a blank-terminated block type is unaffected
+    — and it splits one block into a block plus a paragraph, which would then be
+    joined.
 
-    So when such a token's own content lacks its terminator, and the terminator
-    does appear further down, the lines up to it are part of the block. When it
-    appears nowhere, markdown-it's reading stands: the block genuinely ended
-    with its container (`> <pre>` followed by unquoted prose).
+    So when such a token's own content lacks its closing delimiter, and the
+    delimiter does appear further down, the lines up to it are part of the
+    block and are protected. When it appears NOWHERE the extent is unknown, and
+    the file is refused rather than rewritten around a guess — unless the
+    container closed the block itself, which is an extent the parser did
+    establish.
     """
     protected: set[int] = set()
-    for token in tokens:
+    for position, token in enumerate(tokens):
         if token.type != "html_block" or token.map is None:
             continue
-        end = _html_terminator(token.content)
-        if not end or end in token.content.lower():
+        enders = _html_enders(token.content)
+        if not enders or _ends_in(token.content, enders):
             continue
         span: list[int] = []
         for index in range(token.map[1] + offset, len(lines)):
             span.append(index)
-            if end in lines[index].lower():
+            if _ends_in(lines[index], enders):
                 protected.update(span)
                 break
-    return protected
+        else:
+            if not _closed_by_its_container(tokens, position):
+                opened = token.map[0] + offset + 1
+                return set(), f"unterminated HTML block ({enders[0]}) opened at line {opened}"
+    return protected, None
 
 
 def _paragraph_ranges(tokens) -> list[tuple[int, int]]:
@@ -205,10 +242,12 @@ def scan(lines: list[str]) -> tuple[list[int], str | None]:
     offset = _frontmatter_end(lines)
     body = lines[offset:]
     tokens = PARSER.parse("\n".join(body) + "\n") if body else []
-    refusal = _refusal(tokens, lines, offset)
+    refusal = _unterminated_fence(tokens, lines, offset)
     if refusal:
         return [], refusal
-    protected = _raw_html_continuations(tokens, lines, offset)
+    protected, refusal = _html_block_extents(tokens, lines, offset)
+    if refusal:
+        return [], refusal
     merges: list[int] = []
     for start, end in _paragraph_ranges(tokens):
         start, end = start + offset, end + offset

--- a/custom_bins/md-unwrap
+++ b/custom_bins/md-unwrap
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Detect and repair hard-wrapped Markdown paragraphs.
+
+    md-unwrap --check claude/                 # exit 1 if any paragraph is hard-wrapped
+    md-unwrap --fix claude/rules/foo.md       # join the wrapped lines back together
+    git show :some.md | md-unwrap --check -   # check staged content
+
+The house rule (claude/rules/communication.md) is that one paragraph is ONE line
+in Markdown: no hard newline inside a paragraph, in prose, bullet bodies or table
+cells. Readers soft-wrap; a hard wrap makes every later edit a reflow diff.
+
+A violation is a text line that continues the previous text line. Everything that
+is not flowing prose is left strictly alone, because a wrong join silently
+corrupts documentation:
+
+  - fenced code blocks (``` and ~~~) and indented code blocks (4+ spaces)
+  - tables (any line carrying a pipe)
+  - YAML frontmatter
+  - headings (ATX and setext), thematic breaks, blockquotes
+  - link reference definitions and HTML blocks
+  - a line ending in an explicit hard break (two trailing spaces, or a backslash)
+  - list item markers: a wrapped list body is joined, but the marker line stays a
+    line of its own, so list structure survives
+  - lines opening with a bolded label ("**When to use**: …"), which are one point
+    per line by intent rather than a wrap
+
+A one-line paragraph is never a violation — shortness is not wrapping.
+
+Exit codes: 0 clean (or fixed), 1 violations found under --check, 2 usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+FENCE_RE = re.compile(r"^(?P<indent> {0,3})(?P<fence>`{3,}|~{3,})")
+ATX_RE = re.compile(r"^ {0,3}#{1,6}(?:\s|$)")
+THEMATIC_RE = re.compile(r"^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$")
+SETEXT_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
+LIST_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
+LINK_DEF_RE = re.compile(r"^ {0,3}\[[^\]]+\]:")
+HTML_START_RE = re.compile(r"^ {0,3}<")
+HTML_RAW_RE = re.compile(r"^ {0,3}<(?:script|pre|style|textarea)\b", re.IGNORECASE)
+HARD_BREAK_RE = re.compile(r"(?:  +|\\)$")
+LABEL_RE = re.compile(r"^ {0,3}(?:\*\*|__)[^*_]+(?:\*\*|__)\s*:")
+
+DEFAULT_EXCLUDES = (".git", "node_modules", ".venv", "__pycache__")
+
+
+def _indent_width(line: str) -> int:
+    width = 0
+    for char in line:
+        if char == " ":
+            width += 1
+        elif char == "\t":
+            width += 4 - (width % 4)
+        else:
+            break
+    return width
+
+
+def merge_indices(lines: list[str]) -> list[int]:
+    """Indices of lines that continue the previous line and should be joined to it."""
+    merges: list[int] = []
+    total = len(lines)
+    index = 0
+
+    # YAML frontmatter: only when the very first line opens it.
+    if total and lines[0].rstrip() == "---":
+        index = 1
+        while index < total and lines[index].rstrip() not in ("---", "..."):
+            index += 1
+        index = min(index + 1, total)
+
+    fence: tuple[str, int] | None = None
+    html_end: str | None = None  # None, "blank", or a closing tag to look for
+    prev_text = False  # the previous line is a paragraph/list body we could join onto
+    prev_hard_break = False
+
+    while index < total:
+        line = lines[index]
+        stripped = line.strip()
+
+        if fence is not None:
+            char, length = fence
+            closer = re.match(r"^ {0,3}(" + re.escape(char) + r"{" + str(length) + r",})[ \t]*$", line)
+            if closer:
+                fence = None
+            index += 1
+            continue
+
+        if html_end is not None:
+            if html_end == "blank":
+                if not stripped:
+                    html_end = None
+            elif html_end.lower() in line.lower():
+                html_end = None
+            index += 1
+            continue
+
+        if not stripped:
+            prev_text = False
+            index += 1
+            continue
+
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group("fence")
+            fence = (marker[0], len(marker))
+            prev_text = False
+            index += 1
+            continue
+
+        # Indented code, or a list continuation deep enough to be ambiguous with it.
+        if _indent_width(line) >= 4:
+            prev_text = False
+            index += 1
+            continue
+
+        if "|" in stripped:  # table row, or prose too pipe-heavy to risk
+            prev_text = False
+            index += 1
+            continue
+
+        if HTML_START_RE.match(line):
+            if stripped.startswith("<!--"):
+                html_end = None if "-->" in stripped else "-->"
+            elif HTML_RAW_RE.match(line):
+                html_end = "blank"
+            else:
+                html_end = "blank"
+            prev_text = False
+            index += 1
+            continue
+
+        if LINK_DEF_RE.match(line):
+            prev_text = False
+            index += 1
+            continue
+
+        if ATX_RE.match(line) or THEMATIC_RE.match(line):
+            prev_text = False
+            index += 1
+            continue
+
+        if prev_text and SETEXT_RE.match(line):  # setext heading underline
+            prev_text = False
+            index += 1
+            continue
+
+        if stripped.startswith(">"):
+            prev_text = False
+            index += 1
+            continue
+
+        # A bolded label at the head of a line ("**When to use**: …") is a
+        # labelled item, not a wrapped continuation — the house rule wants one
+        # such point per line. Treat it like a list marker: it starts a logical
+        # line, and its own wrapped body still gets joined onto it.
+        if LIST_RE.match(line) or LABEL_RE.match(line):
+            prev_text = True
+            prev_hard_break = bool(HARD_BREAK_RE.search(line.rstrip("\n")))
+            index += 1
+            continue
+
+        if prev_text and not prev_hard_break:
+            merges.append(index)
+        prev_text = True
+        prev_hard_break = bool(HARD_BREAK_RE.search(line.rstrip("\n")))
+        index += 1
+
+    return merges
+
+
+def unwrap(text: str) -> tuple[str, list[int], int]:
+    """Return (fixed text, merged line numbers (1-based), paragraph count)."""
+    newline = "\r\n" if "\r\n" in text else "\n"
+    ends_with_newline = text.endswith(("\n", "\r"))
+    lines = text.splitlines()
+    merges = merge_indices(lines)
+    if not merges:
+        return text, [], 0
+
+    merge_set = set(merges)
+    out: list[str] = []
+    for index, line in enumerate(lines):
+        if index in merge_set and out:
+            out[-1] = out[-1].rstrip() + " " + line.strip()
+        else:
+            out.append(line)
+
+    paragraphs = sum(1 for i in merges if (i - 1) not in merge_set)
+    fixed = newline.join(out) + (newline if ends_with_newline else "")
+    return fixed, [i + 1 for i in merges], paragraphs
+
+
+def iter_markdown(paths: list[str]) -> list[Path]:
+    found: list[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            for child in sorted(path.rglob("*.md")):
+                if any(part in DEFAULT_EXCLUDES for part in child.parts):
+                    continue
+                found.append(child)
+        else:
+            found.append(path)
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="md-unwrap",
+        description="Detect (--check) or repair (--fix) hard-wrapped Markdown paragraphs.",
+        epilog="Files or directories; '-' reads stdin. Directories are searched for *.md.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="report violations, exit 1 if any (default)")
+    mode.add_argument("--fix", action="store_true", help="rewrite the files in place")
+    parser.add_argument("--exclude", action="append", default=[], metavar="SUBSTRING",
+                        help="skip any path containing SUBSTRING (repeatable)")
+    parser.add_argument("-q", "--quiet", action="store_true", help="print only the summary")
+    parser.add_argument("paths", nargs="+", help="Markdown files, directories, or '-'")
+    args = parser.parse_args(argv)
+
+    if args.paths == ["-"]:
+        text = sys.stdin.read()
+        fixed, merged, paragraphs = unwrap(text)
+        if args.fix:
+            sys.stdout.write(fixed)
+            return 0
+        if merged:
+            if not args.quiet:
+                print(f"<stdin>: {len(merged)} wrapped line(s) in {paragraphs} paragraph(s): "
+                      f"{', '.join(str(n) for n in merged[:20])}", file=sys.stderr)
+            return 1
+        return 0
+
+    targets = iter_markdown(args.paths)
+    if args.exclude:
+        targets = [p for p in targets if not any(token in str(p) for token in args.exclude)]
+
+    bad_files = 0
+    total_lines = 0
+    total_paragraphs = 0
+    for path in targets:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"md-unwrap: cannot read {path}: {exc}", file=sys.stderr)
+            return 2
+        fixed, merged, paragraphs = unwrap(text)
+        if not merged:
+            continue
+        bad_files += 1
+        total_lines += len(merged)
+        total_paragraphs += paragraphs
+        if args.fix:
+            path.write_text(fixed, encoding="utf-8")
+            if not args.quiet:
+                print(f"fixed {path}: {paragraphs} paragraph(s), {len(merged)} line(s) joined")
+        elif not args.quiet:
+            shown = ", ".join(str(n) for n in merged[:10])
+            more = " …" if len(merged) > 10 else ""
+            print(f"{path}: hard-wrapped paragraph continues at line(s) {shown}{more}")
+
+    if args.fix:
+        if not args.quiet:
+            print(f"md-unwrap: fixed {bad_files} file(s), {total_paragraphs} paragraph(s), "
+                  f"{total_lines} line(s) joined")
+        return 0
+
+    if bad_files:
+        print(f"md-unwrap: {bad_files} file(s) with hard-wrapped paragraphs "
+              f"({total_paragraphs} paragraph(s), {total_lines} line(s)). "
+              f"Fix with: md-unwrap --fix <path>", file=sys.stderr)
+        return 1
+    if not args.quiet:
+        print(f"md-unwrap: {len(targets)} file(s) clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/custom_bins/md-unwrap
+++ b/custom_bins/md-unwrap
@@ -30,6 +30,19 @@ corrupts documentation:
 
 A one-line paragraph is never a violation — shortness is not wrapping.
 
+Blocks nest. A fence or an HTML element is recognised relative to its CONTAINER
+— written directly after a list marker, at a list item's continuation column, or
+inside a blockquote — because CommonMark measures a block start from the
+container's content column and calls four columns past it indented code. The
+closing delimiter is measured against the same column, and a line that dedents
+out of the item or leaves the blockquote closes what was opened inside it.
+Handled: a list item, a blockquote, a list inside a blockquote, and any depth of
+list nesting. NOT handled, and left alone rather than joined: a construct
+indented four or more columns past its container (CommonMark reads it as
+indented code, and so do we), and a fence indented under a paragraph
+continuation. If a fence or a raw HTML block is still open at the end of the
+file, the document was not understood: it is reported and left untouched.
+
 Exit codes: 0 clean (or fixed), 1 violations found under --check, 2 usage error.
 """
 
@@ -40,18 +53,33 @@ import re
 import sys
 from pathlib import Path
 
-FENCE_RE = re.compile(r"^(?P<indent> {0,3})(?P<fence>`{3,}|~{3,})")
+FENCE_RE = re.compile(r"^(?P<fence>`{3,}|~{3,})")
 ATX_RE = re.compile(r"^ {0,3}#{1,6}(?:\s|$)")
 THEMATIC_RE = re.compile(r"^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$")
 SETEXT_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
 LIST_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
+LIST_MARKER_RE = re.compile(r"^ *(?P<marker>[-*+]|\d{1,9}[.)])(?P<spaces>[ \t]*)(?P<body>.*)$")
 LINK_DEF_RE = re.compile(r"^ {0,3}\[[^\]]+\]:")
-HTML_START_RE = re.compile(r"^ {0,3}<")
-HTML_RAW_RE = re.compile(r"^ {0,3}<(script|pre|style|textarea)\b", re.IGNORECASE)
+HTML_START_RE = re.compile(r"^<")
+HTML_RAW_RE = re.compile(r"^<(script|pre|style|textarea)\b", re.IGNORECASE)
 HARD_BREAK_RE = re.compile(r"(?:  +|\\)$")
 LABEL_RE = re.compile(r"^ {0,3}(?:\*\*|__)[^*_]+(?:\*\*|__)\s*:")
+QUOTE_PREFIX_RE = re.compile(r"^ {0,3}>[ \t]?")
 
 DEFAULT_EXCLUDES = (".git", "node_modules", ".venv", "__pycache__")
+
+# The container column a construct is measured against. CommonMark recognises a
+# block start at 0-3 spaces of indentation RELATIVE TO ITS CONTAINER, and treats
+# 4 or more as indented code; inside a list item the container column is the
+# item's content column, not column zero.
+BLOCK_INDENT = 3
+
+
+def _advance(column: int, text: str) -> int:
+    """The column reached after `text`, with tabs going to the next 4-stop."""
+    for char in text:
+        column += 4 - (column % 4) if char == "\t" else 1
+    return column
 
 
 def _indent_width(line: str) -> int:
@@ -66,8 +94,116 @@ def _indent_width(line: str) -> int:
     return width
 
 
-def merge_indices(lines: list[str]) -> list[int]:
-    """Indices of lines that continue the previous line and should be joined to it."""
+def _strip_quotes(line: str) -> tuple[int, str]:
+    """(blockquote depth, the line's content inside those blockquotes)."""
+    depth = 0
+    rest = line
+    while True:
+        match = QUOTE_PREFIX_RE.match(rest)
+        if not match:
+            return depth, rest
+        depth += 1
+        rest = rest[match.end():]
+
+
+def _list_marker(rest: str, indent: int) -> tuple[int, str | None] | None:
+    """(content column, text after the marker) for a list item opened by `rest`.
+
+    The text is None when nothing on the line can start a block inside the item
+    — an empty item, or a marker followed by enough spaces to make the remainder
+    indented code.
+    """
+    if THEMATIC_RE.match(rest):
+        return None
+    match = LIST_MARKER_RE.match(rest)
+    if not match:
+        return None
+    marker_end = indent + len(match.group("marker"))
+    spaces, body = match.group("spaces"), match.group("body")
+    if not spaces:
+        # "-foo" is not a list item; "-" alone is an empty one.
+        return (marker_end + 1, None) if not body else None
+    if not body:
+        return marker_end + 1, None
+    content_col = _advance(marker_end, spaces)
+    if content_col - marker_end > 4:
+        return marker_end + 1, None
+    return content_col, body
+
+
+def _block_start(body: str, container_col: int, depth: int) -> dict | None:
+    """Protection state for a fence or HTML block opened by `body`, or None.
+
+    `body` is the line with its indentation and any blockquote and list markers
+    already removed, so the same recogniser serves column zero, a list item's
+    content column and the inside of a blockquote. `container_col` is the column
+    the block's closing delimiter is measured against.
+
+    A block that opens and closes on this one line comes back as kind "done":
+    the line is still a block, so nothing may be joined onto it, but no
+    protection outlives it.
+    """
+    state = {"col": container_col, "depth": depth}
+    done = {**state, "kind": "done"}
+    fence = FENCE_RE.match(body)
+    if fence:
+        marker = fence.group("fence")
+        return {**state, "kind": "fence", "char": marker[0], "length": len(marker)}
+    if not HTML_START_RE.match(body):
+        return None
+    lowered = body.lower()
+    if body.startswith("<!--"):
+        return done if "-->" in body else {**state, "kind": "html", "end": "-->"}
+    raw = HTML_RAW_RE.match(body)
+    if raw:
+        # CommonMark HTML block type 1: <pre>, <script>, <style> and <textarea>
+        # run to their CLOSING TAG, and a blank line inside one does not end it.
+        closer = f"</{raw.group(1).lower()}>"
+        return done if closer in lowered else {**state, "kind": "html", "end": closer}
+    return {**state, "kind": "html", "end": "blank"}
+
+
+def _block_status(block: dict, depth: int, rest: str, indent: int) -> str:
+    """"open", "closed_consuming" (this line is the delimiter) or "closed_before".
+
+    "closed_before" is the container ending under the block: a non-blank line
+    that leaves the blockquote or dedents out of the list item closes every
+    block open inside it, and belongs to whatever comes next.
+    """
+    stripped = rest.strip()
+    if stripped:
+        if depth < block["depth"]:
+            return "closed_before"
+        if block["col"] and depth == block["depth"] and indent < block["col"]:
+            return "closed_before"
+    if block["kind"] == "fence":
+        closer = re.compile(r"^ *" + re.escape(block["char"]) + r"{" + str(block["length"]) + r",}[ \t]*$")
+        # The closing fence may be indented up to three spaces past its
+        # container's content column — not past column zero.
+        if indent <= block["col"] + BLOCK_INDENT and closer.match(rest):
+            return "closed_consuming"
+        return "open"
+    if block["end"] == "blank":
+        return "open" if stripped else "closed_consuming"
+    return "closed_consuming" if block["end"] in rest.lower() else "open"
+
+
+def scan(lines: list[str]) -> tuple[list[int], str | None]:
+    """(indices of lines to join onto the previous one, refusal reason or None).
+
+    A refusal reason means the document ran past the end of a block this scanner
+    could not see closed, so its structure was not understood and nothing may be
+    rewritten. Refusing loudly is the acceptable failure; joining lines inside a
+    block we misread is not.
+
+    ORDERING RULE, which the whole scanner is arranged around: the two guards
+    that install protection STATE lasting until a closing delimiter — the code
+    fence and the raw HTML block — are recognised FIRST, for every line, before
+    any guard that merely skips a single line (indented code, the pipe/table
+    heuristic, link definitions, headings, blockquotes, list markers, labels).
+    A skip guard that runs first costs one line; a state guard that never runs
+    costs every line of the block, joined as if it were prose.
+    """
     merges: list[int] = []
     total = len(lines)
     index = 0
@@ -79,99 +215,87 @@ def merge_indices(lines: list[str]) -> list[int]:
             index += 1
         index = min(index + 1, total)
 
-    fence: tuple[str, int] | None = None
-    html_end: str | None = None  # None, "blank", or a closing tag to look for
+    block: dict | None = None
+    block_line = 0
+    containers: list[int] = []  # content columns of the open list items
+    quote_depth = 0
     prev_text = False  # the previous line is a paragraph/list body we could join onto
     prev_hard_break = False
 
     while index < total:
         line = lines[index]
-        stripped = line.strip()
+        index += 1
+        raw_stripped = line.strip()
+        depth, rest = _strip_quotes(line)
+        indent = _indent_width(rest)
 
-        if fence is not None:
-            char, length = fence
-            closer = re.match(r"^ {0,3}(" + re.escape(char) + r"{" + str(length) + r",})[ \t]*$", line)
-            if closer:
-                fence = None
-            index += 1
-            continue
+        if block is not None:
+            status = _block_status(block, depth, rest, indent)
+            if status == "open":
+                continue
+            block = None
+            if status == "closed_consuming":
+                prev_text = False
+                continue
+            # "closed_before": fall through and read this line in its own right.
 
-        if html_end is not None:
-            if html_end == "blank":
-                if not stripped:
-                    html_end = None
-            elif html_end.lower() in line.lower():
-                html_end = None
-            index += 1
-            continue
-
-        if not stripped:
+        if not raw_stripped:
             prev_text = False
-            index += 1
             continue
 
-        fence_match = FENCE_RE.match(line)
-        if fence_match:
-            marker = fence_match.group("fence")
-            fence = (marker[0], len(marker))
-            prev_text = False
-            index += 1
-            continue
+        # Track the open list items, so a block start is measured against the
+        # column its container actually gives it. A non-blank line that dedents
+        # past an item's content column closes that item.
+        if depth != quote_depth:
+            containers.clear()
+            quote_depth = depth
+        while containers and indent < containers[-1]:
+            containers.pop()
+        container_col = containers[-1] if containers else 0
 
-        # Indented code, or a list continuation deep enough to be ambiguous with it.
+        # --- state-installing constructs, at every container column ---
+        if indent - container_col <= BLOCK_INDENT:
+            start = _block_start(rest.strip(), container_col, depth)
+            if start is None:
+                marker = _list_marker(rest, indent)
+                if marker is not None:
+                    content_col, body = marker
+                    containers.append(content_col)
+                    # A fence or HTML element written directly after the marker
+                    # opens inside the item, at the item's content column.
+                    if body is not None:
+                        start = _block_start(body.strip(), content_col, depth)
+            if start is not None:
+                block = None if start["kind"] == "done" else start
+                block_line = index
+                prev_text = False
+                continue
+
+        # Indented code, or a list continuation deep enough to be ambiguous with
+        # it. Measured from column zero on purpose: this guard only ever
+        # SUPPRESSES a join, so keeping it conservative cannot corrupt anything.
         if _indent_width(line) >= 4:
             prev_text = False
-            index += 1
             continue
 
-        # An HTML block start is recognised BEFORE the pipe-and-table exclusion
-        # below, because it is the guard that installs protection STATE. While
-        # the pipe heuristic ran first, an opening tag carrying a pipe — in an
-        # attribute value, or in content on the same line — was taken by the
-        # heuristic and returned early, so the block was never entered and every
-        # line of it was joined as ordinary prose. The exclusion below only ever
-        # skips one line, so losing it to an HTML start costs nothing.
-        if HTML_START_RE.match(line):
-            raw = HTML_RAW_RE.match(line)
-            if stripped.startswith("<!--"):
-                html_end = None if "-->" in stripped else "-->"
-            elif raw:
-                # CommonMark HTML block type 1: <pre>, <script>, <style> and
-                # <textarea> run to their CLOSING TAG, and a blank line inside
-                # one does not end it. Ending protection at the blank line
-                # resumed joining inside the block, which changes what the page
-                # renders and what a script means.
-                closer = f"</{raw.group(1).lower()}>"
-                html_end = None if closer in line.lower() else closer
-            else:
-                html_end = "blank"
+        if "|" in raw_stripped:  # table row, or prose too pipe-heavy to risk
             prev_text = False
-            index += 1
-            continue
-
-        if "|" in stripped:  # table row, or prose too pipe-heavy to risk
-            prev_text = False
-            index += 1
             continue
 
         if LINK_DEF_RE.match(line):
             prev_text = False
-            index += 1
             continue
 
         if ATX_RE.match(line) or THEMATIC_RE.match(line):
             prev_text = False
-            index += 1
             continue
 
         if prev_text and SETEXT_RE.match(line):  # setext heading underline
             prev_text = False
-            index += 1
             continue
 
-        if stripped.startswith(">"):
+        if raw_stripped.startswith(">"):
             prev_text = False
-            index += 1
             continue
 
         # A bolded label at the head of a line ("**When to use**: …") is a
@@ -181,26 +305,36 @@ def merge_indices(lines: list[str]) -> list[int]:
         if LIST_RE.match(line) or LABEL_RE.match(line):
             prev_text = True
             prev_hard_break = bool(HARD_BREAK_RE.search(line.rstrip("\n")))
-            index += 1
             continue
 
         if prev_text and not prev_hard_break:
-            merges.append(index)
+            merges.append(index - 1)
         prev_text = True
         prev_hard_break = bool(HARD_BREAK_RE.search(line.rstrip("\n")))
-        index += 1
 
-    return merges
+    if block is not None and (block["kind"] == "fence" or block["end"] != "blank"):
+        what = "code fence" if block["kind"] == "fence" else f"HTML block ({block['end']})"
+        return [], f"unterminated {what} opened at line {block_line}"
+    return merges, None
 
 
-def unwrap(text: str) -> tuple[str, list[int], int]:
-    """Return (fixed text, merged line numbers (1-based), paragraph count)."""
+def merge_indices(lines: list[str]) -> list[int]:
+    """Indices of lines that continue the previous line and should be joined to it."""
+    return scan(lines)[0]
+
+
+def analyse(text: str) -> tuple[str, list[int], int, str | None]:
+    """Return (fixed text, merged line numbers (1-based), paragraphs, refusal).
+
+    A refusal reason comes back with no merges and the text unchanged: the
+    scanner lost track of a block, so the document is reported, not rewritten.
+    """
     newline = "\r\n" if "\r\n" in text else "\n"
     ends_with_newline = text.endswith(("\n", "\r"))
     lines = text.splitlines()
-    merges = merge_indices(lines)
+    merges, refusal = scan(lines)
     if not merges:
-        return text, [], 0
+        return text, [], 0, refusal
 
     merge_set = set(merges)
     out: list[str] = []
@@ -219,7 +353,12 @@ def unwrap(text: str) -> tuple[str, list[int], int]:
 
     paragraphs = sum(1 for i in merges if (i - 1) not in merge_set)
     fixed = newline.join(out) + (newline if ends_with_newline else "")
-    return fixed, [i + 1 for i in merges], paragraphs
+    return fixed, [i + 1 for i in merges], paragraphs, None
+
+
+def unwrap(text: str) -> tuple[str, list[int], int]:
+    """Return (fixed text, merged line numbers (1-based), paragraph count)."""
+    return analyse(text)[:3]
 
 
 def iter_markdown(paths: list[str]) -> list[Path]:
@@ -253,7 +392,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.paths == ["-"]:
         text = sys.stdin.read()
-        fixed, merged, paragraphs = unwrap(text)
+        fixed, merged, paragraphs, refusal = analyse(text)
+        if refusal:
+            print(f"md-unwrap: <stdin> left unchanged: {refusal}", file=sys.stderr)
         if args.fix:
             sys.stdout.write(fixed)
             return 0
@@ -271,13 +412,20 @@ def main(argv: list[str] | None = None) -> int:
     bad_files = 0
     total_lines = 0
     total_paragraphs = 0
+    refused = 0
     for path in targets:
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             print(f"md-unwrap: cannot read {path}: {exc}", file=sys.stderr)
             return 2
-        fixed, merged, paragraphs = unwrap(text)
+        fixed, merged, paragraphs, refusal = analyse(text)
+        if refusal:
+            # Out of our depth: say so on every run rather than rewrite a
+            # document whose block structure we did not follow.
+            refused += 1
+            print(f"md-unwrap: {path} left unchanged: {refusal}", file=sys.stderr)
+            continue
         if not merged:
             continue
         bad_files += 1
@@ -292,10 +440,11 @@ def main(argv: list[str] | None = None) -> int:
             more = " …" if len(merged) > 10 else ""
             print(f"{path}: hard-wrapped paragraph continues at line(s) {shown}{more}")
 
+    skipped = f", {refused} file(s) left unchanged" if refused else ""
     if args.fix:
         if not args.quiet:
             print(f"md-unwrap: fixed {bad_files} file(s), {total_paragraphs} paragraph(s), "
-                  f"{total_lines} line(s) joined")
+                  f"{total_lines} line(s) joined{skipped}")
         return 0
 
     if bad_files:
@@ -304,7 +453,7 @@ def main(argv: list[str] | None = None) -> int:
               f"Fix with: md-unwrap --fix <path>", file=sys.stderr)
         return 1
     if not args.quiet:
-        print(f"md-unwrap: {len(targets)} file(s) clean")
+        print(f"md-unwrap: {len(targets) - refused} file(s) clean{skipped}")
     return 0
 
 

--- a/custom_bins/md-unwrap
+++ b/custom_bins/md-unwrap
@@ -14,11 +14,14 @@ is not flowing prose is left strictly alone, because a wrong join silently
 corrupts documentation:
 
   - fenced code blocks (``` and ~~~) and indented code blocks (4+ spaces)
+  - raw HTML blocks for <pre>, <script>, <style> and <textarea>, protected all
+    the way to their closing tag (a blank line inside one does not end it)
   - tables (any line carrying a pipe)
   - YAML frontmatter
   - headings (ATX and setext), thematic breaks, blockquotes
   - link reference definitions and HTML blocks
-  - a line ending in an explicit hard break (two trailing spaces, or a backslash)
+  - a line ending in an explicit hard break (two trailing spaces, or a backslash);
+    a joined continuation keeps its own hard break, so --fix is idempotent
   - list item markers: a wrapped list body is joined, but the marker line stays a
     line of its own, so list structure survives
   - lines opening with a bolded label ("**When to use**: …"), which are one point
@@ -43,7 +46,7 @@ SETEXT_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
 LIST_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
 LINK_DEF_RE = re.compile(r"^ {0,3}\[[^\]]+\]:")
 HTML_START_RE = re.compile(r"^ {0,3}<")
-HTML_RAW_RE = re.compile(r"^ {0,3}<(?:script|pre|style|textarea)\b", re.IGNORECASE)
+HTML_RAW_RE = re.compile(r"^ {0,3}<(script|pre|style|textarea)\b", re.IGNORECASE)
 HARD_BREAK_RE = re.compile(r"(?:  +|\\)$")
 LABEL_RE = re.compile(r"^ {0,3}(?:\*\*|__)[^*_]+(?:\*\*|__)\s*:")
 
@@ -126,10 +129,17 @@ def merge_indices(lines: list[str]) -> list[int]:
             continue
 
         if HTML_START_RE.match(line):
+            raw = HTML_RAW_RE.match(line)
             if stripped.startswith("<!--"):
                 html_end = None if "-->" in stripped else "-->"
-            elif HTML_RAW_RE.match(line):
-                html_end = "blank"
+            elif raw:
+                # CommonMark HTML block type 1: <pre>, <script>, <style> and
+                # <textarea> run to their CLOSING TAG, and a blank line inside
+                # one does not end it. Ending protection at the blank line
+                # resumed joining inside the block, which changes what the page
+                # renders and what a script means.
+                closer = f"</{raw.group(1).lower()}>"
+                html_end = None if closer in line.lower() else closer
             else:
                 html_end = "blank"
             prev_text = False
@@ -188,7 +198,14 @@ def unwrap(text: str) -> tuple[str, list[int], int]:
     out: list[str] = []
     for index, line in enumerate(lines):
         if index in merge_set and out:
-            out[-1] = out[-1].rstrip() + " " + line.strip()
+            # Strip the continuation's LEADING indentation only. Two trailing
+            # spaces are an explicit hard break, so stripping them would delete
+            # a line break the author asked for — and would make a second --fix
+            # join the line the first one left alone.
+            body = line.lstrip()
+            if not HARD_BREAK_RE.search(body):
+                body = body.rstrip()
+            out[-1] = out[-1].rstrip() + " " + body
         else:
             out.append(line)
 

--- a/custom_bins/md-unwrap
+++ b/custom_bins/md-unwrap
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["markdown-it-py>=3.0"]
+# ///
 """Detect and repair hard-wrapped Markdown paragraphs.
 
     md-unwrap --check claude/                 # exit 1 if any paragraph is hard-wrapped
@@ -9,39 +13,41 @@ The house rule (claude/rules/communication.md) is that one paragraph is ONE line
 in Markdown: no hard newline inside a paragraph, in prose, bullet bodies or table
 cells. Readers soft-wrap; a hard wrap makes every later edit a reflow diff.
 
-A violation is a text line that continues the previous text line. Everything that
-is not flowing prose is left strictly alone, because a wrong join silently
-corrupts documentation:
+WHICH LINES MAY BE TOUCHED IS A COMMONMARK QUESTION, SO COMMONMARK ANSWERS IT.
+The document is parsed with markdown-it-py, and the only lines this tool will
+ever join are the interiors of top-level `paragraph` tokens, read off each
+token's source line map. Fences, indented code, HTML blocks, tables,
+frontmatter, headings, thematic breaks, link reference definitions, list
+markers, blockquotes — and every one of those nested at any depth inside any
+other — are excluded because the parser never puts them in a paragraph, not
+because a rule here remembers to skip them. Four rounds of hand-rolled block
+scanning were defeated by four constructs nobody had thought of; the fifth was a
+literal quoted fence delimiter inside a list-contained fenced example. There is
+no fifth rule here to get wrong.
 
-  - fenced code blocks (``` and ~~~) and indented code blocks (4+ spaces)
-  - raw HTML blocks for <pre>, <script>, <style> and <textarea>, protected all
-    the way to their closing tag (a blank line inside one does not end it)
-  - tables (any line carrying a pipe) — but a block start is recognised first,
-    so an opening <pre> or <!-- carrying a pipe still enters its block
-  - YAML frontmatter
-  - headings (ATX and setext), thematic breaks, blockquotes
-  - link reference definitions and HTML blocks
-  - a line ending in an explicit hard break (two trailing spaces, or a backslash);
-    a joined continuation keeps its own hard break, so --fix is idempotent
-  - list item markers: a wrapped list body is joined, but the marker line stays a
-    line of its own, so list structure survives
-  - lines opening with a bolded label ("**When to use**: …"), which are one point
-    per line by intent rather than a wrap
+What remains hand-rolled is the JOIN decision inside a paragraph, which is about
+text rather than structure:
+
+  - a line ending in an explicit hard break (two trailing spaces, or a
+    backslash) keeps its break, so --fix is idempotent
+  - a line carrying a pipe is left alone: the parser has already lifted real
+    tables out, so what is left is prose too table-shaped to risk
+  - a line indented four or more columns is left alone, being ambiguous with
+    indented code and with a deep list continuation
+  - a line opening with a bolded label ("**When to use**: …") or a list marker
+    starts a logical line by intent, so it is not joined onto what precedes it —
+    though its own wrapped body is still joined onto it. A marker only reaches
+    this rule when CommonMark refused it a list of its own: "2. foo" cannot
+    interrupt a paragraph, but the author still wrote a numbered point
+  - a line opening with "<" is markup on a line of its own by intent, even where
+    CommonMark folds it into the paragraph above: a closing "</example>" cannot
+    interrupt a paragraph, so the parser reads it as a lazy continuation, and
+    joining it would reflow the author's tags
 
 A one-line paragraph is never a violation — shortness is not wrapping.
 
-Blocks nest. A fence or an HTML element is recognised relative to its CONTAINER
-— written directly after a list marker, at a list item's continuation column, or
-inside a blockquote — because CommonMark measures a block start from the
-container's content column and calls four columns past it indented code. The
-closing delimiter is measured against the same column, and a line that dedents
-out of the item or leaves the blockquote closes what was opened inside it.
-Handled: a list item, a blockquote, a list inside a blockquote, and any depth of
-list nesting. NOT handled, and left alone rather than joined: a construct
-indented four or more columns past its container (CommonMark reads it as
-indented code, and so do we), and a fence indented under a paragraph
-continuation. If a fence or a raw HTML block is still open at the end of the
-file, the document was not understood: it is reported and left untouched.
+If the document ends inside a code fence or a raw HTML block, its structure was
+not understood: it is reported and left untouched.
 
 Exit codes: 0 clean (or fixed), 1 violations found under --check, 2 usage error.
 """
@@ -53,33 +59,19 @@ import re
 import sys
 from pathlib import Path
 
-FENCE_RE = re.compile(r"^(?P<fence>`{3,}|~{3,})")
-ATX_RE = re.compile(r"^ {0,3}#{1,6}(?:\s|$)")
-THEMATIC_RE = re.compile(r"^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$")
-SETEXT_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
-LIST_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
-LIST_MARKER_RE = re.compile(r"^ *(?P<marker>[-*+]|\d{1,9}[.)])(?P<spaces>[ \t]*)(?P<body>.*)$")
-LINK_DEF_RE = re.compile(r"^ {0,3}\[[^\]]+\]:")
-HTML_START_RE = re.compile(r"^<")
-HTML_RAW_RE = re.compile(r"^<(script|pre|style|textarea)\b", re.IGNORECASE)
+from markdown_it import MarkdownIt
+
 HARD_BREAK_RE = re.compile(r"(?:  +|\\)$")
 LABEL_RE = re.compile(r"^ {0,3}(?:\*\*|__)[^*_]+(?:\*\*|__)\s*:")
-QUOTE_PREFIX_RE = re.compile(r"^ {0,3}>[ \t]?")
+LIST_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
+RAW_HTML_RE = re.compile(r"^<(script|pre|style|textarea)\b", re.IGNORECASE)
 
 DEFAULT_EXCLUDES = (".git", "node_modules", ".venv", "__pycache__")
 
-# The container column a construct is measured against. CommonMark recognises a
-# block start at 0-3 spaces of indentation RELATIVE TO ITS CONTAINER, and treats
-# 4 or more as indented code; inside a list item the container column is the
-# item's content column, not column zero.
-BLOCK_INDENT = 3
-
-
-def _advance(column: int, text: str) -> int:
-    """The column reached after `text`, with tabs going to the next 4-stop."""
-    for char in text:
-        column += 4 - (column % 4) if char == "\t" else 1
-    return column
+# CommonMark plus tables. Tables are not CommonMark, but they are everywhere in
+# this repo's Markdown and a table row joined onto its neighbour is a corrupted
+# table, so the rule is enabled rather than re-derived.
+PARSER = MarkdownIt("commonmark").enable("table")
 
 
 def _indent_width(line: str) -> int:
@@ -94,227 +86,134 @@ def _indent_width(line: str) -> int:
     return width
 
 
-def _strip_quotes(line: str) -> tuple[int, str]:
-    """(blockquote depth, the line's content inside those blockquotes)."""
+def _frontmatter_end(lines: list[str]) -> int:
+    """The first line index past YAML frontmatter, or 0 when there is none.
+
+    Frontmatter is not CommonMark — a parser reads `---` as a thematic break and
+    the keys between as a paragraph — so the delimiters are found here and the
+    block is handed to nobody.
+    """
+    if not lines or lines[0].rstrip() != "---":
+        return 0
+    index = 1
+    while index < len(lines) and lines[index].rstrip() not in ("---", "..."):
+        index += 1
+    return min(index + 1, len(lines))
+
+
+def _html_terminator(content: str) -> str | None:
+    """The closing delimiter an HTML block needs, or None if a blank line ends it."""
+    opening = content.split("\n", 1)[0].lstrip()
+    if opening.startswith("<!--"):
+        return "-->"
+    raw = RAW_HTML_RE.match(opening)
+    # CommonMark HTML block type 1: <pre>, <script>, <style> and <textarea> run
+    # to their closing tag. Every other type ends at a blank line, which cannot
+    # go missing.
+    return f"</{raw.group(1).lower()}>" if raw else None
+
+
+def _refusal(tokens, lines: list[str], offset: int) -> str | None:
+    """Why the document ran off the end of a block, or None if it did not."""
+    total = len(lines)
+    for token in tokens:
+        if token.map is None or token.map[1] + offset != total:
+            continue
+        opened = token.map[0] + offset + 1
+        if token.type == "fence":
+            char = re.escape(token.markup[0])
+            closer = re.compile(rf"^[ \t>]*{char}{{{len(token.markup)},}}[ \t]*$")
+            if not closer.match(lines[total - 1]):
+                return f"unterminated code fence opened at line {opened}"
+        elif token.type == "html_block":
+            end = _html_terminator(token.content)
+            if end and end not in token.content.lower():
+                return f"unterminated HTML block ({end}) opened at line {opened}"
+    return None
+
+
+def _raw_html_continuations(tokens, lines: list[str], offset: int) -> set[int]:
+    """Lines markdown-it cut out of a raw HTML block that CommonMark keeps in it.
+
+    Measured against cmark 0.31 on 2026-09-11: markdown-it ends an HTML block at
+    a blank line even for <pre>, <script>, <style>, <textarea> and comments,
+    which CommonMark runs to their closing delimiter. The divergence needs a
+    genuinely blank line inside a LIST item — a fence, a blockquote alone, or a
+    blank-terminated block type is unaffected — and it splits one block into a
+    block plus a paragraph, which would then be joined.
+
+    So when such a token's own content lacks its terminator, and the terminator
+    does appear further down, the lines up to it are part of the block. When it
+    appears nowhere, markdown-it's reading stands: the block genuinely ended
+    with its container (`> <pre>` followed by unquoted prose).
+    """
+    protected: set[int] = set()
+    for token in tokens:
+        if token.type != "html_block" or token.map is None:
+            continue
+        end = _html_terminator(token.content)
+        if not end or end in token.content.lower():
+            continue
+        span: list[int] = []
+        for index in range(token.map[1] + offset, len(lines)):
+            span.append(index)
+            if end in lines[index].lower():
+                protected.update(span)
+                break
+    return protected
+
+
+def _paragraph_ranges(tokens) -> list[tuple[int, int]]:
+    """Source line ranges of the paragraphs outside any blockquote.
+
+    A blockquote's prose is excluded wholesale: joining it would have to carry
+    the `>` markers, which is a rewrite rather than an unwrap.
+    """
     depth = 0
-    rest = line
-    while True:
-        match = QUOTE_PREFIX_RE.match(rest)
-        if not match:
-            return depth, rest
-        depth += 1
-        rest = rest[match.end():]
+    ranges: list[tuple[int, int]] = []
+    for token in tokens:
+        if token.type == "blockquote_open":
+            depth += 1
+        elif token.type == "blockquote_close":
+            depth -= 1
+        elif token.type == "paragraph_open" and depth == 0 and token.map:
+            ranges.append((token.map[0], token.map[1]))
+    return ranges
 
 
-def _list_marker(rest: str, indent: int) -> tuple[int, str | None] | None:
-    """(content column, text after the marker) for a list item opened by `rest`.
-
-    The text is None when nothing on the line can start a block inside the item
-    — an empty item, or a marker followed by enough spaces to make the remainder
-    indented code.
-    """
-    if THEMATIC_RE.match(rest):
-        return None
-    match = LIST_MARKER_RE.match(rest)
-    if not match:
-        return None
-    marker_end = indent + len(match.group("marker"))
-    spaces, body = match.group("spaces"), match.group("body")
-    if not spaces:
-        # "-foo" is not a list item; "-" alone is an empty one.
-        return (marker_end + 1, None) if not body else None
-    if not body:
-        return marker_end + 1, None
-    content_col = _advance(marker_end, spaces)
-    if content_col - marker_end > 4:
-        return marker_end + 1, None
-    return content_col, body
-
-
-def _block_start(body: str, container_col: int, depth: int) -> dict | None:
-    """Protection state for a fence or HTML block opened by `body`, or None.
-
-    `body` is the line with its indentation and any blockquote and list markers
-    already removed, so the same recogniser serves column zero, a list item's
-    content column and the inside of a blockquote. `container_col` is the column
-    the block's closing delimiter is measured against.
-
-    A block that opens and closes on this one line comes back as kind "done":
-    the line is still a block, so nothing may be joined onto it, but no
-    protection outlives it.
-    """
-    state = {"col": container_col, "depth": depth}
-    done = {**state, "kind": "done"}
-    fence = FENCE_RE.match(body)
-    if fence:
-        marker = fence.group("fence")
-        return {**state, "kind": "fence", "char": marker[0], "length": len(marker)}
-    if not HTML_START_RE.match(body):
-        return None
-    lowered = body.lower()
-    if body.startswith("<!--"):
-        return done if "-->" in body else {**state, "kind": "html", "end": "-->"}
-    raw = HTML_RAW_RE.match(body)
-    if raw:
-        # CommonMark HTML block type 1: <pre>, <script>, <style> and <textarea>
-        # run to their CLOSING TAG, and a blank line inside one does not end it.
-        closer = f"</{raw.group(1).lower()}>"
-        return done if closer in lowered else {**state, "kind": "html", "end": closer}
-    return {**state, "kind": "html", "end": "blank"}
-
-
-def _block_status(block: dict, depth: int, rest: str, indent: int) -> str:
-    """"open", "closed_consuming" (this line is the delimiter) or "closed_before".
-
-    "closed_before" is the container ending under the block: a non-blank line
-    that leaves the blockquote or dedents out of the list item closes every
-    block open inside it, and belongs to whatever comes next.
-    """
-    stripped = rest.strip()
-    if stripped:
-        if depth < block["depth"]:
-            return "closed_before"
-        if block["col"] and depth == block["depth"] and indent < block["col"]:
-            return "closed_before"
-    if block["kind"] == "fence":
-        closer = re.compile(r"^ *" + re.escape(block["char"]) + r"{" + str(block["length"]) + r",}[ \t]*$")
-        # The closing fence may be indented up to three spaces past its
-        # container's content column — not past column zero.
-        if indent <= block["col"] + BLOCK_INDENT and closer.match(rest):
-            return "closed_consuming"
-        return "open"
-    if block["end"] == "blank":
-        return "open" if stripped else "closed_consuming"
-    return "closed_consuming" if block["end"] in rest.lower() else "open"
+def _joins_within(lines: list[str], start: int, end: int) -> list[int]:
+    """Indices inside one paragraph that continue the line above them."""
+    found: list[int] = []
+    joinable = False  # the line above is one we may join onto
+    for index in range(start, end):
+        line = lines[index]
+        if _indent_width(line) >= 4 or "|" in line or line.lstrip().startswith("<"):
+            joinable = False
+            continue
+        if LIST_RE.match(line) or LABEL_RE.match(line):
+            joinable = not HARD_BREAK_RE.search(line)
+            continue
+        if joinable:
+            found.append(index)
+        joinable = not HARD_BREAK_RE.search(line)
+    return found
 
 
 def scan(lines: list[str]) -> tuple[list[int], str | None]:
-    """(indices of lines to join onto the previous one, refusal reason or None).
-
-    A refusal reason means the document ran past the end of a block this scanner
-    could not see closed, so its structure was not understood and nothing may be
-    rewritten. Refusing loudly is the acceptable failure; joining lines inside a
-    block we misread is not.
-
-    ORDERING RULE, which the whole scanner is arranged around: the two guards
-    that install protection STATE lasting until a closing delimiter — the code
-    fence and the raw HTML block — are recognised FIRST, for every line, before
-    any guard that merely skips a single line (indented code, the pipe/table
-    heuristic, link definitions, headings, blockquotes, list markers, labels).
-    A skip guard that runs first costs one line; a state guard that never runs
-    costs every line of the block, joined as if it were prose.
-    """
+    """(indices of lines to join onto the previous one, refusal reason or None)."""
+    offset = _frontmatter_end(lines)
+    body = lines[offset:]
+    tokens = PARSER.parse("\n".join(body) + "\n") if body else []
+    refusal = _refusal(tokens, lines, offset)
+    if refusal:
+        return [], refusal
+    protected = _raw_html_continuations(tokens, lines, offset)
     merges: list[int] = []
-    total = len(lines)
-    index = 0
-
-    # YAML frontmatter: only when the very first line opens it.
-    if total and lines[0].rstrip() == "---":
-        index = 1
-        while index < total and lines[index].rstrip() not in ("---", "..."):
-            index += 1
-        index = min(index + 1, total)
-
-    block: dict | None = None
-    block_line = 0
-    containers: list[int] = []  # content columns of the open list items
-    quote_depth = 0
-    prev_text = False  # the previous line is a paragraph/list body we could join onto
-    prev_hard_break = False
-
-    while index < total:
-        line = lines[index]
-        index += 1
-        raw_stripped = line.strip()
-        depth, rest = _strip_quotes(line)
-        indent = _indent_width(rest)
-
-        if block is not None:
-            status = _block_status(block, depth, rest, indent)
-            if status == "open":
-                continue
-            block = None
-            if status == "closed_consuming":
-                prev_text = False
-                continue
-            # "closed_before": fall through and read this line in its own right.
-
-        if not raw_stripped:
-            prev_text = False
+    for start, end in _paragraph_ranges(tokens):
+        start, end = start + offset, end + offset
+        if protected.intersection(range(start, end)):
             continue
-
-        # Track the open list items, so a block start is measured against the
-        # column its container actually gives it. A non-blank line that dedents
-        # past an item's content column closes that item.
-        if depth != quote_depth:
-            containers.clear()
-            quote_depth = depth
-        while containers and indent < containers[-1]:
-            containers.pop()
-        container_col = containers[-1] if containers else 0
-
-        # --- state-installing constructs, at every container column ---
-        if indent - container_col <= BLOCK_INDENT:
-            start = _block_start(rest.strip(), container_col, depth)
-            if start is None:
-                marker = _list_marker(rest, indent)
-                if marker is not None:
-                    content_col, body = marker
-                    containers.append(content_col)
-                    # A fence or HTML element written directly after the marker
-                    # opens inside the item, at the item's content column.
-                    if body is not None:
-                        start = _block_start(body.strip(), content_col, depth)
-            if start is not None:
-                block = None if start["kind"] == "done" else start
-                block_line = index
-                prev_text = False
-                continue
-
-        # Indented code, or a list continuation deep enough to be ambiguous with
-        # it. Measured from column zero on purpose: this guard only ever
-        # SUPPRESSES a join, so keeping it conservative cannot corrupt anything.
-        if _indent_width(line) >= 4:
-            prev_text = False
-            continue
-
-        if "|" in raw_stripped:  # table row, or prose too pipe-heavy to risk
-            prev_text = False
-            continue
-
-        if LINK_DEF_RE.match(line):
-            prev_text = False
-            continue
-
-        if ATX_RE.match(line) or THEMATIC_RE.match(line):
-            prev_text = False
-            continue
-
-        if prev_text and SETEXT_RE.match(line):  # setext heading underline
-            prev_text = False
-            continue
-
-        if raw_stripped.startswith(">"):
-            prev_text = False
-            continue
-
-        # A bolded label at the head of a line ("**When to use**: …") is a
-        # labelled item, not a wrapped continuation — the house rule wants one
-        # such point per line. Treat it like a list marker: it starts a logical
-        # line, and its own wrapped body still gets joined onto it.
-        if LIST_RE.match(line) or LABEL_RE.match(line):
-            prev_text = True
-            prev_hard_break = bool(HARD_BREAK_RE.search(line.rstrip("\n")))
-            continue
-
-        if prev_text and not prev_hard_break:
-            merges.append(index - 1)
-        prev_text = True
-        prev_hard_break = bool(HARD_BREAK_RE.search(line.rstrip("\n")))
-
-    if block is not None and (block["kind"] == "fence" or block["end"] != "blank"):
-        what = "code fence" if block["kind"] == "fence" else f"HTML block ({block['end']})"
-        return [], f"unterminated {what} opened at line {block_line}"
+        merges.extend(_joins_within(lines, start, end))
     return merges, None
 
 
@@ -327,7 +226,7 @@ def analyse(text: str) -> tuple[str, list[int], int, str | None]:
     """Return (fixed text, merged line numbers (1-based), paragraphs, refusal).
 
     A refusal reason comes back with no merges and the text unchanged: the
-    scanner lost track of a block, so the document is reported, not rewritten.
+    document ended inside a block, so it is reported, not rewritten.
     """
     newline = "\r\n" if "\r\n" in text else "\n"
     ends_with_newline = text.endswith(("\n", "\r"))

--- a/custom_bins/md-unwrap
+++ b/custom_bins/md-unwrap
@@ -135,9 +135,10 @@ def _refusal(tokens, lines: list[str], offset: int) -> str | None:
 def _raw_html_continuations(tokens, lines: list[str], offset: int) -> set[int]:
     """Lines markdown-it cut out of a raw HTML block that CommonMark keeps in it.
 
-    Measured against cmark 0.31 on 2026-09-11: markdown-it ends an HTML block at
-    a blank line even for <pre>, <script>, <style>, <textarea> and comments,
-    which CommonMark runs to their closing delimiter. The divergence needs a
+    Measured on 2026-09-11 against reference cmark-gfm (cmarkgfm 2025.10.22):
+    markdown-it ends an HTML block at a blank line even for <pre>, <script>,
+    <style>, <textarea> and comments, which CommonMark runs to their closing
+    delimiter — measured on markdown-it-py 3.0.0 and 4.2.0. The divergence needs a
     genuinely blank line inside a LIST item — a fence, a blockquote alone, or a
     blank-terminated block type is unaffected — and it splits one block into a
     block plus a paragraph, which would then be joined.

--- a/tests/test_md_unwrap.py
+++ b/tests/test_md_unwrap.py
@@ -11,6 +11,7 @@ Run: python3 -m unittest tests.test_md_unwrap   (or pytest tests/test_md_unwrap.
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 import tempfile
@@ -446,6 +447,253 @@ class TestHardBreaksSurviveJoining(unittest.TestCase):
         self.assertEqual("alpha one alpha two\n", fix("alpha one\nalpha two \n"))
 
 
+def render_commonmark(text: str) -> str:
+    """Render with a strict CommonMark implementation, pulled through uv if needed."""
+    try:
+        from markdown_it import MarkdownIt
+    except ImportError:
+        pass
+    else:
+        return MarkdownIt("commonmark").render(text)
+    probe = subprocess.run(
+        ["uv", "run", "--no-project", "--with", "markdown-it-py", "python", "-c",
+         ("import sys;from markdown_it import MarkdownIt;"
+          "sys.stdout.write(MarkdownIt('commonmark').render(sys.stdin.read()))")],
+        capture_output=True, text=True, input=text,
+    )
+    if probe.returncode != 0:
+        raise unittest.SkipTest("no CommonMark renderer available: " + probe.stderr[-200:])
+    return probe.stdout
+
+
+class TestBlocksNestedInsideContainers(unittest.TestCase):
+    """A block start is measured from its CONTAINER's column, not from column zero.
+
+    Round two moved the HTML-block guard above the pipe heuristic, on the rule
+    that a guard installing protection STATE must beat a guard that skips one
+    line. The rule was right and the reading of it was too narrow: a guard that
+    is never REACHED is as absent as one that runs too late. A fence or a raw
+    HTML element written directly after a list marker was taken by the list-item
+    guard, which skips exactly one line; the block was never entered, and every
+    line of it was joined onto the opening fence's info string. A two-line code
+    block came out rendering as an empty one.
+
+    So the recogniser now runs against the line with its container prefixes
+    removed, at every column CommonMark allows: column zero, an item's content
+    column, and inside a blockquote. Indented code still wins at four columns
+    past the container, which is the line CommonMark draws.
+    """
+
+    MARKERS = ("-", "*", "+", "1.", "2)")
+    FENCES = ("```", "~~~")
+    LANGS = ("", "python")
+    RAW_TAGS = ("pre", "script", "style", "textarea")
+
+    def assert_untouched(self, source: str, message: str = "") -> None:
+        fixed, merged, _ = md_unwrap.unwrap(source)
+        self.assertEqual([], merged, message or source)
+        self.assertEqual(source, fixed, message or source)
+        self.assertEqual(render_commonmark(source), render_commonmark(fixed), message or source)
+
+    def test_a_fence_opened_on_the_list_marker_line_is_a_code_block(self):
+        for marker in self.MARKERS:
+            for fence in self.FENCES:
+                for lang in self.LANGS:
+                    with self.subTest(marker=marker, fence=fence, lang=lang):
+                        pad = " " * (len(marker) + 1)
+                        source = (f"{marker} {fence}{lang}\n"
+                                  f"{pad}x = 1\n{pad}y = 2\n{pad}{fence}\n")
+                        self.assert_untouched(source)
+
+    def test_a_fence_on_its_own_line_at_the_items_content_column(self):
+        for marker in self.MARKERS:
+            for fence in self.FENCES:
+                with self.subTest(marker=marker, fence=fence):
+                    pad = " " * (len(marker) + 1)
+                    source = (f"{marker} item body\n\n"
+                              f"{pad}{fence}sh\n{pad}x = 1\n{pad}y = 2\n{pad}{fence}\n")
+                    self.assert_untouched(source)
+
+    def test_a_raw_html_block_opened_on_the_list_marker_line(self):
+        for marker in self.MARKERS:
+            for tag in self.RAW_TAGS:
+                with self.subTest(marker=marker, tag=tag):
+                    pad = " " * (len(marker) + 1)
+                    source = (f"{marker} <{tag}>\n"
+                              f"{pad}first inner line\n\n{pad}second inner line\n"
+                              f"{pad}</{tag}>\n")
+                    self.assert_untouched(source)
+
+    def test_a_generic_html_block_opened_on_the_list_marker_line(self):
+        self.assert_untouched('- <div class="a|b">\n  line one\n  line two\n  </div>\n')
+
+    def test_content_dedented_out_of_the_item_is_prose_again(self):
+        # An HTML block is not lazy, so unindented lines leave the item and are
+        # an ordinary paragraph — joining them is the right answer, and the
+        # rendered code block above them is unaffected.
+        source = '- <div class="a|b">\nline one\nline two\n</div>\n'
+        self.assertEqual('- <div class="a|b">\nline one line two\n</div>\n', fix(source))
+
+    def test_an_html_comment_opened_on_the_list_marker_line(self):
+        self.assert_untouched("- <!-- columns | rows\n  comment one\n  comment two\n  -->\n")
+
+    def test_a_fence_inside_a_blockquote(self):
+        for fence in self.FENCES:
+            with self.subTest(fence=fence):
+                self.assert_untouched(f"> {fence}py\n> x = 1\n> y = 2\n> {fence}\n")
+
+    def test_a_raw_html_block_inside_a_blockquote(self):
+        self.assert_untouched("> <pre>\n> first inner line\n> second inner line\n> </pre>\n")
+
+    def test_a_fence_inside_a_list_inside_a_blockquote(self):
+        for fence in self.FENCES:
+            with self.subTest(fence=fence):
+                self.assert_untouched(f"> - {fence}py\n>   x = 1\n>   y = 2\n>   {fence}\n")
+
+    def test_a_fence_two_list_levels_deep(self):
+        self.assert_untouched("- outer\n  - inner\n\n    ```py\n    x = 1\n    y = 2\n    ```\n")
+
+    def test_a_block_leaving_its_blockquote_does_not_protect_the_prose_after_it(self):
+        # <pre> is not lazy, so the unquoted lines are a plain paragraph and
+        # joining them is the right answer.
+        self.assertEqual(
+            "> <pre>\nprose one prose two\n",
+            fix("> <pre>\nprose one\nprose two\n"),
+        )
+
+
+class TestClosingDelimiterIndentation(unittest.TestCase):
+    """The closing fence is measured against the container column too.
+
+    CommonMark lets the closing fence sit up to three spaces past its
+    container's content column, and ends the block with the container when a
+    line dedents out of it. Matching the closer against column zero alone either
+    reopens the document mid-code-block or freezes the rest of the file.
+    """
+
+    def test_a_closer_three_columns_past_the_container_still_closes(self):
+        source = "- ```py\n  x = 1\n     ```\nprose one\nprose two\n"
+        self.assertEqual(
+            "- ```py\n  x = 1\n     ```\nprose one prose two\n",
+            fix(source),
+        )
+        self.assertIn("<code", render_commonmark(fix(source)))
+
+    def test_a_closer_four_columns_past_the_container_stays_inside_the_block(self):
+        source = "- ```py\n  x = 1\n      ```\nprose one\nprose two\n"
+        self.assertEqual("- ```py\n  x = 1\n      ```\nprose one prose two\n", fix(source))
+
+    def test_an_item_ending_closes_the_fence_it_opened(self):
+        source = "- ```py\n  x = 1\n\nprose one\nprose two\n"
+        self.assertEqual("- ```py\n  x = 1\n\nprose one prose two\n", fix(source))
+
+    def test_a_construct_indented_under_a_paragraph_continuation_is_left_alone(self):
+        # Four spaces after a paragraph line is a lazy continuation, not a
+        # fence. The tool does not join it — under-fixing, never corrupting.
+        for construct in ("```", "~~~", "<pre>"):
+            with self.subTest(construct=construct):
+                source = f"prose line\n    {construct}\nstill prose\n"
+                self.assertEqual(source, fix(source))
+
+
+class TestRefusesDocumentsItCannotFollow(unittest.TestCase):
+    """Out of its depth is reported, never silently rewritten."""
+
+    def test_an_unterminated_fence_leaves_the_whole_document_alone(self):
+        source = "```py\nx = 1\nprose one\nprose two\n"
+        fixed, merged, _, refusal = md_unwrap.analyse(source)
+        self.assertEqual(source, fixed)
+        self.assertEqual([], merged)
+        self.assertIn("unterminated code fence", refusal)
+
+    def test_an_unterminated_raw_html_block_leaves_the_whole_document_alone(self):
+        source = "<pre>\na\nprose one\nprose two\n"
+        _, merged, _, refusal = md_unwrap.analyse(source)
+        self.assertEqual([], merged)
+        self.assertIn("unterminated", refusal)
+
+    def test_the_cli_reports_the_refusal_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "unterminated.md"
+            source = "```py\nx = 1\nprose one\nprose two\n"
+            target.write_text(source, encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--fix", str(target)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(source, target.read_text(encoding="utf-8"))
+            self.assertIn("left unchanged", result.stderr)
+            self.assertIn("unterminated code fence opened at line 1", result.stderr)
+
+
+class TestNoJoinInsideANestedProtectedRegion(unittest.TestCase):
+    """The property check of the round-two fix, run again inside every container.
+
+    The flat matrix stayed green through this defect: nothing in it was indented
+    under anything. Each document is rebuilt inside a list item, a blockquote and
+    a list inside a blockquote, and the ground truth reads the same documents
+    with the container prefix removed.
+    """
+
+    CONTAINERS = (
+        ("- ", "  "),
+        ("* ", "  "),
+        ("+ ", "  "),
+        ("1. ", "   "),
+        ("10) ", "    "),
+        ("> ", "> "),
+        ("> - ", ">   "),
+    )
+
+    def wrap(self, lines: list[str], first: str, rest: str) -> list[str]:
+        return [(first if i == 0 else rest) + line for i, line in enumerate(lines)]
+
+    def unwrap_prefix(self, line: str, first: str, rest: str, index: int) -> str:
+        prefix = first if index == 0 else rest
+        return line[len(prefix):] if line.startswith(prefix) else line
+
+    def test_no_nested_document_is_joined_inside_its_block(self):
+        flat = TestNoJoinInsideAProtectedRegion()
+        checked = 0
+        for opener, lines in flat.documents():
+            for first, rest in self.CONTAINERS:
+                nested = self.wrap(lines, first, rest)
+                bare = [self.unwrap_prefix(line, first, rest, i)
+                        for i, line in enumerate(nested)]
+                checked += 1
+                clash = set(md_unwrap.merge_indices(nested)) & flat.protected_lines(bare)
+                self.assertEqual(
+                    set(), clash,
+                    f"joined inside {opener!r} nested under {first!r}: lines {sorted(clash)}",
+                )
+        self.assertGreater(checked, 1000, "the nesting matrix shrank")
+
+    def test_the_rendering_of_every_nested_document_survives_the_fix(self):
+        """What a reader sees must not move, whatever --fix does to the bytes.
+
+        Joining a wrapped paragraph turns a newline inside a <p> into a space
+        and changes nothing else, so comparing the rendered HTML with runs of
+        whitespace collapsed is exactly the invariant: a block whose start was
+        missed loses its <pre>, which no amount of whitespace collapsing hides.
+        """
+        flat = TestNoJoinInsideAProtectedRegion()
+        def collapse(html: str) -> str:
+            return re.sub(r"\s+", " ", html).strip()
+
+        checked = 0
+        for _opener, lines in flat.documents():
+            for first, rest in (("", ""), *self.CONTAINERS):
+                source = "".join((first if i == 0 else rest) + line + "\n"
+                                 for i, line in enumerate(lines))
+                checked += 1
+                self.assertEqual(
+                    collapse(render_commonmark(source)),
+                    collapse(render_commonmark(fix(source))),
+                    f"--fix changed what {first!r}-nested document renders as:\n{source}",
+                )
+        self.assertGreater(checked, 1000, "the nesting matrix shrank")
+
+
 # Documents that previously moved on a second --fix. The repo's own Markdown
 # does not happen to contain these shapes, so the corpus sweep below would pass
 # on the broken fixer without them.
@@ -461,6 +709,11 @@ ADVERSARIAL_FIXTURES = {
     "script-with-a-pipe-on-the-opening-line": "<script>var re = /a|b/;\nx = 1\n\ny = 2\nz = 3\n</script>\n",
     "comment-with-a-pipe-on-the-opening-line": "<!-- cols | rows\nline one\nline two\n-->\n",
     "table-directly-under-prose": "Intro prose line.\n| a | b |\n|---|---|\n| 1 | 2 |\n",
+    "fence-on-a-list-marker-line": "- ```python\n  x = 1\n  y = 2\n  ```\n",
+    "tilde-fence-on-a-list-marker-line": "* ~~~\n  x = 1\n  y = 2\n  ~~~\n",
+    "pre-on-a-list-marker-line": "1. <pre>\n   a\n\n   b\n   </pre>\n",
+    "fence-inside-a-blockquote-list": "> - ```py\n>   x = 1\n>   y = 2\n>   ```\n",
+    "closer-indented-past-the-container": "- ```py\n  x = 1\n     ```\nprose one\nprose two\n",
 }
 
 

--- a/tests/test_md_unwrap.py
+++ b/tests/test_md_unwrap.py
@@ -466,6 +466,53 @@ def render_commonmark(text: str) -> str:
     return probe.stdout
 
 
+def render_cmark_gfm(documents: list[str]) -> list[str]:
+    """Render documents with reference cmark-gfm, raw HTML included.
+
+    markdown-it is the tool's own parser, so it cannot be the ground truth for a
+    question about where markdown-it is wrong. cmark-gfm is the reference
+    implementation GitHub's renderer is built on, and CMARK_OPT_UNSAFE is what
+    makes raw HTML block content visible in the output at all — with it off,
+    every block this test is about renders as the same placeholder comment.
+
+    Rendered in one batch: with cmarkgfm absent from the interpreter the
+    fallback is a single uv subprocess for the whole matrix, not one per
+    document.
+    """
+    script = ("import sys, cmarkgfm;"
+              "docs = sys.stdin.read().split('\\0');"
+              "sys.stdout.write('\\0'.join("
+              "cmarkgfm.github_flavored_markdown_to_html(d, options=cmarkgfm.Options.CMARK_OPT_UNSAFE)"
+              " for d in docs))")
+    try:
+        import cmarkgfm  # noqa: PLC0415
+    except ImportError:
+        pass
+    else:
+        unsafe = cmarkgfm.Options.CMARK_OPT_UNSAFE
+        return [cmarkgfm.github_flavored_markdown_to_html(d, options=unsafe) for d in documents]
+    probe = subprocess.run(
+        ["uv", "run", "--no-project", "--with", "cmarkgfm", "python", "-c", script],
+        capture_output=True, text=True, input="\0".join(documents),
+    )
+    if probe.returncode != 0:
+        raise unittest.SkipTest("no cmark-gfm renderer available: " + probe.stderr[-200:])
+    return probe.stdout.split("\0")
+
+
+def reflow_normalised(html: str) -> str:
+    """Rendered HTML with whitespace collapsed INSIDE PARAGRAPHS ONLY.
+
+    Joining a wrapped paragraph turns a newline inside a <p> into a space and
+    must change nothing else. Collapsing whitespace everywhere would also hide a
+    join made inside a raw HTML block — which is the corruption this matrix is
+    looking for, and is why an earlier whole-document collapse reported zero.
+    """
+    return re.sub(r"<p>(.*?)</p>",
+                  lambda m: "<p>" + re.sub(r"\s+", " ", m.group(1)).strip() + "</p>",
+                  html, flags=re.DOTALL)
+
+
 class TestBlocksNestedInsideContainers(unittest.TestCase):
     """A block start is measured from its CONTAINER's column, not from column zero.
 
@@ -698,6 +745,153 @@ class TestRefusesDocumentsItCannotFollow(unittest.TestCase):
             self.assertEqual(source, target.read_text(encoding="utf-8"))
             self.assertIn("left unchanged", result.stderr)
             self.assertIn("unterminated code fence opened at line 1", result.stderr)
+
+    def test_an_unclosed_html_block_inside_a_list_item_is_refused(self):
+        # The blank line ends markdown-it's html_block, so the token no longer
+        # reaches end-of-file and the end-of-file refusal never saw it; no
+        # terminator exists later, so the continuation helper protected nothing.
+        # Measured against cmark-gfm (cmarkgfm 2025.10.22): every line here is
+        # raw HTML block content, and the tool joined the last two of them.
+        source = "- <pre>\n  first inner line\n\n  second inner line\n  third inner line\n"
+        fixed, merged, _, refusal = md_unwrap.analyse(source)
+        self.assertEqual(source, fixed)
+        self.assertEqual([], merged)
+        self.assertIn("unterminated HTML block (</pre>)", refusal)
+
+    def test_an_unclosed_comment_inside_a_list_item_is_refused(self):
+        source = "- <!-- note\n  first inner line\n\n  second inner line\n  third inner line\n"
+        _, merged, _, refusal = md_unwrap.analyse(source)
+        self.assertEqual([], merged)
+        self.assertIn("unterminated HTML block (-->)", refusal)
+
+    def test_a_block_ending_with_its_container_is_not_refused(self):
+        # The terminator is missing here too, but markdown-it closed the
+        # container immediately after the block, and CommonMark ends a block
+        # with its container. Refusing these would be a false alarm: cmark-gfm
+        # reads the lines after the container as an ordinary paragraph.
+        for source, expected in (
+            ("> <pre>\nprose one\nprose two\n", "> <pre>\nprose one prose two\n"),
+            ("- <pre>\n  a\n\nprose one\nprose two\n", "- <pre>\n  a\n\nprose one prose two\n"),
+            ("- <pre>\n  a\n\n- prose one\n  prose two\n", "- <pre>\n  a\n\n- prose one prose two\n"),
+        ):
+            with self.subTest(source=source):
+                fixed, _, _, refusal = md_unwrap.analyse(source)
+                self.assertIsNone(refusal)
+                self.assertEqual(expected, fixed)
+
+    def test_the_cli_reports_an_unterminated_html_block_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "unclosed-html.md"
+            source = "- <pre>\n  a\n\n  prose one\n  prose two\n"
+            target.write_text(source, encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--fix", str(target)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(source, target.read_text(encoding="utf-8"))
+            self.assertIn("left unchanged", result.stderr)
+            self.assertIn("unterminated HTML block (</pre>) opened at line 1", result.stderr)
+
+
+class TestEveryHtmlBlockTypeEndsWhereCommonMarkSaysItDoes(unittest.TestCase):
+    """CDATA, processing instructions and declarations end at their own delimiter.
+
+    markdown-it ends a list-contained HTML block at a blank line whatever its
+    type; CommonMark runs types 1-5 to their own closing delimiter. The
+    compatibility layer knew two of the five — raw tags and comments — and read
+    the other three as blank-line-terminated, so the half of the block below the
+    blank line was joined as prose. Confirmed corrupting against cmark-gfm
+    (cmarkgfm 2025.10.22), which renders every line of these documents as raw
+    HTML block content.
+
+    The end conditions are CommonMark's own: a line containing "]]>", "?>", ">"
+    for a markup declaration, "-->" for a comment, and for type 1 any of the
+    four raw closing tags.
+    """
+
+    def assert_untouched(self, source: str) -> None:
+        fixed, merged, _, refusal = md_unwrap.analyse(source)
+        self.assertIsNone(refusal, source)
+        self.assertEqual([], merged, source)
+        self.assertEqual(source, fixed, source)
+
+    def test_a_list_contained_cdata_section_with_a_blank_line(self):
+        self.assert_untouched("- <![CDATA[\n  a\n\n  inner one\n  inner two\n  ]]>\n")
+
+    def test_a_list_contained_processing_instruction_with_a_blank_line(self):
+        self.assert_untouched("- <?php\n  a\n\n  inner one\n  inner two\n  ?>\n")
+
+    def test_a_list_contained_markup_declaration_with_a_blank_line(self):
+        self.assert_untouched("- <!DOCTYPE\n  a\n\n  inner one\n  inner two\n  >\n")
+
+    def test_a_list_contained_comment_with_a_blank_line(self):
+        self.assert_untouched("- <!-- note\n  a\n\n  inner one\n  inner two\n  -->\n")
+
+    def test_a_raw_block_closed_by_a_different_raw_tag(self):
+        # CommonMark ends a type 1 block at ANY of the four raw closing tags,
+        # not only the one matching the tag that opened it.
+        self.assert_untouched("- <pre>\n  a\n\n  inner one\n  inner two\n  </script>\n")
+
+    def test_the_cli_leaves_a_cdata_document_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "cdata.md"
+            source = "- <![CDATA[\n  a\n\n  inner one\n  inner two\n  ]]>\n"
+            target.write_text(source, encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--fix", str(target)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(source, target.read_text(encoding="utf-8"))
+
+
+
+class TestEveryHtmlBlockTypeInEveryContainerAgainstReferenceCmark(unittest.TestCase):
+    """The generalising check: ten openers x six containers x closed and open.
+
+    Each document holds a blank line inside the block, which is the shape that
+    splits one markdown-it html_block into a block plus a paragraph. Every case
+    must end in one of two states — refused, or rendered by cmark-gfm exactly as
+    before with only paragraph interiors reflowed. Silently rewriting a raw HTML
+    block is the third state, and it is the one that must not exist.
+
+    Measured on 2026-09-11: 33 of these 120 documents are corrupted by the tool
+    at 66eb3a9 and 0 by this one.
+    """
+
+    OPENERS = ("<pre>", "<script>", "<style>", "<textarea>", "<!-- note", "<?php",
+               "<!DOCTYPE", "<![CDATA[", '<div class="a">', "<custom-tag>")
+    CLOSERS = (("<!-- note", "-->"), ("<?php", "?>"), ("<!DOCTYPE", ">"), ("<![CDATA[", "]]>"))
+    CONTAINERS = (("", ""), ("- ", "  "), ("* ", "  "), ("1. ", "   "), ("> ", "> "), ("> - ", ">   "))
+
+    def documents(self) -> list[tuple[str, str]]:
+        built = []
+        for marker, pad in self.CONTAINERS:
+            for opener in self.OPENERS:
+                tag = opener.removeprefix("<").split()[0].rstrip(">")
+                closer = dict(self.CLOSERS).get(opener, f"</{tag}>")
+                for terminated in (True, False):
+                    body = [f"{marker}{opener}", f"{pad}first inner line", pad.rstrip(),
+                            f"{pad}second inner line", f"{pad}third inner line"]
+                    if terminated:
+                        body.append(f"{pad}{closer}")
+                    state = "closed" if terminated else "unclosed"
+                    built.append((f"{marker or 'top level'} / {opener} / {state}", "\n".join(body) + "\n"))
+        return built
+
+    def test_each_document_is_refused_or_rendered_identically(self):
+        cases = self.documents()
+        results = [md_unwrap.analyse(source) for _, source in cases]
+        considered = [(name, source, fixed)
+                      for (name, source), (fixed, _, _, refusal) in zip(cases, results)
+                      if refusal is None]
+        rendered = render_cmark_gfm([source for _, source, _ in considered]
+                                    + [fixed for _, _, fixed in considered])
+        half = len(considered)
+        for (name, _, _), before, after in zip(considered, rendered[:half], rendered[half:]):
+            with self.subTest(case=name):
+                self.assertEqual(reflow_normalised(before), reflow_normalised(after))
+        self.assertGreater(half, 60, "a refusal storm would make this check vacuous")
 
 
 class TestNoJoinInsideANestedProtectedRegion(unittest.TestCase):

--- a/tests/test_md_unwrap.py
+++ b/tests/test_md_unwrap.py
@@ -1,0 +1,325 @@
+"""Regression tests for custom_bins/md-unwrap.
+
+The checker rewrites documentation in place, so the tests that matter most are
+the ones proving what it must NOT touch: fenced and indented code, tables, YAML
+frontmatter, list markers, link reference definitions, HTML blocks, explicit
+hard breaks, and single-line paragraphs. Those come first.
+
+Run: python3 -m unittest tests.test_md_unwrap   (or pytest tests/test_md_unwrap.py)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "custom_bins" / "md-unwrap"
+
+_spec = importlib.util.spec_from_loader(
+    "md_unwrap", importlib.machinery.SourceFileLoader("md_unwrap", str(SCRIPT))
+)
+md_unwrap = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(md_unwrap)
+
+
+def doc(text: str) -> str:
+    return textwrap.dedent(text).lstrip("\n")
+
+
+def fix(text: str) -> str:
+    return md_unwrap.unwrap(text)[0]
+
+
+def violations(text: str) -> list[int]:
+    return md_unwrap.unwrap(text)[1]
+
+
+class TestLeavesStructureAlone(unittest.TestCase):
+    """Everything that is not flowing prose must survive byte-identical."""
+
+    def assert_untouched(self, text: str) -> None:
+        fixed, merged, _ = md_unwrap.unwrap(text)
+        self.assertEqual([], merged)
+        self.assertEqual(text, fixed)
+
+    def test_fenced_code_block_keeps_its_line_breaks(self):
+        self.assert_untouched(doc("""
+            Intro line.
+
+            ```python
+            def f():
+                return (1
+                        + 2)
+            ```
+            """))
+
+    def test_tilde_fence_and_nested_backticks_survive(self):
+        self.assert_untouched(doc("""
+            ~~~
+            one
+            two
+            ```
+            still fenced
+            ~~~
+            """))
+
+    def test_indented_code_block_survives(self):
+        self.assert_untouched(doc("""
+            Prose paragraph.
+
+                indented code
+                more code
+            """))
+
+    def test_table_rows_are_never_joined(self):
+        self.assert_untouched(doc("""
+            | Want to | Command |
+            |---|---|
+            | commit | `/commit` |
+            | push | `git push` |
+            """))
+
+    def test_yaml_frontmatter_survives(self):
+        self.assert_untouched(doc("""
+            ---
+            name: thing
+            description: a long description
+              that the YAML parser folds
+            ---
+
+            Body line.
+            """))
+
+    def test_link_reference_definitions_stay_on_their_own_lines(self):
+        self.assert_untouched(doc("""
+            [one]: https://example.com/one
+            [two]: https://example.com/two
+            """))
+
+    def test_html_block_lines_are_untouched(self):
+        self.assert_untouched(doc("""
+            <details>
+            <summary>Click</summary>
+            body text
+            </details>
+            """))
+
+    def test_html_comment_block_is_untouched(self):
+        self.assert_untouched(doc("""
+            <!-- a comment
+            spanning lines -->
+            """))
+
+    def test_single_line_paragraphs_are_not_violations(self):
+        self.assert_untouched(doc("""
+            # Heading
+
+            A short line.
+
+            Another short line.
+
+            - a bullet
+            - another bullet
+            """))
+
+    def test_explicit_hard_break_is_respected(self):
+        self.assert_untouched("line one with a break  \nline two\n")
+        self.assert_untouched("line one with a backslash\\\nline two\n")
+
+    def test_bolded_label_lines_stay_one_point_per_line(self):
+        self.assert_untouched(doc("""
+            **What it is**: a horizontal chain of stages.
+            **When to use**: showing data flow.
+            """))
+
+    def test_underscore_bolded_label_lines_stay_put(self):
+        self.assert_untouched(doc("""
+            __Key styles__: bluebox, lavbox
+            __Complexity__: low
+            """))
+
+    def test_setext_heading_underline_is_not_joined(self):
+        self.assert_untouched(doc("""
+            Title
+            =====
+
+            Subtitle
+            --------
+            """))
+
+    def test_blockquotes_are_left_alone(self):
+        self.assert_untouched(doc("""
+            > quoted line one
+            > quoted line two
+            """))
+
+    def test_thematic_break_is_not_joined(self):
+        self.assert_untouched(doc("""
+            Paragraph.
+
+            ---
+
+            Next paragraph.
+            """))
+
+
+class TestJoinsWrappedProse(unittest.TestCase):
+    def test_wrapped_paragraph_becomes_one_line(self):
+        self.assertEqual(
+            "This is a paragraph that someone hard wrapped at eighty columns.\n",
+            fix("This is a paragraph that someone\nhard wrapped at eighty columns.\n"),
+        )
+
+    def test_list_marker_survives_but_wrapped_body_is_joined(self):
+        self.assertEqual(
+            doc("""
+                - first item body continues here
+                - second item
+                """),
+            fix(doc("""
+                - first item
+                  body continues here
+                - second item
+                """)),
+        )
+
+    def test_nested_list_marker_is_not_swallowed(self):
+        source = doc("""
+            - parent item
+              - child item
+            """)
+        self.assertEqual(source, fix(source))
+
+    def test_a_wrapped_label_body_is_still_joined_onto_its_label(self):
+        self.assertEqual(
+            "**When to use**: showing data flow through a pipeline.\n",
+            fix("**When to use**: showing data flow\nthrough a pipeline.\n"),
+        )
+
+    def test_paragraph_after_heading_is_joined_but_heading_is_not(self):
+        self.assertEqual(
+            doc("""
+                # A heading
+                prose one prose two
+                """),
+            fix(doc("""
+                # A heading
+                prose one
+                prose two
+                """)),
+        )
+
+    def test_counts_paragraphs_and_lines(self):
+        _, merged, paragraphs = md_unwrap.unwrap(
+            "a one\na two\na three\n\nb one\nb two\n"
+        )
+        self.assertEqual(3, len(merged))
+        self.assertEqual(2, paragraphs)
+
+    def test_reported_line_numbers_are_one_based(self):
+        self.assertEqual([2], violations("first\nsecond\n"))
+
+    def test_fix_is_idempotent(self):
+        once = fix("wrapped one\nwrapped two\n")
+        self.assertEqual(once, fix(once))
+
+    def test_crlf_and_missing_trailing_newline_survive(self):
+        self.assertEqual("a b\r\n", fix("a\r\nb\r\n"))
+        self.assertEqual("a b", fix("a\nb"))
+
+    def test_prose_resumes_after_a_code_fence(self):
+        self.assertEqual(
+            doc("""
+                ```
+                code
+                ```
+                prose one prose two
+                """),
+            fix(doc("""
+                ```
+                code
+                ```
+                prose one
+                prose two
+                """)),
+        )
+
+
+class TestCommandLine(unittest.TestCase):
+    def run_cli(self, *args: str, stdin: str | None = None):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            capture_output=True, text=True, input=stdin,
+        )
+
+    def test_check_exits_one_on_a_violation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "bad.md"
+            target.write_text("wrapped one\nwrapped two\n", encoding="utf-8")
+            result = self.run_cli("--check", str(target))
+            self.assertEqual(1, result.returncode)
+            self.assertIn("bad.md", result.stdout)
+
+    def test_check_exits_zero_when_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "good.md"
+            target.write_text("one line paragraph.\n", encoding="utf-8")
+            self.assertEqual(0, self.run_cli("--check", str(target)).returncode)
+
+    def test_check_is_the_default_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "bad.md"
+            target.write_text("wrapped one\nwrapped two\n", encoding="utf-8")
+            self.assertEqual(1, self.run_cli(str(target)).returncode)
+
+    def test_fix_rewrites_the_file_and_exits_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "bad.md"
+            target.write_text("wrapped one\nwrapped two\n", encoding="utf-8")
+            result = self.run_cli("--fix", str(target))
+            self.assertEqual(0, result.returncode)
+            self.assertEqual("wrapped one wrapped two\n", target.read_text(encoding="utf-8"))
+
+    def test_directory_recursion_finds_nested_markdown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            nested = Path(tmp) / "a" / "b"
+            nested.mkdir(parents=True)
+            (nested / "bad.md").write_text("one\ntwo\n", encoding="utf-8")
+            (nested / "notes.txt").write_text("one\ntwo\n", encoding="utf-8")
+            result = self.run_cli("--check", tmp)
+            self.assertEqual(1, result.returncode)
+            self.assertIn("bad.md", result.stdout)
+            self.assertNotIn("notes.txt", result.stdout)
+
+    def test_exclude_skips_matching_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "skipme.md").write_text("one\ntwo\n", encoding="utf-8")
+            result = self.run_cli("--check", "--exclude", "skipme", tmp)
+            self.assertEqual(0, result.returncode)
+
+    def test_stdin_check_reports_without_writing(self):
+        result = self.run_cli("--check", "-", stdin="one\ntwo\n")
+        self.assertEqual(1, result.returncode)
+
+    def test_stdin_fix_writes_to_stdout(self):
+        result = self.run_cli("--fix", "-", stdin="one\ntwo\n")
+        self.assertEqual(0, result.returncode)
+        self.assertEqual("one two\n", result.stdout)
+
+    def test_missing_file_exits_two(self):
+        self.assertEqual(2, self.run_cli("--check", "/nonexistent/nope.md").returncode)
+
+    def test_help_works(self):
+        result = self.run_cli("--help")
+        self.assertEqual(0, result.returncode)
+        self.assertIn("--fix", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_md_unwrap.py
+++ b/tests/test_md_unwrap.py
@@ -267,6 +267,157 @@ class TestRawHtmlBlocksSurvive(unittest.TestCase):
         self.assertEqual(source, fix(source))
 
 
+class TestPipeOnAnHtmlBlockOpeningLine(unittest.TestCase):
+    """A pipe on the opening line must not cancel HTML-block protection.
+
+    The pipe-and-table exclusion is a heuristic ("any line carrying a pipe might
+    be a table row"); an HTML block start is a real block-level construct that
+    installs protection state. While the heuristic ran first, an opening tag
+    carrying a pipe — in an attribute value, or in content on the same line —
+    was taken by the heuristic and returned early, so the protection was never
+    installed at all and every following line was treated as ordinary prose.
+    Inside <pre> that changes what the page renders; inside <script> it changes
+    what the code does.
+    """
+
+    RAW_TAGS = ("pre", "script", "style", "textarea")
+
+    def assert_untouched(self, source: str, message: str = "") -> None:
+        fixed, merged, _ = md_unwrap.unwrap(source)
+        self.assertEqual([], merged, message)
+        self.assertEqual(source, fixed, message)
+
+    def block(self, opening: str, tag: str) -> str:
+        return (
+            "Intro paragraph.\n"
+            "\n"
+            f"{opening}\n"
+            "\n"
+            "first inner line\n"
+            "second inner line\n"
+            f"</{tag}>\n"
+            "\n"
+            "Closing paragraph.\n"
+        )
+
+    def test_pipe_in_an_attribute_value_still_protects_the_block(self):
+        for tag in self.RAW_TAGS:
+            with self.subTest(tag=tag):
+                source = self.block(f'<{tag} class="col-a|col-b">', tag)
+                self.assert_untouched(source, f"joined inside a <{tag}> opened with a piped attribute")
+
+    def test_pipe_in_the_opening_lines_content_still_protects_the_block(self):
+        for tag in self.RAW_TAGS:
+            with self.subTest(tag=tag):
+                source = self.block(f"<{tag}>alpha | beta", tag)
+                self.assert_untouched(source, f"joined inside a <{tag}> whose opening line content has a pipe")
+
+    def test_the_rendered_preformatted_content_does_not_change(self):
+        source = (
+            '<pre class="a|b">\n'
+            "\n"
+            "first inner line\n"
+            "second inner line\n"
+            "</pre>\n"
+        )
+        self.assertEqual(render_markdown(source), render_markdown(fix(source)))
+
+    def test_html_comment_with_a_pipe_is_protected_to_its_terminator(self):
+        self.assert_untouched("<!-- columns | rows\ncomment line one\ncomment line two\n-->\n")
+
+    def test_generic_html_block_with_a_pipe_is_protected_to_the_blank_line(self):
+        self.assert_untouched('<div data-cols="a|b">\nline one\nline two\n</div>\n')
+
+    def test_a_genuine_markdown_table_is_still_excluded(self):
+        # The guard that moved must still do its job: without it the first table
+        # row would be joined onto the prose line above it.
+        self.assert_untouched(doc("""
+            Intro prose line.
+            | Want to | Command |
+            |---|---|
+            | commit | `/commit` |
+            | push | `git push` |
+            """))
+
+    def test_pipe_heavy_prose_is_still_left_alone(self):
+        self.assert_untouched("a | b | c\nd | e | f\n")
+
+
+class TestNoJoinInsideAProtectedRegion(unittest.TestCase):
+    """A property check over constructed documents, not the repo's own Markdown.
+
+    The repo contains no HTML block whose opening line carries a pipe, so a
+    corpus sweep stays green however badly the guards are ordered — which is how
+    the pipe-before-HTML defect survived the previous fix and its sweep. This
+    builds the documents instead: every state-installing construct, opened with
+    every decoration that could plausibly hijack its opening line, and asserts
+    that no line inside the resulting block is ever joined.
+
+    The region scanner below is deliberately independent of merge_indices — it
+    is the ground truth the fixer is checked against, not a copy of its logic.
+    """
+
+    RAW_TAGS = ("pre", "script", "style", "textarea")
+    DECORATIONS = ("", ' class="a|b"', ">alpha | beta", ">   ", " data-x='a|b'")
+    BODIES = (
+        ("one", "", "two", "three"),
+        ("a | b", "c", "", "d"),
+        ("x", "  y  ", "z"),
+    )
+    PREFIXES = ((), ("Lead prose line.",), ("Lead prose.", ""))
+
+    def protected_lines(self, lines: list[str]) -> set[int]:
+        """Indices strictly inside a fence or a raw/comment HTML block."""
+        inside: str | None = None
+        protected: set[int] = set()
+        for index, line in enumerate(lines):
+            stripped = line.strip().lower()
+            if inside is None:
+                if stripped.startswith(("```", "~~~")):
+                    inside = "fence"
+                elif stripped.startswith("<!--") and "-->" not in stripped:
+                    inside = "-->"
+                else:
+                    for tag in self.RAW_TAGS:
+                        if stripped.startswith("<" + tag) and f"</{tag}>" not in stripped:
+                            inside = f"</{tag}>"
+                            break
+            elif inside == "fence":
+                if stripped.startswith(("```", "~~~")):
+                    inside = None
+            elif inside in stripped:
+                inside = None
+            else:
+                protected.add(index)
+        return protected
+
+    def documents(self):
+        openers = {}
+        for tag in self.RAW_TAGS:
+            for decoration in self.DECORATIONS:
+                opener = f"<{tag}{decoration}" if decoration.startswith(">") else f"<{tag}{decoration}>"
+                openers[opener] = f"</{tag}>"
+        openers["<!-- note | here"] = "-->"
+        openers["```python"] = "```"
+        openers["~~~"] = "~~~"
+        for opener, closer in openers.items():
+            for body in self.BODIES:
+                for prefix in self.PREFIXES:
+                    lines = [*prefix, opener, *body, closer, "", "trailing one", "trailing two"]
+                    yield opener, lines
+
+    def test_no_constructed_document_is_joined_inside_its_block(self):
+        checked = 0
+        for opener, lines in self.documents():
+            checked += 1
+            clash = set(md_unwrap.merge_indices(lines)) & self.protected_lines(lines)
+            self.assertEqual(
+                set(), clash,
+                f"joined inside the block opened by {opener!r}: lines {sorted(clash)}",
+            )
+        self.assertGreater(checked, 150, "the construction matrix shrank")
+
+
 class TestHardBreaksSurviveJoining(unittest.TestCase):
     """Two trailing spaces are a hard line break and must not be stripped."""
 
@@ -306,6 +457,10 @@ ADVERSARIAL_FIXTURES = {
     "pre-block-with-a-blank-line": "<pre>\na\n\nb\nc\n</pre>\n",
     "script-block-with-a-blank-line": "<script>\nx = 1\n\ny = 2\nz = 3\n</script>\n",
     "one-line-pre-then-prose": "<pre>inline</pre>\nprose one\nprose two\n",
+    "pre-opened-with-a-piped-attribute": '<pre class="a|b">\nalpha\n\nbeta\ngamma\n</pre>\n',
+    "script-with-a-pipe-on-the-opening-line": "<script>var re = /a|b/;\nx = 1\n\ny = 2\nz = 3\n</script>\n",
+    "comment-with-a-pipe-on-the-opening-line": "<!-- cols | rows\nline one\nline two\n-->\n",
+    "table-directly-under-prose": "Intro prose line.\n| a | b |\n|---|---|\n| 1 | 2 |\n",
 }
 
 

--- a/tests/test_md_unwrap.py
+++ b/tests/test_md_unwrap.py
@@ -596,6 +596,80 @@ class TestClosingDelimiterIndentation(unittest.TestCase):
                 self.assertEqual(source, fix(source))
 
 
+class TestLiteralDelimitersInsideACodeBlock(unittest.TestCase):
+    """Code content that LOOKS like a delimiter must not be read as one.
+
+    The round-four defect, and the one that ended the hand-rolled scanner: a
+    fenced example inside a list item whose content is a quoted fence — the
+    literal text "> ```". The blockquote-stripping helper ran on every line,
+    including lines inside the fence, so it removed the quote marker and handed
+    a bare "```" to the closing-delimiter test. The fence was declared closed
+    three lines early and the code lines after it were joined as prose.
+
+    No rule here fixes that. markdown-it decides where the fence ends, and a
+    closing fence is a property of the block structure it already computed, so
+    a line of code can no longer be mistaken for one at any depth.
+    """
+
+    SOURCE = (
+        "- Example:\n"
+        "\n"
+        "  ```\n"
+        "  > ```\n"
+        "  code line one\n"
+        "  code line two\n"
+        "  ```\n"
+        "\n"
+        "Outside prose one\n"
+        "outside prose two\n"
+    )
+
+    def test_the_code_lines_after_the_literal_delimiter_are_not_joined(self):
+        fixed, merged, _ = md_unwrap.unwrap(self.SOURCE)
+        self.assertNotIn("code line one code line two", fixed)
+        self.assertEqual([10], merged, "only the outside paragraph may be joined")
+
+    def test_the_outside_paragraph_is_still_joined(self):
+        self.assertEqual(
+            self.SOURCE.replace("Outside prose one\noutside prose two",
+                                "Outside prose one outside prose two"),
+            fix(self.SOURCE),
+        )
+
+    def test_the_rendered_code_block_is_unchanged(self):
+        self.assertEqual(render_commonmark(self.SOURCE).count("<code"),
+                         render_commonmark(fix(self.SOURCE)).count("<code"))
+        self.assertIn("&gt; ```", render_commonmark(fix(self.SOURCE)))
+
+    def test_a_tilde_fence_holding_a_quoted_tilde_delimiter(self):
+        source = ("1. Example:\n\n   ~~~\n   > ~~~\n   code line one\n"
+                  "   code line two\n   ~~~\n\nOutside one\noutside two\n")
+        self.assertNotIn("code line one code line two", fix(source))
+
+    def test_a_quoted_delimiter_inside_a_top_level_fence(self):
+        source = "```\n> ```\ncode line one\ncode line two\n```\nProse one\nprose two\n"
+        self.assertNotIn("code line one code line two", fix(source))
+
+
+class TestHtmlTagLinesAreNotReflowed(unittest.TestCase):
+    """A tag on a line of its own stays there, even as a lazy continuation.
+
+    "</example>" is not one of CommonMark's block tag names and a closing tag of
+    an unknown element cannot interrupt a paragraph, so a parser folds it into
+    the prose line above it. Joining would be rendering-equivalent and still
+    wrong: the repo's agent files delimit their examples with these tags, and
+    reflowing them rewrites the author's markup.
+    """
+
+    def test_a_closing_tag_after_prose_keeps_its_own_line(self):
+        source = "<example>\nContext: something\n\n(148 words - fits)\n</example>\n"
+        self.assertEqual(source, fix(source))
+
+    def test_a_closing_tag_after_a_list_item_keeps_its_own_line(self):
+        source = "<example>\nGOOD approach:\n\n1. Glob for things\n2. Read the file\n</example>\n"
+        self.assertEqual(source, fix(source))
+
+
 class TestRefusesDocumentsItCannotFollow(unittest.TestCase):
     """Out of its depth is reported, never silently rewritten."""
 
@@ -714,6 +788,10 @@ ADVERSARIAL_FIXTURES = {
     "pre-on-a-list-marker-line": "1. <pre>\n   a\n\n   b\n   </pre>\n",
     "fence-inside-a-blockquote-list": "> - ```py\n>   x = 1\n>   y = 2\n>   ```\n",
     "closer-indented-past-the-container": "- ```py\n  x = 1\n     ```\nprose one\nprose two\n",
+    "quoted-fence-delimiter-inside-a-list-fence":
+        "- Example:\n\n  ```\n  > ```\n  code line one\n  code line two\n  ```\n"
+        "\nOutside prose one\noutside prose two\n",
+    "closing-tag-of-an-unknown-element": "<example>\nprose one\n\n(148 words)\n</example>\n",
 }
 
 

--- a/tests/test_md_unwrap.py
+++ b/tests/test_md_unwrap.py
@@ -498,5 +498,17 @@ class TestCommandLine(unittest.TestCase):
         self.assertIn("--fix", result.stdout)
 
 
+class TestRepoMarkdownStaysClean(unittest.TestCase):
+    """The gate itself: Markdown under claude/ must stay unwrapped."""
+
+    def test_claude_markdown_has_no_hard_wrapped_paragraphs(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check", str(REPO_ROOT / "claude")],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            self.fail("hard-wrapped Markdown under claude/:\n" + result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_md_unwrap.py
+++ b/tests/test_md_unwrap.py
@@ -40,6 +40,24 @@ def violations(text: str) -> list[int]:
     return md_unwrap.unwrap(text)[1]
 
 
+def render_markdown(text: str) -> str:
+    """Render with python-markdown, pulled through uv when it is not importable."""
+    try:
+        import markdown  # noqa: PLC0415
+    except ImportError:
+        pass
+    else:
+        return markdown.markdown(text)
+    probe = subprocess.run(
+        ["uv", "run", "--no-project", "--with", "markdown", "python", "-c",
+         "import sys,markdown;sys.stdout.write(markdown.markdown(sys.stdin.read()))"],
+        capture_output=True, text=True, input=text,
+    )
+    if probe.returncode != 0:
+        raise unittest.SkipTest("no markdown renderer available: " + probe.stderr[-200:])
+    return probe.stdout
+
+
 class TestLeavesStructureAlone(unittest.TestCase):
     """Everything that is not flowing prose must survive byte-identical."""
 
@@ -167,6 +185,165 @@ class TestLeavesStructureAlone(unittest.TestCase):
 
             Next paragraph.
             """))
+
+
+class TestRawHtmlBlocksSurvive(unittest.TestCase):
+    """<pre>, <script>, <style> and <textarea> are protected to their closing tag.
+
+    A blank line inside such a block does not end it (CommonMark HTML block type
+    1 runs to the closing tag), so joining must not resume part-way through: the
+    rendered page would change, and inside a script the code would change meaning.
+    """
+
+    RAW_TAGS = ("pre", "script", "style", "textarea")
+
+    def test_raw_block_with_an_internal_blank_line_is_byte_identical(self):
+        for tag in self.RAW_TAGS:
+            with self.subTest(tag=tag):
+                source = (
+                    "Intro paragraph.\n"
+                    "\n"
+                    f"<{tag}>\n"
+                    "first inner line\n"
+                    "\n"
+                    "second inner line\n"
+                    "third inner line\n"
+                    f"</{tag}>\n"
+                    "\n"
+                    "Closing paragraph.\n"
+                )
+                fixed, merged, _ = md_unwrap.unwrap(source)
+                self.assertEqual([], merged, f"joined inside a <{tag}> block")
+                self.assertEqual(source, fixed)
+
+    def test_raw_block_with_attributes_and_mixed_case_is_protected(self):
+        source = doc("""
+            <PRE class="sample">
+            one
+
+            two
+            three
+            </PRE>
+            """)
+        self.assertEqual(source, fix(source))
+
+    def test_raw_block_protects_to_the_closing_tag_not_the_next_blank_line(self):
+        source = doc("""
+            <pre>
+            alpha
+
+            beta
+            gamma
+            </pre>
+            """)
+        self.assertNotIn("beta gamma", fix(source))
+
+    def test_opening_and_closing_tag_on_one_line_ends_the_block(self):
+        # The block ends on its own line, so the prose after it is ordinary
+        # prose and is joined; protection must not run to the end of file.
+        self.assertEqual(
+            doc("""
+                <pre>inline sample</pre>
+                prose one prose two
+                """),
+            fix(doc("""
+                <pre>inline sample</pre>
+                prose one
+                prose two
+                """)),
+        )
+
+    def test_a_later_raw_block_is_still_protected_after_a_one_line_block(self):
+        source = doc("""
+            <pre>inline</pre>
+
+            <pre>
+            alpha
+
+            beta
+            gamma
+            </pre>
+            """)
+        self.assertEqual(source, fix(source))
+
+
+class TestHardBreaksSurviveJoining(unittest.TestCase):
+    """Two trailing spaces are a hard line break and must not be stripped."""
+
+    SOURCE = "alpha one\nalpha two  \nalpha three\n"
+
+    def test_a_hard_break_on_a_joined_line_is_preserved(self):
+        self.assertEqual("alpha one alpha two  \nalpha three\n", fix(self.SOURCE))
+
+    def test_the_rendered_line_break_survives(self):
+        before = render_markdown(self.SOURCE)
+        after = render_markdown(fix(self.SOURCE))
+        self.assertIn("<br", before)
+        self.assertIn("<br", after)
+
+    def test_a_backslash_hard_break_on_a_joined_line_is_preserved(self):
+        self.assertEqual(
+            "alpha one alpha two\\\nalpha three\n",
+            fix("alpha one\nalpha two\\\nalpha three\n"),
+        )
+
+    def test_joining_a_paragraph_with_a_hard_break_is_idempotent(self):
+        once = fix(self.SOURCE)
+        self.assertEqual(once, fix(once))
+
+    def test_incidental_single_trailing_space_is_still_tidied(self):
+        self.assertEqual("alpha one alpha two\n", fix("alpha one\nalpha two \n"))
+
+
+# Documents that previously moved on a second --fix. The repo's own Markdown
+# does not happen to contain these shapes, so the corpus sweep below would pass
+# on the broken fixer without them.
+ADVERSARIAL_FIXTURES = {
+    "hard-break-mid-paragraph": "alpha one\nalpha two  \nalpha three\n",
+    "hard-break-in-a-list-body": "- item one\n  item two  \n  item three\n",
+    "backslash-break-mid-paragraph": "alpha one\nalpha two\\\nalpha three\n",
+    "hard-break-after-a-label": "**Label**: one\ntwo  \nthree\n",
+    "pre-block-with-a-blank-line": "<pre>\na\n\nb\nc\n</pre>\n",
+    "script-block-with-a-blank-line": "<script>\nx = 1\n\ny = 2\nz = 3\n</script>\n",
+    "one-line-pre-then-prose": "<pre>inline</pre>\nprose one\nprose two\n",
+}
+
+
+class TestIdempotentOverTheRepoCorpus(unittest.TestCase):
+    """--fix twice must equal --fix once, over the whole corpus."""
+
+    def corpus(self) -> dict[str, str]:
+        documents = dict(ADVERSARIAL_FIXTURES)
+        for path in sorted(REPO_ROOT.rglob("*.md")):
+            if any(part in md_unwrap.DEFAULT_EXCLUDES for part in path.parts):
+                continue
+            try:
+                documents[str(path.relative_to(REPO_ROOT))] = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+        return documents
+
+    def test_every_document_reaches_a_fixed_point(self):
+        documents = self.corpus()
+        self.assertGreater(len(documents), 100, "corpus looks too small to be the repo")
+        unstable = [name for name, text in documents.items()
+                    if fix(fix(text)) != fix(text)]
+        self.assertEqual([], unstable, "--fix is not idempotent for these documents")
+
+    def test_the_cli_gives_the_same_bytes_on_a_second_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name, text in ADVERSARIAL_FIXTURES.items():
+                (root / f"{name}.md").write_text(text, encoding="utf-8")
+            run = lambda: subprocess.run(  # noqa: E731
+                [sys.executable, str(SCRIPT), "--fix", "-q", str(root)],
+                capture_output=True, text=True, check=False,
+            )
+            run()
+            once = {p.name: p.read_bytes() for p in sorted(root.glob("*.md"))}
+            run()
+            twice = {p.name: p.read_bytes() for p in sorted(root.glob("*.md"))}
+            self.assertEqual(once, twice)
 
 
 class TestJoinsWrappedProse(unittest.TestCase):

--- a/tests/test_pre_commit_md_wrap_guard.sh
+++ b/tests/test_pre_commit_md_wrap_guard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Pins the Markdown hard-wrap guard in config/git-hooks/pre-commit.
+#
+# The hook is global (core.hooksPath), so both directions matter: it must block
+# a hard-wrapped paragraph staged under claude/, and it must stay out of the way
+# everywhere else — Markdown outside claude/, non-Markdown files, and repos that
+# do not carry custom_bins/md-unwrap at all.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS_DIR="${HOOKS_DIR:-$REPO_ROOT/config/git-hooks}"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/md-wrap-guard-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+cd "$WORK"
+git init -q .
+git config user.email test@example.com
+git config user.name test
+git config commit.gpgsign false
+git config core.hooksPath "$HOOKS_DIR"
+
+# The guard resolves the checker from the repo it is committing into, so give
+# this scratch repo a copy at the same path the real one uses.
+mkdir -p custom_bins claude/rules docs
+cp "$REPO_ROOT/custom_bins/md-unwrap" custom_bins/md-unwrap
+chmod +x custom_bins/md-unwrap
+
+printf 'A single-line paragraph.\n' > claude/rules/clean.md
+git add custom_bins/md-unwrap claude/rules/clean.md
+git commit -qm baseline || fail "clean baseline was blocked"
+baseline_count="$(git rev-list --count HEAD)"
+
+# --- Case 1: a hard-wrapped paragraph under claude/ must be blocked ---------
+printf 'This paragraph was hard wrapped\nacross two lines.\n' > claude/rules/wrapped.md
+git add claude/rules/wrapped.md
+if git commit -qm wrapped >/dev/null 2>&1; then
+    fail "hard-wrapped Markdown under claude/ was committed; guard did not fire"
+fi
+[ "$(git rev-list --count HEAD)" = "$baseline_count" ] \
+    || fail "commit count changed despite the guard firing"
+
+# --- Case 2: the same wrapping outside claude/ must pass --------------------
+git restore --staged claude/rules/wrapped.md
+rm claude/rules/wrapped.md
+printf 'This paragraph was hard wrapped\nacross two lines.\n' > docs/wrapped.md
+git add docs/wrapped.md
+git commit -qm outside-claude || fail "Markdown outside claude/ was blocked"
+
+# --- Case 3: a fixed file must commit -------------------------------------
+"$WORK/custom_bins/md-unwrap" --fix --quiet docs/wrapped.md
+cp docs/wrapped.md claude/rules/fixed.md
+git add claude/rules/fixed.md
+git commit -qm fixed || fail "an unwrapped file under claude/ was blocked"
+
+# --- Case 4: fixing the working tree without re-staging must STILL fail -----
+# The gate reads staged content, which is the whole reason it is a pre-commit
+# hook rather than a working-tree linter.
+printf 'Wrapped again\nover two lines.\n' > claude/rules/stale.md
+git add claude/rules/stale.md
+"$WORK/custom_bins/md-unwrap" --fix --quiet claude/rules/stale.md
+if git commit -qm stale-index >/dev/null 2>&1; then
+    fail "a stale hard-wrapped index entry was committed"
+fi
+
+# --- Case 5: code fences and tables under claude/ must not trip the guard ---
+git restore --staged claude/rules/stale.md
+rm claude/rules/stale.md
+cat > claude/rules/structured.md <<'MD'
+# Heading
+
+```python
+x = (1
+     + 2)
+```
+
+| a | b |
+|---|---|
+| 1 | 2 |
+MD
+git add claude/rules/structured.md
+git commit -qm structured || fail "code fences or tables tripped the guard"
+
+# --- Case 6: a repo with no checker present must not be gated --------------
+OTHER="$(mktemp -d "${TMPDIR:-/tmp}/md-wrap-nocheck.XXXXXX")"
+cd "$OTHER"
+git init -q .
+git config user.email test@example.com
+git config user.name test
+git config commit.gpgsign false
+git config core.hooksPath "$HOOKS_DIR"
+mkdir -p claude/rules
+printf 'Wrapped\nlines.\n' > claude/rules/anything.md
+PATH_WITHOUT_CHECKER="$(echo "$PATH" | tr ':' '\n' | grep -v custom_bins | paste -sd:)"
+git add claude/rules/anything.md
+PATH="$PATH_WITHOUT_CHECKER" git commit -qm no-checker \
+    || fail "a repo without md-unwrap was gated anyway"
+rm -rf "$OTHER"
+
+echo "PASS: Markdown hard-wrap guard blocks wrapped claude/ Markdown and nothing else"


### PR DESCRIPTION
Enforce the house rule that one paragraph is ONE line in Markdown, then sweep the tree that had drifted from it.

**The tool no longer re-derives CommonMark.** Four rounds of hand-rolled block scanning were defeated four times, each by a construct its author had not thought of. `c4deb7a` replaces the scanner with a real parser: markdown-it-py decides which lines may be touched, and the hand-rolled code is left with the joining alone. `32d1fcb` finishes the job on the one hand-written layer the rewrite left behind — the HTML-block compatibility patch — which now implements CommonMark's terminator rules in full and **refuses** any block whose extent it cannot establish. The sweep is unchanged — byte-identical for the sixth tool version running.

## Eight commits

- `4c58095` the tool: `custom_bins/md-unwrap` (`--check` / `--fix`), wired into `config/git-hooks/pre-commit` and `.github/workflows/md-no-hard-wrap.yml`, both scoped to Markdown under `claude/`
- `3a80cbc` **two preservation defects fixed** (P1, P2), with the regression tests that failed before the fix
- `947527e` the sweep: 17 files, 70 paragraphs, 149 lines joined
- `da1c659` **P3** — found in review of `3a80cbc`, because the first fix for a preservation bug is usually too narrow
- `8de39f7` **P4** — the same class again, found in review of `da1c659`: the ordering was right and the *reachability* was not
- `c4deb7a` **P5, and the design change that ends the series** — a real CommonMark parser decides which lines may be touched
- `66eb3a9` name the reference implementation the markdown-it divergence was measured against
- `32d1fcb` **P6** — the compatibility layer the rewrite left hand-written: all five terminated HTML block types implemented, and a refusal where the extent is unknowable

## P5 ended the series, so the design changed instead of the rules

The round-five defect, reproduced at ~100% confidence: a fenced example inside a list item whose content is a literal quoted fence delimiter — the text `> ` followed by three backticks. `_strip_quotes` removed blockquote markers on **every** line, including lines inside a fence, so a line of literal code content reached the closing-delimiter test as a bare fence. The fence was declared closed three lines early and the code lines after it were joined as prose. The reviewer's matrix corrupted 16 of 20 cases; a 20-case matrix built here from the same shape (five container markers x two fence characters x two bodies) corrupts 12 of 20 under `8de39f7` and 0 under `c4deb7a`.

Each of the four earlier fixes was correct, and each was followed by another case. That is the signature of a wrong design, not of careless work. You cannot re-derive CommonMark block structure with line-at-a-time heuristics, and every round spent trying grew a worse parser.

**So the block question now goes to a block parser.** The document is parsed with markdown-it-py and the only lines the tool will ever join are the interiors of top-level `paragraph` tokens, read off each token's source line map. Fences, indented code, HTML blocks, tables, headings, thematic breaks, link reference definitions, list markers, blockquotes — and every one of those nested at any depth inside any other — are excluded **because the parser never puts them in a paragraph**, not because a rule remembered to skip them. There is no fifth rule to get wrong.

### What was deleted

`_advance`, `_strip_quotes`, `_list_marker`, `_block_start`, `_block_status`, the 130-line `scan` state machine and its ORDERING RULE, and nine of the fourteen module-level constants: `FENCE_RE`, `ATX_RE`, `THEMATIC_RE`, `SETEXT_RE`, `LIST_MARKER_RE`, `LINK_DEF_RE`, `HTML_START_RE`, `QUOTE_PREFIX_RE` and `BLOCK_INDENT`. A tenth, `HTML_RAW_RE`, survives renamed with one caller instead of the block scanner.

| Measure | Before | After |
|---|---|---|
| `custom_bins/md-unwrap`, total lines | 461 | 361 |
| Block-analysis section, lines | 263 | 158 |
| Block-analysis section, executable statements | 152 | 94 |
| Module-level constants | 14 | 6 |

The 94 statements that remain are frontmatter detection (not CommonMark, so no parser owns it), refusal detection, one measured parser patch, and the join decision. The diff is +246 / −258 across the tool, its tests and the CI workflow; the tool alone is −100 lines.

### What stays hand-rolled, and why

The JOIN decision inside a paragraph is about text rather than structure, and is unchanged in behaviour from `8de39f7`:

| Rule | Why it is not a structure question |
|---|---|
| A two-space or backslash hard break stops the next join | The break is what the author typed; keeping it is what makes `--fix` idempotent |
| A line carrying a pipe declines to be joined | The parser has already lifted real tables out, so what is left is prose too table-shaped to risk |
| A line indented four or more columns declines | Ambiguous with indented code and with a deep list continuation |
| A bolded-label or list-marker line is not joined onto what precedes it | Reached only where CommonMark refused it a block of its own: `2. foo` cannot interrupt a paragraph, but the author still wrote a numbered point |
| A `<`-opening line declines | A closing `</example>` cannot interrupt a paragraph either, so the parser folds it into the prose above. The repo's agent files delimit examples with these tags; reflowing one is a rewrite of the author's markup even where the rendering does not move |

The last two exist **only** for shapes CommonMark deliberately folds into a paragraph. Without them the parser-based tool reflows `</example>` into the prose line above it in `claude/agents/application-writer.md` and `claude/agents/efficient-explorer.md` — which is how the sweep check earned its keep.

### One upstream divergence had to be patched, not trusted

Measured on 2026-09-11 against reference cmark-gfm (cmarkgfm 2025.10.22): **markdown-it ends an HTML block at a blank line even for the five types CommonMark runs to a closing delimiter**. Reproduced on markdown-it-py 3.0.0 and 4.2.0.

The divergence needs a genuinely blank line inside a **list** item — a fence, a blockquote alone, or a blank-terminated block type is unaffected — and it splits one block into a block plus a paragraph that would then be joined, changing significant whitespace inside a `<pre>`. `_html_block_extents` restores those lines when the delimiter appears further down. Where it appears nowhere, the file is refused: see P6 below, which is where this layer was still guessing.

### Refusal is kept, and now reads the token stream

A code fence whose token reaches the last line of the file without its closing delimiter, or an HTML block whose closing delimiter appears nowhere in the document, means the structure was not understood, so `md-unwrap` prints the reason on stderr and leaves the file untouched. Exit paths are unchanged from `8de39f7`; the HTML message now fires on the block rather than only at end of file.

### Dependency

markdown-it-py was already a test dependency; it is now a real one, declared in a PEP 723 inline script block under the repo's `uv run --script` shebang — the same pattern as `custom_bins/model-router-wire`. The CI workflow gains `actions/setup-python` (first-party, matching the workflow's stated supply-chain posture) and one pip step for markdown-it-py and uv, since ubuntu-latest carries neither.

## The four defects

All four were found in review, all four corrupt documents silently, and all four change what a document *means* rather than only how it is laid out.

**P1 — raw HTML protection ended too early.** `md-unwrap` protected a `<pre>`, `<script>`, `<style>` or `<textarea>` block only until the next BLANK LINE. Those are CommonMark HTML block type 1: they run to their matching closing tag, and a blank line inside one does not end the block. So any such block containing a blank line lost protection part-way through and prose joining resumed INSIDE it — two lines of a `<pre>` became one rendered line, and inside a `<script>` a join can change what the code means. Protection now runs to the closing tag, with the opening and closing tag on one line handled so that a `<pre>x</pre>` does not silently protect the rest of the file.

**P2 — joining destroyed explicit hard breaks.** Markdown encodes a hard line break as two trailing spaces, and the joiner called `line.strip()` on the continuation line, which removed them. The author's line break disappeared from the render. It also broke idempotence: the hard break had been what stopped the NEXT line from being joined, so a second `--fix` joined the line the first one left alone. The joiner now strips only the leading continuation indent and keeps a trailing hard break; an incidental single trailing space is still tidied.

**P3 — a pipe on the opening line cancelled HTML protection entirely.** The fix for P1 made a raw block run to its closing tag, but the pipe-and-table exclusion ran BEFORE the HTML block start. So an opening tag carrying a pipe — `<pre class="a|b">`, or `<script>` with a pipe in the content on that same line — was taken by the pipe heuristic, which returned early. The protection state was never installed, the block was never entered, and every line inside it was joined as ordinary prose. P1's own regression test passed throughout, because its fixture has no pipe. This is the reason the third commit exists: the first fix for a preservation bug is usually too narrow.

### Why P3 was one bug in three places

The fix is a single reordering — recognise an HTML block start before applying the pipe exclusion — because the block start is the guard that installs protection STATE, while the exclusion only ever skips one line. Losing that one line to a block start costs nothing.

I audited every other early-return guard for the same mistake. **Only two guards install state**, the code fence and the HTML block, and the fence already ran first, so this was the one *ordering* bug of its class — ~~and therefore the whole class~~ superseded by P4 below: a guard that is never **reached** is as absent as one that runs too late, and the audit never asked where each guard is reached from. The single HTML branch has three consumers, and the same early return was silently breaking all of them:

| Opening line | Before | After |
|---|---|---|
| `<pre class="a\|b">` and the other three raw elements | block never entered, contents joined as prose | protected to `</pre>` |
| `<!-- cols \| rows` | comment body joined, terminator swallowed onto it | protected to `-->` |
| `<div data-x="a\|b">` | block never entered, contents joined as prose | protected to the blank line |

**P4 — a block start was only ever recognised at column zero.** A fenced code block or a raw HTML element written directly after a list marker is valid CommonMark, and the list-item guard took the line first. That guard skips exactly one line, so the block was never entered and every line of it was joined onto the opening fence's info string. A two-line code block came out rendering as an **empty** code block. Confirmed under markdown-it-py for both fence characters, with and without a language tag, across `-`, `*`, `+` and ordered markers, and for all four preformatted elements, HTML comments and generic HTML blocks.

### P4 is P3's rule applied to the dimension P3's audit did not have

P3 fixed the *order* of the guards. P4 is the same rule — a construct that installs protection must beat a construct that skips one line — failing on *reachability* instead: the guard was in the right place and the line never got to it, because the recogniser only ever matched at 0-3 columns from the start of the line.

The general rule, now stated in the scanner's own docstring so the next reader does not have to rediscover it: **a construct that installs protection lasting until a closing delimiter must be recognised BEFORE every guard that skips a single line, and at EVERY column CommonMark allows it** — which is 0-3 columns past its **container's** content column, not past column zero.

So the recogniser now runs against the line with its blockquote and list-item prefixes removed, and one function serves column zero, an item's content column and the inside of a blockquote. Closing delimiters are measured the same way, and a non-blank line that dedents out of the item or leaves the blockquote closes what was opened inside it. The joining guards are untouched and still measure from column zero: they only ever *suppress* a join, and a conservative skip cannot corrupt anything.

### Every site of the class, and what happened to each

| Site | Before | After |
|---|---|---|
| Fence or HTML element on the list-marker line | contents joined onto the info string; code block rendered empty | recognised, at any nesting depth and inside a blockquote |
| Construct at a list item's continuation column | worked at columns 0-3 by luck | correct by construction at any column |
| Inside a blockquote, and a list inside a blockquote | safe only because every line carried `>` and was skipped one at a time | genuinely recognised; a block that loses its blockquote correctly stops protecting the prose after it |
| Closing delimiter at a different indent | matched against column zero only, so the rest of the file froze behind an unterminated fence | accepted up to three columns past the container, and the container ending closes the block |
| Four or more columns past the container | left alone | **deliberately not supported** — CommonMark reads it as indented code and so do we |
| Construct indented under a paragraph continuation | left alone | **deliberately not supported** — under-fixed, never joined |

### Out of its depth is now reported, never guessed at

A fence or raw HTML block still open at end of file means the structure was not understood, so `md-unwrap` prints the reason on stderr and leaves the file untouched instead of rewriting it on a guess. Not supported and detected is acceptable; not supported and silently rewritten is not.

That refusal found a real bug on its first run. `claude/agents/efficient-explorer.md` wrapped a Markdown sample in a three-backtick fence containing a nested ```` ```python ```` block, and a closing fence indented two columns closes the **outer** fence — so everything from `# EXAMPLE INTERACTIONS` to the end of the file was rendering as one code block. Fixed in this commit by opening the sample with four backticks.

## Regression tests — red before each fix, green after

P1 and P2, in `3a80cbc`: 13 failures before, all green after.

P3, in `da1c659`: 12 failures before, all green after, measured by running the new tests against the previous commit's tool.

P4, in `8de39f7`: **50 failures before, all green after**, measured the same way.

| P4 regression test | Shape |
|---|---|
| Fence on the marker line | both fence characters x with and without a language tag x five list markers — 20 subtests, byte-identical output **and** identical rendering |
| Raw HTML on the marker line | all four preformatted elements x five list markers — 20 subtests |
| Generic HTML block and HTML comment on the marker line | one each |
| Nested containers | inside a blockquote, inside a list inside a blockquote, two list levels deep |
| Closing delimiter | three columns past the container closes; four does not; an item ending closes the fence it opened |
| Refusal path | through the module and through the CLI, asserting the file on disk is unchanged |
| The round-two property matrix, rebuilt inside seven containers | 1512 documents against a ground truth that strips the container prefix and is written independently of the fixer |
| Differential render check over the same matrix | CommonMark HTML identical up to whitespace collapse — 16 corrupting documents against the pre-fix tool, 0 after |

The differential render check is the assertion that generalises: joining a wrapped paragraph turns a newline inside a `<p>` into a space and changes nothing else, so collapsing whitespace makes reflow invisible while a missed block start — which loses its `<pre>` entirely — always shows.

- all four raw elements, with a pipe in an attribute value and with a pipe in the opening line's content
- an HTML comment and a generic HTML block whose opening line carries a pipe
- rendered output compared before and after, so the assertion is about observable corruption rather than only bytes
- a genuine Markdown table sitting directly under a prose line is still excluded, and pipe-heavy prose is still left alone — the guard that moved has not stopped doing its job
- a constructed-document property check: every state-installing construct, opened with every decoration that could hijack its opening line, asserting no line inside the resulting block is ever joined. 216 documents, checked against a region scanner written independently of the fixer. It reports 78 corrupting documents against the pre-fix tool and 0 after
- `--fix` is idempotent over the whole corpus — every Markdown file in the repo plus eleven adversarial fixtures, asserted both through the module and through the CLI on real files

### The lesson P3 taught, now encoded in the tests

The repo contains **zero** Markdown lines that both open an HTML block and carry a pipe (`grep -rnE '^ {0,3}<[^>]*\|' --include='*.md'` finds nothing, anywhere in the tree). So a corpus-only check proves very little here: the sweep stayed green, and so did idempotence, because the corruption is *stable* — joining once and then reaching a fixed point is not evidence that the join was correct.

Preservation therefore has to be asserted on **constructed** inputs, which is what the property check above does. The fixtures and the constructed matrix are what make these regression tests rather than standing guards, and the test file says so in its own docstrings.


### P5 regression tests, added in `c4deb7a`

| Test | Shape |
|---|---|
| The reviewer's reproduction | A list-contained fenced example whose content is the literal quoted fence delimiter, followed by two code lines and an outside paragraph. The code lines are not joined, the outside paragraph still is, and the rendered code block is unchanged |
| The same with a tilde fence in an ordered item | Delimiter character and container both varied |
| The same at top level | The defect did not need a container, only the quote-stripping |
| `</example>` after prose, and after a list item | The two shapes that exist in `claude/agents/` |
| Two new adversarial idempotency fixtures | Run alongside all 239 documents in the repo corpus |

All 76 tests that existed at `8de39f7` are untouched and still green, including every regression set from the four previous rounds: the flat protection matrix (207 constructed documents), the nested matrix rebuilt inside seven containers (1449 documents) against an independently written ground truth, and the differential render check over the same matrix.

## P6 — the compatibility layer was still deciding block structure by hand

The parser rewrite moved the block question to a block parser and left exactly one piece of hand-written structure behind: the patch for the markdown-it divergence above, at `custom_bins/md-unwrap` lines 104-113 and 155-163 before this commit. A reviewer found two shapes where it was wrong, both confirmed against cmark-gfm with raw HTML visible.

**Trigger 1, a REGRESSION against `8de39f7`.** A list item holding an unclosed raw HTML block, a genuinely blank line, then two indented content lines. Three things went wrong at once: the blank line ends markdown-it's `html_block`, so the token no longer reached end of file and the end-of-file refusal never saw it; no terminator exists later, so the continuation helper protected nothing; and the two lines below the blank line were joined. Every line of that document is raw HTML block content under cmark-gfm. The previous commit refused this input and left it alone.

**Trigger 2.** A correctly terminated list-contained CDATA section, processing instruction or markup declaration containing a blank line. `_html_terminator` recognised raw tags and comments and nothing else, so all three were read as blank-line-terminated and the half of the block below the blank line was joined as prose — closing delimiter and all.

### Implement the closed set, refuse the open one

The brief allowed either implementing the remaining terminator rules or detecting those types and refusing. **Both, split by whether a rule exists to implement:**

| Case | Choice | Why |
|---|---|---|
| A block type whose end condition CommonMark states | implement it | The set is closed — five types, each ending at a line CONTAINING one literal string: `-->`, `?>`, `]]>`, `>` for a markup declaration, and for type 1 **any** of the four raw closing tags, not only the tag that opened the block. Four lines of code, reusing the protection path the layer already had, and no correctly written document is refused |
| The closing delimiter appears nowhere | refuse | There is no rule left to implement: the block's true extent depends on text that is not in the file. The existing message and exit path are reused, and the file is left byte-identical |
| markdown-it closed the list item or blockquote on the very next token | keep the join | Not a guess — an extent the parser established. A container ends the block it holds, and cmark-gfm reads `> <pre>` followed by unquoted prose the same way. Read off the token stream, not re-derived from the lines |

Refusing where the delimiter is missing is what restores the behaviour of `8de39f7` on trigger 1, so that half is a regression fix rather than a new feature.

### The differential check that catches this class, and the one that did not

**120 documents** — ten HTML openers x six containers x closed and unclosed, each with a blank line inside the block — rendered by reference cmark-gfm with `CMARK_OPT_UNSAFE` so raw HTML block content is visible at all. Each document must end in one of two states: refused, or rendered exactly as before. **33 of the 120 are corrupted by the tool at `66eb3a9`; 0 are corrupted here** — 39 refuse and 81 pass through unchanged.

The comparison is the part that matters. Collapsing whitespace over the whole rendered document — which is what the sweep check and the earlier matrices do — reports **0 corruptions for both tools**, because joining two lines inside a `<pre>` replaces a newline with a space and collapses to the same string. This check collapses whitespace **inside `<p>` only**, so a paragraph reflow is invisible and a join inside a raw block is not. That is why this defect class survived five tool versions of green matrices.

The matrix runs as `TestEveryHtmlBlockTypeInEveryContainerAgainstReferenceCmark` and is red at `66eb3a9` with exactly 33 failing subtests. Ten targeted tests cover the two triggers and the container-ends-the-block exception directly; 8 of those 10 fail at `66eb3a9` and all pass here.

## The sweep has now survived six corrected fixers unchanged

Re-running the parser-based `md-unwrap --fix` over the **pre-sweep** tree (`git archive 947527e^ claude`) produces output **byte-identical** to the committed sweep across all 164 Markdown files under `claude/`: zero differ, compared by MD5 over the whole tree. Re-running `--fix` over the current tree changes nothing, and `md-unwrap --check claude` reports `164 file(s) clean`.

The round-five rewrite is the first one where the sweep was a real gate rather than a formality: the first parser-based draft **did** change two files, reflowing `</example>` into the prose line above it in `claude/agents/application-writer.md` and `claude/agents/efficient-explorer.md`. Investigating those two changes is what produced the `<`-opening-line rule above. Both files are byte-identical again.

One independent check was added on real documents rather than constructed ones: of the 164 pre-sweep files the tool rewrites 17, and reference cmark-gfm renders all 17 identically before and after with whitespace collapsed — 0 render differences.

### Proof the sweep is safe

For every one of the **17 changed files**, **70 paragraphs**, 149 joined lines:

| Check | Result |
|---|---|
| Rendered HTML, tag structure with attributes | identical before and after |
| Rendered HTML, whitespace-normalised text | identical before and after |
| Word content, heading text, list-marker sequence, link reference definitions | unchanged |
| Code-fence lines, any line carrying a pipe, raw HTML lines | unchanged |
| Changed lines carrying a pipe, a fence or raw HTML | none in the whole diff |
| Reference cmark-gfm render, whitespace collapsed | identical for all 17 (added in `c4deb7a`) |
| `--fix` over every Markdown file in the repo, this tool against `66eb3a9` | identical bytes for all 221 files, and neither tool refuses any of them (added in `32d1fcb`) |

**Renderers verified with:** python-markdown 3.10.3 (`tables` + `fenced_code`), markdown-it-py 3.0.0 and 4.2.0 (CommonMark + `table`), and cmark-gfm via cmarkgfm 2025.10.22. All agree on all 17 files.

**Renderers NOT verified with:** GitHub's and Obsidian's, neither of which is installed here. Both are CommonMark supersets, and cmark-gfm is what GitHub's is built on.

## Suite status

The three CI steps in `.github/workflows/md-no-hard-wrap.yml` all pass locally at `32d1fcb`: `python3 -m unittest tests.test_md_unwrap` gives **94 tests, OK** (83 at `66eb3a9`); `bash tests/test_pre_commit_md_wrap_guard.sh` gives `PASS`; `custom_bins/md-unwrap --check claude` gives `164 file(s) clean`.

Whole suite, `python3 -m unittest discover -s tests` with deps supplied through `uv` (`--with pytest --with markdown --with markdown-it-py --with cmarkgfm`): **207 tests, 2 errors, 1 skipped**. The 2 errors are `test_md2artifact_browser` and `test_plotting_merge` failing to import (playwright, matplotlib), identical at baseline. So `32d1fcb` adds 11 test methods (83 → 94) and no failure.

`ruff check custom_bins/md-unwrap tests/test_md_unwrap.py` reports 12 findings, all in the test file and all of the kinds already there (`subprocess.run` without `check=`, unused `noqa`, one pre-existing `removeprefix` hint); it reported 8 at `66eb3a9`, and the 4 added are the three new `subprocess.run` calls and one `noqa` matching the file's existing style. The tool itself is clean.

The workflow's pip step gains `cmarkgfm` so the HTML-block matrix runs natively in CI. Without it the test still runs, through a single `uv run --with cmarkgfm` subprocess for the whole matrix rather than one per document.

Shell suites at `8de39f7`: 26 run, 21 pass. The 5 failures (`test_claude_spawn`, `test_claude_wrapper_channels`, `test_claude_wrapper_rc`, `test_profile_defaults`, `test_reset_mac_media`) fail identically at baseline on this Linux box. `test_pre_commit_md_wrap_guard.sh` and `test_pre_commit_gateway_guard.sh` both pass. `test_model_router_gateway` and `test_mats_slack_tunnel` were skipped: they need launchd or a tailnet.

## What is not done

No `CLAUDE.md` Learnings entry yet — the design change is worth one, but the entry belongs to whoever merges, and this branch touches no documentation beyond the tool's own docstring.

No file in this repo is refused by the new rule. `--fix` over all 221 Markdown files produces identical bytes under this tool and the tool at `66eb3a9`, and neither refuses any of them; the only refusal the sweep has ever produced is the unterminated fence in `claude/agents/efficient-explorer.md` in the pre-sweep tree, which `947527e` fixed. A refusal is still possible on a real document — an unclosed `<pre>` or `<!-- ` inside a list item, with no closing delimiter anywhere below it, refuses the whole file rather than one block. That is a usability cost, and it is the one the brief chose deliberately: silently rewriting is the outcome that must not exist.

