### PR TITLE
model-router: a direct OpenAI provider cannot work until CLIProxyAPI translates max_tokens

### DIFF
--- a/config/model-router.toml
+++ b/config/model-router.toml
@@ -57,6 +57,21 @@ declared-context-window = 258400
 [providers.openrouter]
 base-url = "https://openrouter.ai/api/v1"
 
+# There is deliberately no [providers.openai]. A direct api.openai.com route
+# would be the obvious fallback while the Codex OAuth account sits in a 429
+# cooldown, and the slugs are there (gpt-5.6-sol, gpt-6-astra and both siblings
+# are in the public /v1/models catalogue) -- but the chain cannot carry the
+# request. CLIProxyAPI forwards the Anthropic `max_tokens` verbatim as Chat
+# Completions `max_tokens`, and OpenAI rejects that parameter for these models:
+# "Unsupported parameter: 'max_tokens' is not supported with this model. Use
+# 'max_completion_tokens' instead." Nothing on this side can patch it -- the
+# provider schema above takes only name/base-url/models, and CLIProxyAPI's own
+# per-model `params:` does not rewrite the parameter either (both measured
+# 2026-09-12 against cli-proxy-api 7.2.154). The fix is upstream and unmerged,
+# so revisit when model-router ships a CLIProxyAPI that carries it:
+#   https://github.com/router-for-me/CLIProxyAPI/issues/5005
+#   https://github.com/router-for-me/CLIProxyAPI/pull/5669
+
 # ---- Older Claude models, passed straight through to Anthropic -----------
 # Active until at least 2027-02-05 (deprecations page, 2026-09-07). Opus 3 is
 # not addable: retired on the API 2026-01-05 and gone from OpenRouter too.


### PR DESCRIPTION
## The decision: option (b), drop it — with the reason kept

The review comment on PR #123 ("Seems like this should be fixed?") sat on a `[providers.openai]` stanza whose own comment admitted it did not work. I went looking for a fix and could not justify one, so this PR resolves the comment by **not porting the stanza** and recording the measured reason in its place. Three facts settled it, each verified rather than assumed.

**The premise is real, so the idea will come back.** A direct `api.openai.com` route is the obvious fallback for the window PR #123 is about — the Codex OAuth account in a 429 cooldown, every GPT route dark — and the slugs genuinely exist there. `GET /v1/models` on the account's own key returns `gpt-5.6-sol`, `gpt-6-astra`, `gpt-5.6-terra` and `gpt-5.6-luna` among 136 models. Nothing about the plan is confused; it is the transport that fails.

**It cannot work today, at either layer.** OpenAI still rejects `max_tokens` for these models, and CLIProxyAPI still sends it. Neither has a knob that this repo can reach.

**A dead config entry is worse than no entry.** Rendering the 0f347f1 draft — stanza and all — through `model-router-wire apply --check` reports no drift, identical to rendering the current file. `render_router_config` skips a provider with no member model (`members = [...]; if not members: continue`), and no `[[models]]` entry names `provider = "openai"`. The stanza was a comment wearing a TOML table: it read as configuration, changed nothing, and would invite the next person to wonder why it did not take effect. Replacing it with a plain comment says the same thing honestly and costs nothing at render time.

### Why not option (a), fix it

Two layers would each have to change, and neither is in this repo.

