### PR TITLE
codex: trust the remember hooks and refresh the rules mirror

### DIFF
--- a/codex/.gitignore
+++ b/codex/.gitignore
@@ -22,6 +22,8 @@ memories/
 ambient-suggestions/
 process_manager/
 app-server-control/
+app-server-daemon/
+tui-thread-reference-capabilities/
 attachments/
 chrome-native-hosts-v2.json
 .codex-chronicle-assets-to-install.marker

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -242,6 +242,18 @@ trusted_hash = "sha256:62acbaff2b2f55f41971e21a164990aaa53c96919baa0a5eae2eb5db7
 [hooks.state."superpowers@claude-plugins-official:hooks/hooks-codex.json:session_start:0:0"]
 trusted_hash = "sha256:687e7af87f0cb59b1bcc71d368e097304b45d84999c90dc97358a22811691a3f"
 
+[hooks.state."remember@claude-plugins-official:hooks/hooks.json:user_prompt_submit:0:0"]
+trusted_hash = "sha256:063ea45c81012b7c36a92e4f0de9e8aaf2dcefeac5c09c6b45466acc62695486"
+
+[hooks.state."remember@claude-plugins-official:hooks/hooks.codex.json:post_tool_use:0:0"]
+trusted_hash = "sha256:b54eb6fa509b1829789b3c820f29cacd3636120ad2a563b8b839d94face0170a"
+
+[hooks.state."remember@claude-plugins-official:hooks/hooks.codex.json:session_start:0:0"]
+trusted_hash = "sha256:cd46d4c1408a0c59a707c959639837696d2fa1f17346db351523e3c04916ef56"
+
+[hooks.state."remember@claude-plugins-official:hooks/hooks.codex.json:user_prompt_submit:0:0"]
+trusted_hash = "sha256:71d43e21408ae365e00406e47e68fc72a78df1a758513ad07dcbf2490467ecd1"
+
 [memories]
 generate_memories = true
 use_memories = true

--- a/codex/rules/default.rules
+++ b/codex/rules/default.rules
@@ -30,6 +30,10 @@
 # Skipped non-Bash permission (allow): Artifact
 # Skipped non-Bash permission (allow): Read
 # Skipped non-Bash permission (allow): Read(**/.envrc)
+prefix_rule(pattern=["bash", "-lc", "model-router-wire *"], decision="allow")
+prefix_rule(pattern=["model-router-wire", "*"], decision="allow")
+prefix_rule(pattern=["bash", "-lc", "mutool draw *"], decision="allow")
+prefix_rule(pattern=["mutool", "draw", "*"], decision="allow")
 # Skipped non-Bash permission (allow): mcp__claude_ai_Notion__notion-fetch
 # Skipped non-Bash permission (allow): mcp__claude_ai_Notion__notion-search
 # Skipped non-Bash permission (allow): mcp__claude_ai_Notion__notion-get-comments
@@ -170,15 +174,8 @@ prefix_rule(pattern=["bash", "-lc", "* | zsh*"], decision="forbidden")
 prefix_rule(pattern=["*", "|", "zsh*"], decision="forbidden")
 
 # ask rules
-prefix_rule(pattern=["bash", "-lc", "curl * | *"], decision="prompt")
-prefix_rule(pattern=["curl", "*", "|", "*"], decision="prompt")
-prefix_rule(pattern=["bash", "-lc", "wget * | *"], decision="prompt")
-prefix_rule(pattern=["wget", "*", "|", "*"], decision="prompt")
-# Skipped non-Bash permission (ask): ExitPlanMode
 prefix_rule(pattern=["bash", "-lc", "sudo *"], decision="prompt")
 prefix_rule(pattern=["sudo", "*"], decision="prompt")
-prefix_rule(pattern=["bash", "-lc", "kubectl delete *"], decision="prompt")
-prefix_rule(pattern=["kubectl", "delete", "*"], decision="prompt")
 # Skipped non-Bash permission (ask): Read(**/.env)
 # Skipped non-Bash permission (ask): Read(**/.env.*)
 


### PR DESCRIPTION
Codex prompts before it runs a plugin hook whose content it has not seen, so the remember plugin's capture hooks asked for trust on every session start, prompt submit and tool use. This pre-trusts them, ignores two Codex runtime directories that sat untracked on every machine, and regenerates the permissions mirror the Codex rule engine reads.

The mirror matters most here, and it needs a decision from you. `codex/rules/default.rules` is generated from `claude/settings.json` by `scripts/sync_claude_to_codex.sh`. It was regenerated against the **deployed** settings — `~/.claude/settings.json`, which is the working copy of `claude/settings.json` on the main checkout — whose `ask` block is exactly `Bash(sudo *)`, `Read(**/.env)`, `Read(**/.env.*)` and whose `allow` list carries `Bash(model-router-wire *)` and `Bash(mutool draw *)`. The version of this file in the unsplit base commit was generated at a moment when the whole `permissions.ask` block had been deleted, so it dropped the sudo and `.env` prompts as well; that version is not used here.

