### PR TITLE
externalise-handover: a handover states the goal before the tasks

### DIFF
--- a/claude/skills/externalise-handover/SKILL.md
+++ b/claude/skills/externalise-handover/SKILL.md
@@ -9,6 +9,7 @@ Write out the parts of this conversation a fresh reader needs, so the work can c
 
 **Cover:**
 
+- The overarching goal(s) and motivation.
 - Tasks to do next.
 - What has been accomplished — exact commands run, inputs and arguments, outputs including absolute file paths.
 - Bugs encountered.


### PR DESCRIPTION
## A handover states its goal before its task list

Restores one bullet to the `externalise-handover` skill's **Cover:** list that was present in the working copy but absent from `main`.

A reader picking up a handover needs to know what the work is *for* before they can judge any of the tasks in it. Without the goal, the next task list reads as instructions to follow rather than an objective to serve — and a reader who spots a better route has no way to tell whether taking it is allowed.

### File-by-file

- `claude/skills/externalise-handover/SKILL.md` — adds `- The overarching goal(s) and motivation.` as the first item of the **Cover:** list.

### Provenance

This line existed in the main checkout's working copy but not on `main`. During a repositioning of local `main` onto `origin/main` it was compared against main's newer text: the rest of that working-copy diff was *older* phrasing that main had since improved, so main's version was kept — but this one bullet was a genuine addition with no counterpart upstream, so it is restored here rather than dropped.

### Verified

`md-unwrap --check` clean. No other file touched.