- **model-router** cannot express the fix. `OpenAiProvider` and `ProviderModel` are both `#[serde(deny_unknown_fields)]` and carry only `name`, `base-url`, `models`, `routing-id`, `display-name`, `context-window`, `context-window-scaling` and `min-context-window`. There is no parameter-translation field to set, so no edit to `config/model-router.toml` could reach one.
- **CLIProxyAPI** is where the translation happens, and its per-model `params:` key does not do it (measured below). The upstream fix is [issue #5005](https://github.com/router-for-me/CLIProxyAPI/issues/5005), open since 2026-08-15, with an unmerged PR at [#5669](https://github.com/router-for-me/CLIProxyAPI/pull/5669) against `dev`, opened 2026-09-09. The newest release, [v7.2.158](https://github.com/router-for-me/CLIProxyAPI/releases/tag/v7.2.158) (2026-09-11), does not list it in its changelog; the installed build is 7.2.154.

Option (c) had nothing left to keep honest once the stanza turned out to be inert — "keep it, but make the comment precise" describes a config entry that does something, and this one did not.

## File-by-file

- `config/model-router.toml` — adds a 15-line comment after the `[providers.openrouter]` block stating that the absence of `[providers.openai]` is deliberate, naming the exact blocker, the error text, the versions and date measured, and the two upstream links to watch. No TOML keys added, changed or removed.

## What this deliberately does not include

This PR is one of six splitting the shared base of PRs #123 and #128. It touches exactly one file and adds no keys, so it should merge in any order relative to the others.

- **The cooldown watchdog itself** — `custom_bins/model-router-cooldown-check`, its systemd units and `deploy.sh` wiring stay in the #123 split. This PR only explains why the direct-OpenAI escape hatch is not available to it.
- **`claude/settings.json`** — untouched. In particular the `permissions.ask` block that #123 and #128 both deleted is not deleted here; that file belongs to PR #133.
- **`CLAUDE.md` Learnings** — untouched, to keep out of the way of the sibling splits. The finding lives in the config comment, where the next attempt will start.
- **`docs/remote-control-and-foreign-models.md`** — untouched. It is a 2026-09-01 decision record that recommends against the gateway which was subsequently re-enabled on 2026-09-06; correcting it is its own change, not this one.
- **`custom_bins/model-router-wire`** — untouched, though see the note below.

## How it was verified

**1. OpenAI rejects `max_tokens` for these models — live, today.** One request per model against `api.openai.com`, key read from `~/.config/model-router/secrets.toml` in a subshell and never printed.

```
===== gpt-5.6-sol with max_tokens =====
HTTP400
ERROR: {
 "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
 "type": "invalid_request_error",
 "param": "max_tokens",
 "code": "unsupported_parameter"
}
===== gpt-6-astra with max_tokens =====
HTTP400
ERROR: {
 "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
 "type": "invalid_request_error",
 "param": "max_tokens",
 "code": "unsupported_parameter"
}
```

The same key's catalogue confirms the slugs are real: `total models: 136`, including `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-6-astra`.

**2. CLIProxyAPI 7.2.154 sends `max_tokens`, not `max_completion_tokens`.** Rather than infer this, I ran a throwaway `cli-proxy-api` on port 8399 with its own config, pointed its single `openai-compatibility` provider at a local recording server on 8398, and sent it the Anthropic `/v1/messages` request Claude Code would send. The live router on 8317 was never touched, and both throwaway processes were killed afterwards (`ss -lntp` on 8398/8399 clean, router still listening on 8317).

```
CLIProxyAPI Version: 7.2.154, Commit: ba7e5583, BuiltAt: 2026-09-07T19:50:35Z
```

The body it forwarded upstream:

```json
{
 "model": "gpt-5.6-sol",
 "messages": [{"role": "user", "content": "reply with exactly: ok"}],
 "max_tokens": 300,
 "stream": false
}

max_tokens present           : True -> 300
max_completion_tokens present: False -> None
```

**3. CLIProxyAPI's per-model `params:` does not rewrite it.** The binary carries a `Params` field with a `yaml:"params"` tag near `OpenAICompatibilityModel`, so I tried it — `params: {max_completion_tokens: 256}` on the compat model entry, proxy restarted, same request. It started without complaint and the outbound body was unchanged:

```json
{
 "model": "gpt-5.6-sol",
 "messages": [{"role": "user", "content": "hi"}],
 "max_tokens": 300,
 "stream": false
}
```

**4. This change renders to nothing.** All three of these report no drift against the currently deployed files, which is the point — the comment is inert, and so was the stanza it replaces.

```
main       exit=0 :: rendered files match config/model-router.toml
this PR    exit=0 :: rendered files match config/model-router.toml
0f347f1    exit=0 :: rendered files match config/model-router.toml   <- with [providers.openai] present
```

Run as `MODEL_ROUTER_SOURCE=<file> MODEL_ROUTER_REPO=$PWD ./custom_bins/model-router-wire apply --check`, which returns before any write.

**5. The file still parses and the suite that reads it passes.**

```
providers: ['openrouter']
models: 9

3 passed, 3 subtests passed in 0.02s     # tests/test_write_prose_policy.py
```

**Not run:** `tests/test_model_router_gateway.sh`. It makes real `claude -p` calls per route and restarts nothing this change affects; since the rendered output is byte-identical to what is already deployed, there is nothing for it to catch here. Say the word and I will run it anyway.

## One thing a reviewer may want to act on separately

`render_router_config` silently drops a `[providers.<name>]` block that no model references, and `load_source` only validates the other direction — that a model's named provider has a block. That asymmetry is why the original stanza read as live configuration and went unnoticed. A one-line check rejecting an unreferenced provider block would have surfaced it immediately. I left `custom_bins/model-router-wire` alone to keep this PR to a single file, but it is a small and worthwhile follow-up.
