### PR TITLE
test: add tests/run-all.sh, a suite runner that separates SKIP from FAIL

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# One command that runs every test suite in this repo and says which ones pass.
+# ═══════════════════════════════════════════════════════════════════════════════
+# The suites here have only ever been invoked by hand, one at a time, from the
+# "Run:" line in each file's own docstring. There was no way to ask the repo
+# "what is green right now", so the answer drifted unobserved — CI's only
+# always-on job has been red on main since 2026-09-01 and nobody noticed.
+#
+# Discovery is by naming convention, so a new suite is picked up by name alone:
+#
+#   tests/test_*.sh             repo-level bash suites
+#   tests/test_*.zsh            repo-level zsh suites
+#   tests/test_*.py             repo-level Python suites (pytest and unittest)
+#   claude/hooks/test_*.sh      hook suites, colocated with the hooks
+#   scripts/tests/test-*.sh     script suites (note the hyphen)
+#
+# SKIP IS NOT FAILURE, and keeping the two apart is the whole point. Several
+# suites legitimately cannot run everywhere: the Playwright browser tests want
+# Chromium, the plotting tests want matplotlib, the gateway smoke test wants a
+# running loopback router, a launchd/systemd user session and a tailnet. A
+# runner that painted those red would be as uninformative as the CI it is meant
+# to make visible. Four signals separate them:
+#
+#   1. exit 77  — the suite decided for itself that it cannot run here. This is
+#                 already the repo's convention (tests/test_cw_resume_env.zsh).
+#   2. missing interpreter — no zsh, no Python, no pytest anywhere.
+#   3. a Python suite whose every test skipped (pytest's own importorskip and
+#      skipif markers, which most optional-dependency suites already carry).
+#   4. SKIP_WHEN below — a named environment gate for a suite that predates the
+#      exit-77 convention and would otherwise fail loudly off its own machine.
+#
+# --strict turns SKIP into failure. That is for a machine you have provisioned
+# to run everything; it is deliberately NOT the default, because the default
+# has to be honest on a laptop.
+#
+# Usage: tests/run-all.sh --help
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO" || exit 1
+
+# Per-suite wall-clock deadline. The suites under test include installers whose
+# entire subject is hanging, so an unbounded runner can itself hang.
+TIMEOUT="${RUN_ALL_TIMEOUT:-600}"
+
+STRICT=0
+VERBOSE=0
+LIST=0
+FILTER=""
+
+usage() {
+    cat <<'EOF'
+Usage: tests/run-all.sh [options]
+
+Runs every discovered test suite and reports PASS / FAIL / SKIP per suite.
+
+Options:
+  -k <substr>   run only suites whose path contains <substr>
+  -v            stream suite output even when the suite passes
+  -l, --list    list the discovered suites and exit, running nothing
+  --strict      treat SKIP as failure (for a fully provisioned machine)
+  -h, --help    this help
+
+Environment:
+  RUN_ALL_TIMEOUT   per-suite deadline in seconds (default 600)
+
+Exit codes:
+  0  every suite that ran passed
+  1  at least one suite failed (or skipped, under --strict)
+  2  usage error
+
+A suite reports that it cannot run here by exiting 77; that is a SKIP, not a
+failure. Python suites additionally count as SKIP when every test in them
+skipped, which is how the optional-dependency suites already declare
+themselves.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -k) FILTER="${2:-}"; [ -z "$FILTER" ] && { echo "-k needs a value" >&2; exit 2; }; shift 2 ;;
+        -v) VERBOSE=1; shift ;;
+        -l|--list) LIST=1; shift ;;
+        --strict) STRICT=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [ -t 1 ]; then
+    RED=$'\033[31m'; GRN=$'\033[32m'; YEL=$'\033[33m'; BLD=$'\033[1m'; DIM=$'\033[2m'; OFF=$'\033[0m'
+else
+    RED=""; GRN=""; YEL=""; BLD=""; DIM=""; OFF=""
+fi
+
+# ─── environment gates ───────────────────────────────────────────────────────
+# Suites that need a resource this machine may not have, and that predate the
+# exit-77 convention so cannot say so themselves. Each entry names a probe; a
+# failing probe is a SKIP with that reason. Migrating a suite to its own
+# exit 77 is strictly better — then it can gate per-leg — so this list should
+# shrink, not grow.
+skip_reason() {
+    case "$1" in
+        tests/test_model_router_gateway.sh)
+            # Its first leg asks the OS service manager whether the router is
+            # running, so a box with neither launchd nor systemd cannot answer
+            # at all. (Its tailnet leg already skips itself, and the Bash
+            # sandbox blocks loopback — run this one with the sandbox off, or a
+            # healthy router reads as down.)
+            if ! command -v launchctl >/dev/null 2>&1 && ! command -v systemctl >/dev/null 2>&1; then
+                echo "no launchd or systemd service manager"
+            fi
+            ;;
+    esac
+}
+
+PASSED=(); FAILED=(); SKIPPED=()
+
+report() {
+    local status="$1" name="$2" note="${3:-}"
+    case "$status" in
+        pass) PASSED+=("$name");  printf '  %sPASS%s  %s%s%s%s\n' "$GRN" "$OFF" "$name" "$DIM" "${note:+  $note}" "$OFF" ;;
+        fail) FAILED+=("$name");  printf '  %sFAIL%s  %s%s\n'     "$RED" "$OFF" "$name" "${note:+  ($note)}" ;;
+        skip) SKIPPED+=("$name"); printf '  %sSKIP%s  %s%s\n'     "$YEL" "$OFF" "$name" "${note:+  ($note)}" ;;
+    esac
+}
+
+selected() {
+    [ -z "$FILTER" ] && return 0
+    case "$1" in *"$FILTER"*) return 0 ;; *) return 1 ;; esac
+}
+
+# Run one command as a suite and fold the result into the tally. Output is
+# buffered and replayed only on failure (or under -v): a green run should be a
+# readable list, not thousands of lines of per-assertion chatter.
+#
+# Every suite gets stdin from /dev/null. That is load-bearing twice over: the
+# discovery loop is draining a pipe on fd 0, so a suite that reads stdin
+# swallows the rest of the suite list and the run ends early with a green
+# summary (claude/hooks/test_hook_features.sh does exactly this); and the
+# suites are meant to run unattended, so anything that would prompt must see
+# EOF rather than hang until the deadline.
+run_cmd() {
+    local name="$1"; shift
+    local out rc=0 started elapsed
+    started=$SECONDS
+    if command -v timeout >/dev/null 2>&1; then
+        out="$(timeout --foreground "$TIMEOUT" "$@" 2>&1 </dev/null)" || rc=$?
+    else
+        out="$("$@" 2>&1 </dev/null)" || rc=$?
+    fi
+    elapsed=$((SECONDS - started))
+
+    case "$rc" in
+        0)   report pass "$name" "${elapsed}s"
+             [ "$VERBOSE" -eq 1 ] && printf '%s\n' "$out" | sed 's/^/        /' ;;
+        77)  report skip "$name" "$(printf '%s' "$out" | grep -i -m1 'skip' | sed 's/^ *//' || true)" ;;
+        124) report fail "$name" "timed out after ${TIMEOUT}s"
+             printf '%s\n' "$out" | tail -20 | sed 's/^/        | /' ;;
+        *)   report fail "$name" "exit $rc, ${elapsed}s"
+             printf '%s\n' "$out" | sed 's/^/        | /' ;;
+    esac
+    return 0
+}
+
+# ─── discovery ───────────────────────────────────────────────────────────────
+# `find` rather than a glob, so a directory with no matches yields nothing
+# instead of the literal pattern.
+shell_suites() {
+    {
+        find tests -maxdepth 1 \( -name 'test_*.sh' -o -name 'test_*.zsh' \) -type f
+        find claude/hooks -maxdepth 1 -name 'test_*.sh' -type f
+        find scripts/tests -maxdepth 1 -name 'test-*.sh' -type f
+    } 2>/dev/null | LC_ALL=C sort
+}
+
+python_suites() {
+    find tests -maxdepth 1 -name 'test_*.py' -type f 2>/dev/null | LC_ALL=C sort
+}
+
+if [ "$LIST" -eq 1 ]; then
+    { shell_suites; python_suites; } | while IFS= read -r s; do
+        selected "$s" && printf '%s\n' "$s"
+    done
+    exit 0
+fi
+
+# ─── how to run a Python suite ───────────────────────────────────────────────
+# There is no virtualenv in this repo and no pytest on the system interpreter,
+# so uv is the normal path. Probe all three forms the suites are documented
+# under; pytest also collects the plain unittest.TestCase suites, so one
+# resolved command covers both styles.
+SYS_PY="$(command -v python3 || true)"
+PYTEST=()
+if python3 -c 'import pytest' >/dev/null 2>&1; then
+    PYTEST=(python3 -m pytest)
+elif command -v pytest >/dev/null 2>&1; then
+    PYTEST=(pytest)
+elif command -v uv >/dev/null 2>&1; then
+    # Pin uv to the system interpreter rather than letting it fetch its own.
+    # Several suites reach their optional dependencies through whatever
+    # `python3` resolves to — test_md2artifact_*.py probe /usr/bin/python3 for
+    # markdown-it-py by name — so an unpinned `uv run` lands on a freshly
+    # downloaded interpreter that carries none of them, and turns "the
+    # dependency is installed on this machine" into a spurious FAIL.
+    if [ -n "$SYS_PY" ]; then
+        PYTEST=(uv run --quiet --no-project --python "$SYS_PY" --with pytest python -m pytest)
+    else
+        PYTEST=(uv run --quiet --no-project --with pytest python -m pytest)
+    fi
+fi
+
+# Colour is decided by OUR stdout, not pytest's: suite output is captured into a
+# variable (never a terminal), so pytest would otherwise strip colour even when
+# the runner is being watched — and an ambient FORCE_COLOR would smear escape
+# codes through a redirected log.
+if [ -t 1 ]; then PYTEST_COLOR=--color=yes; else PYTEST_COLOR=--color=no; fi
+
+# pytest's own exit codes and summary line, translated into our three states.
+# A file whose every test skipped exits 0 with a summary that mentions no
+# passes — that is the optional-dependency case (matplotlib, Playwright,
+# markdown-it-py), and calling it PASS would overstate what was checked.
+run_pytest_suite() {
+    local name="$1" out rc=0 started elapsed summary
+    started=$SECONDS
+    if command -v timeout >/dev/null 2>&1; then
+        out="$(timeout --foreground "$TIMEOUT" "${PYTEST[@]}" -q -rs -p no:cacheprovider "$PYTEST_COLOR" "$name" 2>&1 </dev/null)" || rc=$?
+    else
+        out="$("${PYTEST[@]}" -q -rs -p no:cacheprovider "$PYTEST_COLOR" "$name" 2>&1 </dev/null)" || rc=$?
+    fi
+    elapsed=$((SECONDS - started))
+    summary="$(printf '%s\n' "$out" | grep -E '^[0-9]+ (passed|skipped|failed)|passed|skipped' | tail -1)"
+    # -rs prints one "SKIPPED [n] file:line: reason" line per skip. The first
+    # reason is what a reader wants ("matplotlib not installed"), not the bare
+    # count, so lift it when the whole suite skipped.
+    reason="$(printf '%s\n' "$out" | sed -n 's/^SKIPPED \[[0-9]*\] [^ ]*: //p' | head -1)"
+
+    if [ "$rc" -eq 5 ] && grep -q '^if __name__ == "__main__"' "$name"; then
+        # Not every tests/*.py is a pytest module. A few are standalone scripts
+        # that own their own assertions and exit codes — the PTY suites, which
+        # need a real terminal that no collector can hand them. pytest collects
+        # nothing from those (exit 5), which is the signal to run the file the
+        # way its own docstring says to. Only rc 5 falls through here, so a
+        # suite pytest CAN collect is never quietly run some other way.
+        run_cmd "$name" "${SYS_PY:-python3}" "$name"
+    elif [ "$rc" -eq 5 ]; then
+        report skip "$name" "${reason:-no tests collected}"
+    elif [ "$rc" -eq 0 ]; then
+        case "$summary" in
+            *passed*) report pass "$name" "${elapsed}s  ${summary% in *}" ;;
+            *skipped*) report skip "$name" "${summary% in *}${reason:+ — $reason}" ;;
+            *) report pass "$name" "${elapsed}s" ;;
+        esac
+        [ "$VERBOSE" -eq 1 ] && printf '%s\n' "$out" | sed 's/^/        /'
+    elif [ "$rc" -eq 124 ]; then
+        report fail "$name" "timed out after ${TIMEOUT}s"
+        printf '%s\n' "$out" | tail -20 | sed 's/^/        | /'
+    else
+        report fail "$name" "exit $rc, ${elapsed}s  ${summary% in *}"
+        printf '%s\n' "$out" | tail -40 | sed 's/^/        | /'
+    fi
+    return 0
+}
+
+# ─── run ─────────────────────────────────────────────────────────────────────
+printf '%s== shell suites ==%s\n' "$BLD" "$OFF"
+while IFS= read -r suite; do
+    selected "$suite" || continue
+    gate="$(skip_reason "$suite")"
+    if [ -n "$gate" ]; then
+        report skip "$suite" "$gate"
+        continue
+    fi
+    case "$suite" in
+        *.zsh)
+            if command -v zsh >/dev/null 2>&1; then
+                run_cmd "$suite" zsh "$suite"
+            else
+                report skip "$suite" "zsh not installed"
+            fi
+            ;;
+        *) run_cmd "$suite" bash "$suite" ;;
+    esac
+done < <(shell_suites)
+
+printf '\n%s== python suites ==%s\n' "$BLD" "$OFF"
+if [ ${#PYTEST[@]} -eq 0 ]; then
+    while IFS= read -r suite; do
+        selected "$suite" && report skip "$suite" "no pytest and no uv"
+    done < <(python_suites)
+else
+    while IFS= read -r suite; do
+        selected "$suite" || continue
+        run_pytest_suite "$suite"
+    done < <(python_suites)
+fi
+
+# ─── summary ─────────────────────────────────────────────────────────────────
+printf '\n%s== summary ==%s\n' "$BLD" "$OFF"
+printf '  %spassed%s   %d\n' "$GRN" "$OFF" "${#PASSED[@]}"
+printf '  %sfailed%s   %d\n' "$RED" "$OFF" "${#FAILED[@]}"
+printf '  %sskipped%s  %d\n' "$YEL" "$OFF" "${#SKIPPED[@]}"
+
+if [ "${#FAILED[@]}" -gt 0 ]; then
+    printf '\n%sFailing suites:%s\n' "$RED" "$OFF"
+    printf '  %s\n' "${FAILED[@]}"
+fi
+
+if [ "${#FAILED[@]}" -gt 0 ]; then
+    exit 1
+fi
+
+if [ "$STRICT" -eq 1 ] && [ "${#SKIPPED[@]}" -gt 0 ]; then
+    printf '\n%s--strict: a skipped suite counts as a failure%s\n' "$RED" "$OFF"
+    printf '  %s\n' "${SKIPPED[@]}"
+    exit 1
+fi
+
+printf '\n%sEvery suite that ran passed.%s\n' "$GRN" "$OFF"


### PR DESCRIPTION
Salvages the one durable idea from #60 (`claude/test-coverage-analysis-67dcrk`, 410 commits behind main): the repo has 82 test suites and no way to run them. The runner is rewritten against the suites that exist today, not ported — #60's version discovered four conventions, three of which have since moved, and resolved a pytest that does not exist on this machine.

## Why it matters more now than when #60 was written

The `Stall canary + profile defaults` job in `.github/workflows/no-stall.yml` has been failing on `main` itself on every run since 2026-09-01, so CI has been uninformative here for ten days with nobody noticing. `tests/test_no_stall.sh` passes; `tests/test_profile_defaults.sh` is the half that is red, and all seven profiles have drifted from their pinned sets.

The runner found something sharper while proving itself: **`63f71da` (#120), the most recent commit on `main`, broke its own test.** It changed `claude/hooks/pr_after_push.sh` alone, adding a `gh pr list` call ahead of `gh pr create`, and `tests/test_pr_after_push.sh` asserts on the *first* recorded `gh` invocation. The `create` call is correct (`pr create --draft --fill --title init --head feature-x`); only the test's first-call assumption is stale. That suite passes at the local tree's older HEAD and fails at `origin/main`, which is exactly the class of regression a runner exists to surface.

## What the runner does

Discovery is by naming convention, so a new suite is picked up by name alone: `tests/test_*.{sh,zsh,py}`, `claude/hooks/test_*.sh`, `scripts/tests/test-*.sh`. It has `--help`, `-k <substr>`, `-v`, `-l/--list`, `--strict`, a per-suite deadline via `RUN_ALL_TIMEOUT`, real exit codes (0 green, 1 failures, 2 usage), no absolute paths, and it is `shellcheck` clean.

**SKIP is kept apart from FAIL**, which is the point. Four signals, in preference order:

- `exit 77` — the suite decided for itself. This is already the repo's convention (`tests/test_cw_resume_env.zsh:18`), not something invented here.
- A missing interpreter (no zsh, no Python, no pytest anywhere).
- A Python suite whose every test skipped, via pytest's own `importorskip`/`skipif` markers — which is how the optional-dependency suites already declare themselves. The reason is lifted from `-rs` output and printed, so the line reads `SKIP tests/test_plotting_merge.py (matplotlib not installed)`.
- A small named table for suites that predate `exit 77` and would otherwise fail loudly off their own machine. It has exactly one entry (`tests/test_model_router_gateway.sh`, whose first leg asks the OS service manager a question a box with neither launchd nor systemd cannot answer), and the comment says it should shrink rather than grow.

`--strict` turns SKIP into failure for a machine provisioned to run everything. It is deliberately not the default, because the default has to be honest on a laptop.

## Three things the survey forced

- **Suites get stdin from `/dev/null`.** The discovery loop drains a pipe on fd 0, and `claude/hooks/test_hook_features.sh` reads stdin — on the first full run it swallowed the remaining 42 suites and the run ended early with a green summary. This is the bug that would have made the runner actively harmful.
- **`uv` is pinned to the system interpreter.** Unpinned, `uv run --no-project --with pytest` downloads its own Python (3.14 here), which carries none of the optional dependencies the suites reach through `python3` by name — `tests/test_md2artifact_*.py` probe `/usr/bin/python3` for markdown-it-py explicitly. That turned "installed on this machine" into a spurious FAIL for `test_md2artifact_key.py`. Pinning also matters on principle: every hook and `custom_bins` script under test has a `#!/usr/bin/env python3` shebang, so the system interpreter is production and a downloaded 3.14 tests something that never runs.
- **A `tests/*.py` that pytest collects nothing from, and that carries a `__main__` guard, is run as a script.** `tests/test_claude_task_list_sigint.py` is one: its docstring says `Run: python3 tests/...` and `Exit 0 = pass, 1 = fail, 77 = skipped`, because a PTY suite owns its own assertions — no collector can hand it a terminal. Only pytest exit 5 falls through, so a suite pytest *can* collect is never quietly run some other way.

## True current state of the repo's suites

`RUN_ALL_TIMEOUT=180 ./tests/run-all.sh` on this branch (Linux, no Playwright, no matplotlib):

```
== summary ==
  passed   70
  failed   9
  skipped  3
```

Reported honestly and not fixed here — this PR adds a runner and changes no suite and no subject code.

| Failing suite | What is wrong |
|---|---|
| `tests/test_profile_defaults.sh` | All 7 profiles drifted from their pinned sets; CLI flags disagree with the env profiles. This is the red half of the CI job. |
| `tests/test_pr_after_push.sh` | Broken by `63f71da` (#120) — stale first-`gh`-call assumption, described above. |
| `claude/hooks/test_hook_features.sh` | 14 passed, 1 failed: 9 registered hooks are unclassified in the checked-in policy. |
| `tests/test_claude_wrapper_rc.sh` | 17 passed, 6 failed, all on the `CLAUDE_RC_OVERRIDE` path. |
| `tests/test_claude_wrapper_channels.sh` | 3 passed, 4 failed: the channels flag does not survive to the launch argv. |
| `tests/test_claude_spawn.sh` | 66 passed, 1 failed: `argv probe: option terminator present`. |
| `tests/test_reset_mac_media.sh` | 22 assertions pass; one uses BSD `stat -f %Lp` and cannot run on Linux. A portability bug in the test, not an environment gate — gating the whole suite would hide the 22 that do pass. |
| `tests/test_claude_usage_audit.py` | 47 passed, 1 failed: a monkeypatched `os.scandir` is not intercepted on Python 3.12, though it is on 3.14. Newly visible *because* of the interpreter pin, and a true finding — it fails under the interpreter its subject actually runs on. |
| `tests/test_memory_tier_budget.py` | 13 passed, 6 failed. Five are the known pre-existing file-size ceilings (`claude/rules/background-jobs.md`, `claude/rules/communication.md`, `claude/rules/delegation.md`, `claude/CLAUDE.md`, `CLAUDE.md`); the sixth is `test_no_unguarded_rule_files` — `claude/rules/vault-deliverables.md` and `claude/rules/sensitive-content.md` exist on disk with no ceiling entry. Confirmed reported correctly; deliberately not fixed. |

The 3 skips are `tests/test_md2artifact_browser.py` (no Playwright), `tests/test_plotting_merge.py` (no matplotlib) and `tests/test_ensure_model_router_launchd.py` (opt-in real macOS launchd integration).

`tests/test_model_router_gateway.sh` passes here in 95s, with the Bash sandbox off — inside the sandbox loopback is blocked and a healthy router reads as down.

## Left behind from #60, on purpose

- **Its eight test fixes.** They target `test_memory_tier_budget`, `test_vault_sync_gate` and `test_simplify_reuse` as those files were 40 days and 410 commits ago. All three now pass on their own terms (`test_vault_sync_gate.py` 53 passed, `test_simplify_reuse.sh` green), so the fixes are worthless and would be noise.
- **`.gitlab-ci.yml`.** This repo is on GitHub Actions.
- **The CI workflow and its `cargo test` gate.** See below.

## Deliberately not in this PR

No CI workflow gating on the runner. Nine suites are red on `main` right now, so a gate added today fails on its first run and gets disabled or ignored — which is how the existing `no-stall` job became invisible. Getting the runner correct and honest comes first.

Proposed as follow-ups, roughly in order:

1. Fix `tests/test_pr_after_push.sh` — a one-commit regression from #120 and the cheapest win.
2. Fix or re-pin `tests/test_profile_defaults.sh`, which turns the existing CI job green again and restores the signal that has been missing since 2026-09-01.
3. Work the rest of the list down, then add `.github/workflows/tests.yml` running `tests/run-all.sh` on push and PR. Checkout needs `fetch-depth: 0` — `test_memory_tier_budget.py` resolves a tag. That workflow is also the right place for #60's other good idea, a `cargo test` gate for `tools/claude-tools`, which today ships as a committed binary with no test step.
4. Make `tests/run-all.sh` discoverable — a row in the CLAUDE.md *Common Tasks* table. Left out here because root `CLAUDE.md` is 34453 bytes against an 11100 ceiling and already failing that assertion; adding to an over-budget always-on file in the same PR that reports it as red would be the wrong order.
5. Migrate `tests/test_model_router_gateway.sh` to its own `exit 77`, so it can gate per-leg and the runner's one-entry environment table can be emptied.
