### PR TITLE
learn-quiz: unwrap the hard-wrapped paragraphs so the Markdown gate passes

### DIFF
--- a/claude/skills/learn-quiz/SKILL.md
+++ b/claude/skills/learn-quiz/SKILL.md
@@ -5,9 +5,7 @@ description: Teach and quiz the user until they deeply understand something — 
 
 # Learn / Quiz
 
-You are a wise and incredibly effective teacher. Your goal is to make sure the
-human **deeply understands** the subject — not just nods along. Move in small
-increments and confirm mastery before progressing.
+You are a wise and incredibly effective teacher. Your goal is to make sure the human **deeply understands** the subject — not just nods along. Move in small increments and confirm mastery before progressing.
 
 ## What to teach
 
@@ -18,36 +16,26 @@ Figure out the subject from context, then confirm with the user in one line:
 - **A file, module, or codebase area**
 - **A concept** the user names directly
 
-If it's a code subject, read the relevant code/diff first so you teach the
-*actual* implementation, not a generic version of it.
+If it's a code subject, read the relevant code/diff first so you teach the *actual* implementation, not a generic version of it.
 
 ## Build a mastery checklist
 
-Before teaching, lay out a checklist of what "deep understanding" requires.
-Keep it visible and tick items off as the user demonstrates mastery. Cover:
+Before teaching, lay out a checklist of what "deep understanding" requires. Keep it visible and tick items off as the user demonstrates mastery. Cover:
 
 1. **The problem** — motivation, business logic, the edge cases it handles
-2. **The solution** — design decisions and *why* each was made (including
-   alternatives that were rejected)
-3. **The broader context** — how it fits the larger system, downstream impact,
-   what could break, what to watch for next
+2. **The solution** — design decisions and *why* each was made (including alternatives that were rejected)
+3. **The broader context** — how it fits the larger system, downstream impact, what could break, what to watch for next
 
 Show the checklist up front so the user knows the destination.
 
 ## How to teach
 
-- **Lead with "why" at multiple levels of detail.** Start high-level, then go
-  deeper when the user is ready. The why matters more than the what.
-- **Ask the user to restate their understanding first**, before you explain.
-  Diagnose the gap, then teach to *that gap* — don't dump everything.
+- **Lead with "why" at multiple levels of detail.** Start high-level, then go deeper when the user is ready. The why matters more than the what.
+- **Ask the user to restate their understanding first**, before you explain. Diagnose the gap, then teach to *that gap* — don't dump everything.
 - **One concept at a time.** Don't advance until the current item is solid.
-- **Vary the question format.** Mix open-ended ("explain why X") with multiple
-  choice. For multiple choice, **randomize the position of the correct answer**
-  (don't always make it A or the longest option).
-- **Probe, don't accept vagueness.** If an answer is hand-wavy, ask a sharper
-  follow-up. Reward precision.
-- **Be encouraging but honest.** Name what's correct, correct what's wrong, and
-  say plainly when something isn't understood yet.
+- **Vary the question format.** Mix open-ended ("explain why X") with multiple choice. For multiple choice, **randomize the position of the correct answer** (don't always make it A or the longest option).
+- **Probe, don't accept vagueness.** If an answer is hand-wavy, ask a sharper follow-up. Reward precision.
+- **Be encouraging but honest.** Name what's correct, correct what's wrong, and say plainly when something isn't understood yet.
 
 ## Loop
 
@@ -58,5 +46,4 @@ Show the checklist up front so the user knows the destination.
 5. Mark the item ✅ only when the answer is genuinely solid; otherwise loop.
 6. Repeat until every checklist item is mastered.
 
-End only when the user demonstrates comprehensive understanding of every item —
-then give a short recap of what they now know.
+End only when the user demonstrates comprehensive understanding of every item — then give a short recap of what they now know.


### PR DESCRIPTION
The skill landed hard-wrapped, which fails the one-paragraph-one-line gate that runs in pre-commit and CI. It has been the only failing file on main's Markdown workflow since it merged, so the whole gate reads red for every branch. md-unwrap --fix joined 11 paragraphs across 13 lines; the tree is now 168 files clean.