That deployed state is ahead of both `main` and #133, so the mirror is too. Measured against #133 at `c8b1697` (`gh pr diff 133`), which changes one line — it removes `Bash(curl * | *)` and keeps everything else — the mirror differs in five entries once #133 lands: it also drops the `wget * | *`, `ExitPlanMode` and `kubectl delete *` prompts, and it adds the `model-router-wire` and `mutool draw` allows that no open pull request commits. The Codex side therefore follows what the machine enforces today rather than what the repo has committed. If you would rather the generated file never run ahead of its source, say so and the answer is one command after #133 merges: regenerate the block from the committed `claude/settings.json` and the two files agree again.

### Files

- `codex/config.toml` — four `hooks.state` entries pre-trusting the remember plugin's hooks: the three Codex-side bindings in `hooks/hooks.codex.json` (`session_start`, `user_prompt_submit`, `post_tool_use`) and the `user_prompt_submit` entry of the Claude manifest, alongside the two remember entries the file already carried. Nothing else in the file changes — the model stays `gpt-6-astra` at `ultra`.
- `codex/.gitignore` — ignores `app-server-daemon/` and `tui-thread-reference-capabilities/`, two directories Codex creates in its own config directory, which is this repo's `codex/` through the deploy symlink. Both are present and untracked in the main checkout today.
- `codex/rules/default.rules` — regenerated mirror: `model-router-wire` and `mutool draw` gain allow rules, and the ask section drops the curl, wget, `kubectl delete` and plan-mode prompts while keeping `sudo` and the two `.env` reads.

### Deliberately not included

- `claude/settings.json` — the permissions change itself belongs to #133, which touches that one file and nothing else (`gh pr view 133 --json files`), so there is no collision on `default.rules` between the two. Merge order does not matter for conflicts; it matters only for how long the mirror runs ahead, as described above.
- The `[projects."…/worktrees/multi-provider-models-spec/tmp/alignment-hive-model-picker"]` trust entry from the base commit. That worktree no longer exists (`ls` reports no such file or directory), so the entry would re-grant trust to a path nothing occupies.
- The removal of `last_updated` from `[marketplaces.openai-bundled]`. Codex rewrites that timestamp on every marketplace refresh, so deleting it buys a dirty working tree rather than less churn.
- The router, watchdog, daemon-env, `figcheck-pdf` and checklist changes that shared the same base commit — each is its own pull request in this split.

### Verification

The regenerated mirror differs from the base commit's version in exactly one place, the restored ask section:

```
$ git diff 0f347f1 -- codex/rules/default.rules
@@ -173,6 +173,12 @@ prefix_rule(pattern=["*", "|", "bash*"], decision="forbidden")
+# ask rules
+prefix_rule(pattern=["bash", "-lc", "sudo *"], decision="prompt")
+prefix_rule(pattern=["sudo", "*"], decision="prompt")
+# Skipped non-Bash permission (ask): Read(**/.env)
+# Skipped non-Bash permission (ask): Read(**/.env.*)
```

No gateway URL, loopback address, token or key reached the generated file:

```
$ rg -n '127\.0\.0\.1|localhost|/t/[0-9a-f]|ANTHROPIC|sk-|api[_-]?key|token' codex/rules/default.rules
$ echo $?
1
```

The generator was run on its own, not through `scripts/sync_claude_to_codex.sh`, which also writes `~/.codex`, the shared MCP config and the hook files — all outside this change. The input was a copy of the worktree's `claude/settings.json` with the two allows inserted and the kept `ask` list, and the `# Source:` header was pinned to `/home/yulong/code/dotfiles/claude/settings.json` so it does not churn.

The config file still parses, and the ignores match:

```
$ python3 -c "import tomllib; d=tomllib.load(open('codex/config.toml','rb')); print(sorted(k for k in d['hooks']['state'] if k.startswith('remember@')))"
['remember@claude-plugins-official:hooks/hooks.codex.json:post_tool_use:0:0',
 'remember@claude-plugins-official:hooks/hooks.codex.json:session_start:0:0',
 'remember@claude-plugins-official:hooks/hooks.codex.json:user_prompt_submit:0:0',
 'remember@claude-plugins-official:hooks/hooks.json:post_tool_use:0:0',
 'remember@claude-plugins-official:hooks/hooks.json:session_start:0:0',
 'remember@claude-plugins-official:hooks/hooks.json:user_prompt_submit:0:0']

$ git check-ignore -v codex/app-server-daemon/x codex/tui-thread-reference-capabilities/y
codex/.gitignore:25:app-server-daemon/	codex/app-server-daemon/x
codex/.gitignore:26:tui-thread-reference-capabilities/	codex/tui-thread-reference-capabilities/y
```

`codex/skills` is still `../claude/skills`, and the sync script's self-link guard compares the deployed directories, both of which resolve to `/home/yulong/code/dotfiles/claude/skills` — so the guard still fires and no skill links are written into Claude's own directory. Nothing in this change touches either side of that comparison.

One thing I could not verify: Codex's `trusted_hash` scheme is not reproducible from outside. Hashing the hook files, the hook entries and the expanded command strings across all four cached remember versions matched none of the recorded hashes, including the two already committed on `main`. The values here are the ones Codex itself wrote on 2026-09-09. If the plugin has changed since, the entry simply stops matching and Codex asks for trust again, which is the behaviour without this change.
