### PR TITLE
Salvage the silent-pty installer harness from #95

### DIFF
--- a/tests/pty_drive.py
+++ b/tests/pty_drive.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Run a command on a real pty whose stdin stays open but silent, and report
+whether it drew a full-screen UI, when, and how it exited.
+
+This is the one harness that reproduces "I ran ./install.sh and nothing
+happened": a TTY exists, so every `[[ -t 0 ]]` guard is bypassed, yet nobody
+types. `</dev/null` cannot reproduce it (every read returns EOF at once) and
+util-linux `script` cannot either (it forwards EOF from its own stdin into the
+pty). Only a pty nobody writes to behaves like a human who never types.
+
+    pty_drive.py [--deadline S] [--expect REGEX] [--send-on-expect BYTES]
+                 [--env K=V ...] -- cmd args...
+
+Prints one JSON object on stdout:
+    exit        integer exit status, or null if the deadline fired
+    expect_at   seconds until --expect first matched, or null
+    elapsed     wall-clock seconds
+    output      everything written to the pty (capped at 1 MB), escapes kept
+
+Exit status: 0 if the child exited before the deadline, 124 on deadline.
+The caller asserts on the JSON, not on this status, so a stalled child is a
+reported fact rather than a crash of the harness.
+"""
+import argparse
+import fcntl
+import json
+import os
+import pty
+import re
+import select
+import signal
+import struct
+import sys
+import termios
+import time
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--deadline", type=float, default=60.0)
+    ap.add_argument("--expect", default=None, help="regex over the pty output")
+    ap.add_argument("--send-on-expect", default=None,
+                    help="bytes (python escapes) written to the pty once --expect matches")
+    ap.add_argument("--send-delay", type=float, default=0.3,
+                    help="seconds between the match and the send, so the UI is ready")
+    ap.add_argument("--env", action="append", default=[], metavar="K=V")
+    ap.add_argument("cmd", nargs=argparse.REMAINDER)
+    args = ap.parse_args()
+    cmd = args.cmd[1:] if args.cmd and args.cmd[0] == "--" else args.cmd
+    if not cmd:
+        ap.error("no command")
+
+    env = dict(os.environ)
+    for kv in args.env:
+        k, _, v = kv.partition("=")
+        env[k] = v
+    # A pty with no size makes some TUIs refuse to draw; give it a real one.
+    env.setdefault("TERM", "xterm-256color")
+    env["COLUMNS"], env["LINES"] = "100", "40"
+
+    expect = re.compile(args.expect.encode()) if args.expect else None
+    to_send = (args.send_on_expect.encode().decode("unicode_escape").encode("latin-1")
+               if args.send_on_expect else None)
+
+    pid, fd = pty.fork()
+    if pid == 0:  # child
+        os.execvpe(cmd[0], cmd, env)
+    # COLUMNS/LINES only reach shell tools; a TUI asks the kernel for the pty's
+    # size, and a fresh pty is 0x0, which makes ratatui render nothing at all.
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 100, 0, 0))
+
+    buf = b""
+    t0 = time.monotonic()
+    expect_at = None
+    send_at = None
+    status = None
+    while True:
+        now = time.monotonic() - t0
+        if now > args.deadline:
+            break
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                chunk = b""
+            if chunk:
+                buf += chunk
+                if expect and expect_at is None and expect.search(buf):
+                    expect_at = time.monotonic() - t0
+                    if to_send is not None:
+                        send_at = expect_at + args.send_delay
+        if send_at is not None and time.monotonic() - t0 >= send_at:
+            os.write(fd, to_send)
+            send_at = None
+        wpid, st = os.waitpid(pid, os.WNOHANG)
+        if wpid == pid:
+            status = st
+            # drain whatever is left in the pty buffer
+            while True:
+                r, _, _ = select.select([fd], [], [], 0.05)
+                if not r:
+                    break
+                try:
+                    chunk = os.read(fd, 65536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                buf += chunk
+            break
+
+    if status is None:
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+        code = None
+    elif os.WIFEXITED(status):
+        code = os.WEXITSTATUS(status)
+    else:
+        code = 128 + os.WTERMSIG(status)
+    os.close(fd)
+
+    # The whole transcript, capped high: callers grep it for a banner printed
+    # in the first lines as well as for the completion line at the end.
+    output = buf[-1_000_000:].decode("utf-8", "replace")
+    print(json.dumps({
+        "exit": code,
+        "expect_at": None if expect_at is None else round(expect_at, 3),
+        "elapsed": round(time.monotonic() - t0, 3),
+        "output": output,
+    }))
+    return 0 if code is not None else 124
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_claude_tools_select.sh
+++ b/tests/test_claude_tools_select.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# `claude-tools select`: the contract the installers' component menu relies on.
+# ═══════════════════════════════════════════════════════════════════════════════
+# Since 2026-06-21 the binary has parsed only --title, ignored the --items that
+# scripts/shared/helpers.sh passes, and read its items from the terminal
+# instead — drawing nothing while it waits for keystrokes nobody types. Every
+# deadline-based check stayed green throughout, because the menu's deadline
+# (run_with_timeout "${DOTFILES_MENU_TIMEOUT:-60}", helpers.sh) does fire and
+# the run does continue. Each case here pins one half of the contract that
+# makes the silent failure impossible:
+#   1. --items on a silent pty draws within 3 s; Enter prints the pre-checked names
+#   2. an unknown flag exits 2 at once, drawing nothing
+#   3. no --items with a terminal on stdin exits 2 at once, drawing nothing
+#   4. Esc exits 1
+#
+# Not pinned here, deliberately: an in-binary --idle-timeout. The menu's
+# deadline lives in the shell (helpers.sh), tests/test_no_stall.sh already
+# asserts it, and test_deadline_holds_without_coreutils covers the macOS path
+# where timeout(1) is absent. A flag no caller passes is not a contract.
+#
+# Case 2 looks pedantic and is not: silently ignoring an unrecognised argument
+# is precisely how --items went missing for two and a half months while the
+# shell kept passing it.
+#
+# Usage: tests/test_claude_tools_select.sh [path-to-claude-tools-binary]
+# Defaults to the committed binary for this platform.
+set -uo pipefail
+DOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64)  ASSET=claude-tools-darwin-arm64 ;;
+    Darwin-x86_64) ASSET=claude-tools-darwin-x86_64 ;;
+    Linux-x86_64)  ASSET=claude-tools-linux-x86_64 ;;
+    Linux-aarch64) ASSET=claude-tools-linux-aarch64 ;;
+    *) echo "FAIL: unsupported platform $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+BIN="${1:-$DOT_DIR/custom_bins/$ASSET}"
+[[ -x "$BIN" ]] || { echo "FAIL: $BIN is not executable" >&2; exit 1; }
+ALT_SCREEN='\x1b\[\?1049h'
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; [[ -n "${2:-}" ]] && printf '       %s\n' "$2"; return 0; }
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/select-test.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+ITEMS="$SCRATCH/items.txt"
+printf 'Base|tmux|Tmux config|true\nBase|vim|Vim config|false\n' > "$ITEMS"
+
+# drive <deadline> <send-or-empty> -- cmd...  → J_EXIT J_AT J_ELAPSED J_OUT
+drive() {
+    local deadline="$1" send="$2"; shift 2
+    [[ "$1" == "--" ]] && shift
+    local -a extra=()
+    [[ -n "$send" ]] && extra=(--send-on-expect "$send")
+    local json
+    # ${extra[@]+"${extra[@]}"}: bash 3.2 (macOS /bin/bash) counts an empty
+    # array expansion as unbound under set -u; this spelling is safe on both.
+    json="$(python3 "$DOT_DIR/tests/pty_drive.py" --deadline "$deadline" --expect "$ALT_SCREEN" ${extra[@]+"${extra[@]}"} -- "$@")"
+    J_EXIT="$(printf '%s' "$json" | python3 -c 'import json,sys; v=json.load(sys.stdin)["exit"]; print("none" if v is None else v)')"
+    J_AT="$(printf '%s' "$json" | python3 -c 'import json,sys; v=json.load(sys.stdin)["expect_at"]; print("none" if v is None else v)')"
+    J_ELAPSED="$(printf '%s' "$json" | python3 -c 'import json,sys; print(int(json.load(sys.stdin)["elapsed"]))')"
+    J_OUT="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["output"])')"
+}
+drew_within() { [[ "$J_AT" != none ]] && python3 -c "import sys; sys.exit(0 if $J_AT <= $1 else 1)"; }
+
+echo "claude-tools select — the menu contract"
+echo "binary: $BIN"
+echo
+
+ITEMS_HONOURED=true
+
+# 1. draws, Enter confirms the pre-checked set (tmux yes, vim no)
+drive 8 '\r' -- "$BIN" select --title test --items "$ITEMS"
+if drew_within 3 && [[ "$J_EXIT" == 0 && "$J_OUT" == *tmux* && "$J_OUT" != *$'\r\nvim'* ]]; then
+    pass "--items on a silent pty draws (at ${J_AT}s); Enter prints the pre-checked names"
+else
+    ITEMS_HONOURED=false
+    fail "--items must draw and Enter must print the pre-checked names" "drew_at=$J_AT exit=$J_EXIT"
+fi
+
+# 2. unknown flag: loud, instant, nothing drawn
+drive 5 '' -- "$BIN" select --items "$ITEMS" --bogus
+if [[ "$J_EXIT" == 2 && "$J_AT" == none && "$J_ELAPSED" -le 2 && "$J_OUT" == *"unknown argument"* ]]; then
+    pass "an unknown flag exits 2 at once with a message, nothing drawn"
+else
+    fail "an unknown flag must exit 2 at once (this is how --items went missing unnoticed)" "exit=$J_EXIT drew_at=$J_AT elapsed=${J_ELAPSED}s"
+fi
+
+# 3. no --items with a terminal on stdin: refuse, never wait
+drive 5 '' -- "$BIN" select --title test
+if [[ "$J_EXIT" == 2 && "$J_AT" == none && "$J_ELAPSED" -le 2 && "$J_OUT" == *"stdin is a terminal"* ]]; then
+    pass "no --items on a terminal exits 2 at once instead of reading the keyboard"
+else
+    fail "no --items on a terminal must be refused, not waited on (the menu stall)" "exit=$J_EXIT drew_at=$J_AT elapsed=${J_ELAPSED}s"
+fi
+
+# 4. Esc cancels
+drive 8 '\x1b' -- "$BIN" select --items "$ITEMS"
+if drew_within 3 && [[ "$J_EXIT" == 1 ]]; then
+    pass "Esc exits 1"
+else
+    fail "Esc must exit 1" "exit=$J_EXIT drew_at=$J_AT"
+fi
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+if [[ "$ITEMS_HONOURED" == false ]]; then
+    cat <<'DIAGNOSIS'
+
+Diagnosis: this binary does not honour --items. It reads its items from stdin,
+so on a terminal it blocks with nothing drawn — the failure the installers show
+today, and the reason every case above is red rather than just case 1.
+Reproduce without this suite:
+
+  printf 'A|x|d|true\n' > /tmp/i.txt
+  claude-tools select --title t --items /tmp/i.txt   # draws nothing, waits
+  printf 'A|x|d|true\n' | claude-tools select --title t   # draws immediately
+
+The fix belongs in tools/claude-tools/src/select/mod.rs (read from --items when
+given; refuse a terminal stdin; reject unknown arguments), followed by a
+rebuild of the committed custom_bins/claude-tools-* assets.
+DIAGNOSIS
+fi
+(( FAIL == 0 ))

--- a/tests/test_installers_silent_pty.sh
+++ b/tests/test_installers_silent_pty.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# On a TTY nobody types at, the installers must DRAW the menu, then finish.
+# ═══════════════════════════════════════════════════════════════════════════════
+# On 2026-09-04 ./install.sh and ./deploy.sh "did nothing": the component menu
+# binary had lost its --items flag in a June merge, read its items from the
+# terminal instead, drew nothing, and waited for keystrokes nobody knew to type.
+# Every stall check passed, because each asserted a DEADLINE — and the 60 s menu
+# deadline fired, logged a warning, and continued. From the user's chair that is
+# a stall; from the canary's it was a pass. tests/test_no_stall.sh cannot see it
+# either: it asserts that the deadline EXISTS, which is true the whole time.
+#
+# CI's own pty step (.github/workflows/no-stall.yml) cannot see it either,
+# because util-linux `script` forwards EOF from its own closed stdin into the
+# pty, so every read returns at once; and --minimal makes "deployed nothing"
+# look identical to success.
+#
+# So this suite runs the real scripts on the one harness that reproduces the
+# report — a pty whose stdin stays OPEN and silent (tests/pty_drive.py) — with
+# a non-minimal profile, and asserts what a deadline cannot:
+#   - the menu DREW (alternate-screen bytes on the pty) within seconds
+#   - the run finished, exit 0, inside a wall-clock bound
+#   - the profile's components were actually deployed
+# plus the two interactive outcomes: Enter confirms the pre-checked set, Esc
+# cancels back to it, and neither leaves the idle deadline to rescue the run.
+#
+# --mutate replaces the platform binary in a scratch copy with a stub that reads
+# stdin — the exact shape of the June regression — and requires red.
+# --mutate=bounded plants a 45 s sleep on the deploy path instead: a wait that
+# gives up eventually is still a stall from the chair, and this proves the
+# wall-clock bound has teeth. A guard that cannot fail proves nothing.
+#
+# Usage: tests/test_installers_silent_pty.sh [--mutate | --mutate=bounded] [--verbose]
+set -uo pipefail
+DOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DRIVE="$DOT_DIR/tests/pty_drive.py"
+ALT_SCREEN='\x1b\[\?1049h'
+# The menu's idle deadline for these runs; the wall bound must comfortably
+# exceed it plus a symlink deploy (measured at 6 s on a warm Linux box).
+MENU_IDLE=4
+DEPLOY_WALL_BOUND=25
+MUTATE=false
+MUTATE_KIND=""
+VERBOSE=false
+for a in "$@"; do
+    case "$a" in
+        --mutate) MUTATE=true; MUTATE_KIND=stdin-binary ;;
+        --mutate=bounded) MUTATE=true; MUTATE_KIND=bounded ;;
+        --verbose) VERBOSE=true ;;
+    esac
+done
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+declare -a FAIL_DETAILS=()
+pass() { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+fail() {
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$1")
+    FAIL_DETAILS+=("$1 — ${2:-}")
+    printf '  \033[31mFAIL\033[0m %s\n' "$1"
+    [[ -n "${2:-}" ]] && printf '       %s\n' "$2"
+}
+
+case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64)  ASSET=claude-tools-darwin-arm64 ;;
+    Darwin-x86_64) ASSET=claude-tools-darwin-x86_64 ;;
+    Linux-x86_64)  ASSET=claude-tools-linux-x86_64 ;;
+    Linux-aarch64) ASSET=claude-tools-linux-aarch64 ;;
+    *) echo "FAIL: unsupported platform $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+# ─── Preconditions: fail loudly, never skip ──────────────────────────────────
+# A suite that passes because the menu binary was missing is the vacuous pass
+# this file exists to end.
+if ! python3 -c 'import pty' 2>/dev/null; then
+    echo "FAIL: python3 with the pty module is required" >&2
+    exit 1
+fi
+if ! "$DOT_DIR/custom_bins/$ASSET" --version >/dev/null 2>&1; then
+    echo "FAIL: custom_bins/$ASSET is missing or does not run — build it first:" >&2
+    echo "      (cd tools/claude-tools && cargo build --release --locked && cp target/release/claude-tools ../../custom_bins/$ASSET)" >&2
+    exit 1
+fi
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/silent-pty.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+mkdir -p "$SCRATCH/home"
+
+# The scripts under test. Under --mutate they are a scratch copy of the repo
+# with the regression planted, so the checkout is never touched.
+RUN_DIR="$DOT_DIR"
+if [[ "$MUTATE" == true ]]; then
+    RUN_DIR="$SCRATCH/repo"
+    mkdir -p "$RUN_DIR"
+    # Tracked files only. claude/ holds the live session state this machine's
+    # ~/.claude symlink points at, so a blind copy of the tree would drag a
+    # gigabyte of it into TMPDIR; a tarball checkout has no .git and takes the
+    # fallback.
+    if git -C "$DOT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+        git -C "$DOT_DIR" ls-files -z | tar -C "$DOT_DIR" --null -T - -cf - | tar -C "$RUN_DIR" -xf -
+    else
+        tar -C "$DOT_DIR" \
+            --exclude=.git --exclude=tmp --exclude=target --exclude=.claude \
+            --exclude=node_modules --exclude=__pycache__ \
+            -cf - . | tar -C "$RUN_DIR" -xf -
+    fi
+    case "$MUTATE_KIND" in
+        stdin-binary)
+            # Answers --version, then reads ITEMS FROM STDIN ignoring --items:
+            # on a terminal that blocks with nothing drawn. June's binary, exactly.
+            cat > "$RUN_DIR/custom_bins/$ASSET" <<'STUB'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && { echo "claude-tools 0.0.0-stub"; exit 0; }
+cat > /dev/null
+exit 0
+STUB
+            chmod +x "$RUN_DIR/custom_bins/$ASSET"
+            ;;
+        bounded)
+            # A wait that gives up eventually is still a stall from the chair.
+            # The anchor is the menu call itself, which both scripts make right
+            # after parse_args and before any component runs.
+            python3 - "$RUN_DIR/deploy.sh" <<'PY' || exit 1
+import sys, pathlib
+p = pathlib.Path(sys.argv[1]); s = p.read_text()
+anchor = "show_component_menu deploy\n"
+assert anchor in s, "mutation anchor missing"
+p.write_text(s.replace(anchor, anchor + "sleep 45\n", 1))
+PY
+            ;;
+    esac
+    echo "(mutation active: $MUTATE_KIND, in a scratch copy of the repo)"
+fi
+
+# drive <deadline> <send-or-empty> -- cmd...  → DRIVE_EXIT DRIVE_AT DRIVE_ELAPSED DRIVE_OUT
+# DOTFILES_SKIP_LOCAL_CONFIG keeps this machine's config.local.sh out of the
+# resolved set, so the standard profile means the same thing everywhere.
+drive() {
+    local deadline="$1" send="$2"; shift 2
+    [[ "$1" == "--" ]] && shift
+    local -a extra=()
+    [[ -n "$send" ]] && extra=(--send-on-expect "$send")
+    local json
+    # ${extra[@]+"${extra[@]}"}: bash 3.2 (macOS /bin/bash) counts an empty
+    # array expansion as unbound under set -u; this spelling is safe on both.
+    json="$(python3 "$DRIVE" --deadline "$deadline" --expect "$ALT_SCREEN" ${extra[@]+"${extra[@]}"} \
+        --env "HOME=$SCRATCH/home" --env "DOTFILES_PROMPT_TIMEOUT=5" \
+        --env "DOTFILES_MENU_TIMEOUT=$MENU_IDLE" --env "DOTFILES_SKIP_LOCAL_CONFIG=1" -- "$@")"
+    DRIVE_EXIT="$(printf '%s' "$json" | python3 -c 'import json,sys; v=json.load(sys.stdin)["exit"]; print("none" if v is None else v)')"
+    DRIVE_AT="$(printf '%s' "$json" | python3 -c 'import json,sys; v=json.load(sys.stdin)["expect_at"]; print("none" if v is None else v)')"
+    DRIVE_ELAPSED="$(printf '%s' "$json" | python3 -c 'import json,sys; print(int(json.load(sys.stdin)["elapsed"]))')"
+    DRIVE_OUT="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["output"])')"
+    [[ "$VERBOSE" == true ]] && printf '%s\n' "$DRIVE_OUT" | tail -8
+    return 0
+}
+drew_within() { [[ "$DRIVE_AT" != none ]] && python3 -c "import sys; sys.exit(0 if $DRIVE_AT <= $1 else 1)"; }
+
+# Non-minimal on purpose: with --minimal an empty run and a correct one print
+# the same thing. Components that write outside the scratch HOME are switched
+# off (claude-tools builds, git-hooks and codex write into the checkout).
+# --allow-worktree --allow-worktree-deploy: two separate guards, and both must
+# be cleared to run this from a worktree. HOME is a scratch dir, so nothing
+# outside $SCRATCH is repointed either way.
+DEPLOY_ARGS=(--allow-worktree --allow-worktree-deploy --profile=standard
+             --no-claude-tools --no-git-hooks --no-codex)
+
+# Shared assertions for a deploy run that must have completed with the standard
+# set. Appends to `why`; the caller adds the menu-outcome checks.
+deploy_completed_with_profile() {
+    [[ "$DRIVE_EXIT" == 0 ]] || why+="exit=$DRIVE_EXIT (none = stalled past the deadline); "
+    (( DRIVE_ELAPSED <= DEPLOY_WALL_BOUND )) || why+="took ${DRIVE_ELAPSED}s, bound is ${DEPLOY_WALL_BOUND}s — something waited; "
+    grep -q "^Profile: standard" <<< "$DRIVE_OUT" || why+="no resolved-profile banner; "
+    grep -q "Deploying tmux configuration" <<< "$DRIVE_OUT" || why+="profile components were not deployed; "
+    grep -q "Deployment complete!" <<< "$DRIVE_OUT" || why+="completion line missing; "
+}
+
+# ─── 1. deploy.sh, nobody types: menu draws, idle deadline, profile deployed ──
+test_deploy_menu_draws_then_deadline_keeps_profile() {
+    drive 90 '' -- zsh "$RUN_DIR/deploy.sh" "${DEPLOY_ARGS[@]}"
+    local why=""
+    drew_within 3 || why+="menu never drew (drew_at=$DRIVE_AT); "
+    grep -q "Component menu unanswered" <<< "$DRIVE_OUT" || why+="no idle-deadline warning; "
+    deploy_completed_with_profile
+    if [[ -z "$why" ]]; then
+        pass "deploy.sh on a silent pty: menu drew at ${DRIVE_AT}s, deadline fired, profile deployed in ${DRIVE_ELAPSED}s"
+    else
+        fail "deploy.sh on a silent pty must draw the menu, time out, and deploy the profile" "$why"
+    fi
+}
+
+# ─── 2. deploy.sh, Enter: confirms the pre-checked set ───────────────────────
+test_deploy_enter_confirms_profile() {
+    drive 60 '\r' -- zsh "$RUN_DIR/deploy.sh" "${DEPLOY_ARGS[@]}"
+    local why=""
+    drew_within 3 || why+="menu never drew (drew_at=$DRIVE_AT); "
+    grep -q "Component menu unanswered" <<< "$DRIVE_OUT" && why+="deadline fired despite Enter; "
+    deploy_completed_with_profile
+    if [[ -z "$why" ]]; then
+        pass "deploy.sh: Enter confirms the pre-checked profile (drew at ${DRIVE_AT}s)"
+    else
+        fail "deploy.sh: Enter on the menu must deploy the pre-checked profile" "$why"
+    fi
+}
+
+# ─── 3. install.sh, Esc: cancels back to the profile, run completes ──────────
+# --minimal here: a non-minimal install.sh installs packages, which is not this
+# suite's business. The menu and the cancel path are what is under test. The
+# menu is shown before the profile is applied, so --minimal still draws it.
+test_install_menu_draws_and_esc_keeps_profile() {
+    drive 60 '\x1b' -- zsh "$RUN_DIR/install.sh" --allow-worktree --minimal
+    local why=""
+    drew_within 3 || why+="menu never drew (drew_at=$DRIVE_AT); "
+    [[ "$DRIVE_EXIT" == 0 ]] || why+="exit=$DRIVE_EXIT; "
+    # Esc exits the menu at once, so the idle deadline must never be reached:
+    # its warning here means the keystroke was not read.
+    grep -q "Component menu unanswered" <<< "$DRIVE_OUT" && why+="deadline fired despite Esc; "
+    grep -q "Installation complete!" <<< "$DRIVE_OUT" || why+="run did not complete; "
+    if [[ -z "$why" ]]; then
+        pass "install.sh on a silent pty: menu drew at ${DRIVE_AT}s, Esc cancelled, run completed"
+    else
+        fail "install.sh must draw the menu and survive Esc" "$why"
+    fi
+}
+
+echo "Installers on a silent pty — the menu draws, and the run still finishes"
+echo
+test_deploy_menu_draws_then_deadline_keeps_profile
+# Under mutation only the case that must go red runs: each extra case waits out
+# the planted regression's full deadline for no additional signal.
+if [[ "$MUTATE" != true ]]; then
+    test_deploy_enter_confirms_profile
+    test_install_menu_draws_and_esc_keeps_profile
+fi
+
+echo
+echo "─────────────────────────────────────────"
+echo "passed: $PASS   failed: $FAIL"
+if (( FAIL > 0 )); then
+    echo "failures:"
+    for f in "${FAILURES[@]}"; do echo "  - $f"; done
+fi
+
+if [[ "$MUTATE" == true ]]; then
+    # Under mutation case 1 MUST be red, and red for the planted reason — any
+    # other failure is a broken suite, not a working guard.
+    case "$MUTATE_KIND" in
+        stdin-binary) want="menu never drew" ;;
+        bounded)      want="took " ;;
+    esac
+    if printf '%s\n' "${FAIL_DETAILS[@]+"${FAIL_DETAILS[@]}"}" \
+        | grep "deploy.sh on a silent pty must draw the menu" | grep -q "$want"; then
+        echo "Mutation caught: the suite goes red for the planted $MUTATE_KIND regression."
+        exit 0
+    fi
+    echo "::error::The silent-pty suite did not go red for the planted $MUTATE_KIND regression — it is vacuous."
+    exit 1
+fi
+(( FAIL == 0 ))


### PR DESCRIPTION
Salvages the three files from #95 (`worktree-installer-stall`, 42 commits behind) that never reached main, onto a fresh branch off current `origin/main`. The rest of that PR — `.github/workflows/no-stall.yml` and all six `tests/golden/profile-*-linux.txt` fixtures — is already on main and was not touched.

## What this adds

`tests/pty_drive.py` runs a command on a pty whose stdin stays **open and silent**, and reports as JSON whether a full-screen UI was drawn, when, and how the child exited. That is the one harness that reproduces "I ran ./install.sh and nothing happened": a TTY exists so every `[[ -t 0 ]]` guard is satisfied, yet nobody types. `</dev/null` cannot reproduce it (every read returns EOF at once), and neither can util-linux `script`, which forwards EOF from its own closed stdin into the pty — which is why the existing pty step in `no-stall.yml` passes in 0.1 s.

`tests/test_installers_silent_pty.sh` drives the real `install.sh` and `deploy.sh` on that pty with a non-minimal profile and asserts what a deadline cannot: the menu **drew** within seconds, the run finished inside a wall-clock bound, and the profile's components were actually deployed. `--mutate` plants a stdin-reading menu binary in a scratch copy of the repo; `--mutate=bounded` plants a 45 s sleep instead. Either must go red or the suite declares itself vacuous.

`tests/test_claude_tools_select.sh` pins the `claude-tools select` contract the component menu depends on: `--items` draws and Enter prints the pre-checked names, an unknown flag exits 2 at once, a terminal stdin with no `--items` is refused rather than read, and Esc exits 1.

## These suites are RED on main right now, and that is the finding

The regression #95 diagnosed is still live. `scripts/shared/helpers.sh` passes `--items "$items_file"` and leaves stdin on the terminal, but `tools/claude-tools/src/select/mod.rs` parses only `--title` and reads its items from stdin — so on a real terminal the menu blocks with nothing drawn until `DOTFILES_MENU_TIMEOUT` rescues the run. Measured on this branch, `DOTFILES_MENU_TIMEOUT=4`, scratch `HOME`:

```
deploy.sh --profile=standard : exit 0, drew_at none, elapsed 6.1s
  "Component menu unanswered for 4s — continuing with the default selection"
  "✓ Deployment complete!"
```

Every existing guard is green throughout, because each one asserts that the deadline exists — which it does, the whole time the menu is broken.

Both suites were verified in both directions, so neither is vacuous:

| run | result |
|---|---|
| `test_installers_silent_pty.sh` against main | 0 passed, 3 failed — "menu never drew (drew_at=none)" |
| `test_installers_silent_pty.sh` against a copy whose menu honours `--items` | 3 passed, 0 failed (menu drew at 0.045 s) |
| `test_installers_silent_pty.sh --mutate` | mutation caught ("menu never drew") |
| `test_installers_silent_pty.sh --mutate=bounded` | mutation caught ("took 50s, bound is 25s") |
| `test_claude_tools_select.sh` against the committed binary | 0 passed, 4 failed, with a diagnosis block |
| `test_claude_tools_select.sh` against a contract-honouring stand-in | 4 passed, 0 failed |

The fix belongs in `tools/claude-tools/src/select/mod.rs` plus a rebuild of the committed `custom_bins/claude-tools-*` assets. It is deliberately **not** in this PR — it is a separate change to a binary, and this PR is only the harness that measures it.

## What was left behind, and why

- `.github/workflows/no-stall.yml` and `tests/golden/profile-*-linux.txt` — already on main, verified before porting.
- The installer and menu changes from #95 (`install.sh`, `deploy.sh`, `config.sh`, `scripts/shared/helpers.sh`, `tools/claude-tools/**`, the rebuilt darwin binary) — main has moved 42 commits and these are the fix, not the harness.
- `artifacts/installer-stall-pulse/**`, its `ARTIFACTS.md` row and the `CLAUDE.md` learning — a status page for a run that ended six days ago.
- The **empty-resolved-set** case (`deploy.sh --only <filtered-component>` must refuse and exit 1). Main has no `guard_nonempty_components` and no "refusing to run an empty deploy" message; asserting it here would be porting an unmerged feature as a test.
- The in-binary **`--idle-timeout`** case. Main's menu deadline lives in the shell (`run_with_timeout "${DOTFILES_MENU_TIMEOUT:-60}"`), `test_no_stall.sh` already pins it, and `test_deadline_holds_without_coreutils` covers the macOS path with no `timeout(1)`. A flag no caller passes is not a contract.

## Adapted, not copied

- Both worktree guards are cleared (`--allow-worktree --allow-worktree-deploy`); #95 knew only the second.
- `Profile: standard` and a plain `Deployment complete!` replace the `Components (N):` banner and the `Deployment complete! (N components)` line, which exist only on that branch.
- The bounded mutation anchors on `show_component_menu deploy`, since `guard_nonempty_components deploy` is not on main.
- Esc and Enter are now checked by the **absence** of the idle-deadline warning, because main's cancel path prints no "Component menu cancelled".
- `test_claude_tools_select.sh` defaults to the committed platform binary instead of requiring a path argument, and prints a reproduction recipe when `--items` is ignored.

## Not wired into CI

`no-stall.yml` is unchanged: the suites are red against main until the menu binary is fixed, and turning the workflow red is not this PR's job. Wiring them in is the natural follow-up once the `select` fix lands.

Run them by hand:

```
bash tests/test_installers_silent_pty.sh            # ~15 s
bash tests/test_installers_silent_pty.sh --mutate   # ~6 s
bash tests/test_claude_tools_select.sh              # ~27 s
```

`shellcheck` clean; `ruff check` clean (`ruff format` deliberately not applied — 29 of 33 existing `tests/*.py` would be reformatted by it).
