### PR TITLE
artifacts: the gateway keys move out of a public file

### DIFF
--- a/ARTIFACTS.md
+++ b/ARTIFACTS.md
@@ -16,6 +16,7 @@ Maintained per `~/.claude/skills/artifacts-sync/SKILL.md` — rows are written a
 
 | Artifact | Org | Status | Source | Public | Updated |
 |---|---|---|---|---|---|
+| [The gateway keys move out of a public file](https://claude.ai/code/artifact/d1d52cd8-b565-4f98-a863-3870026adc8b) — what PR #117 changes, for a reader deciding whether to adopt it. `~/.claude` is a symlink to this repo, so the file Claude Code reads and the file git tracks are the same bytes — the gateway needs a loopback URL with a per-install token in it, and the repo is public, so the diff can never resolve. A root-owned managed drop-in ends that because the file is not in the tree at all. The costs are a manual `sudo install` per machine and the loss of the `CLAUDE_RC_OVERRIDE` escape hatch. Nothing in it has run on a real machine yet | lin.yulong@gmail.com's Organization | live | `artifacts/gateway-managed-dropin/` | no | 2026-09-12 |
 | [Dotfiles Review Queue](https://claude.ai/code/artifact/9aeb2de4-1bdb-4ec7-b843-4679ea6e7ef7) — the open pull requests grouped by how much judgement each needs rather than by age, so the table can be read instead of opened. Each row's tick is stored as its own document, so two viewers ticking different rows cannot overwrite each other, and a tick made before the store resolves is queued rather than lost | lin.yulong@gmail.com's Organization | live | `artifacts/pr-review-queue/` | no | 2026-09-11 |
 | [When Settings Reach a Session](https://claude.ai/code/artifact/7338696f-f448-4751-a209-db0cd49cdca9) — adding or changing an `env` value reaches a running session when the file is saved, while removing one takes effect only at the next launch — quoted from the environment-variable documentation, not established here; a scan on 2026-09-11 found 16 processes still carrying a value deleted two days earlier, 13 of them orphaned socat forwarders, none of which call the classifier. The scan shows stale environments, not the cause of any one of them | lin.yulong@gmail.com's Organization | live | `artifacts/settings-propagation/` | no | 2026-09-11 |
 | [Dotfiles Artifacts](https://claude.ai/code/artifact/6cbce727-6346-4dff-a2ef-78aa2da38107) — this index, hosted; republished to this URL after every artifact publish | lin.yulong@gmail.com's Organization | live | `artifacts/index/` | no | 2026-09-10 |
@@ -38,7 +39,7 @@ Maintained per `~/.claude/skills/artifacts-sync/SKILL.md` — rows are written a
 | [Alias Audit](https://claude.ai/code/artifact/739598b0-362d-4aaa-a8c2-c77775be5eb4) — alias files fight over names by source order; the set was cut 161 → ~110 against two months of shell history | see note | done | — | no | 2026-08-18 |
 | [Tool-Backed Agents](https://claude.ai/code/artifact/4c124679-7346-4dc5-9cb4-75889320aaf4) — which agents actually invoke their CLI rather than answering from their own reasoning | see note | done | — | no | 2026-08-18 |
 
-21 rows: 8 live, 10 done, 2 archived, 1 superseded.
+22 rows: 9 live, 10 done, 2 archived, 1 superseded.
 
 [//]: # (END GENERATED ARTIFACTS TABLE)
 

--- a/artifacts/gateway-managed-dropin/explainer.md
+++ b/artifacts/gateway-managed-dropin/explainer.md
@@ -1,0 +1,116 @@
+# The gateway keys move out of a public file
+
+PR [#117](https://github.com/yulonglin/dotfiles/pull/117) moves the model-router gateway keys out of `claude/settings.json` and into a root-owned managed settings drop-in. This explains what that means, what it buys, what it costs, and what I think you should do. Nothing here has run on a real machine yet — see [What has and has not been verified](#what-has-and-has-not-been-verified).
+
+## One file cannot be both live and committable
+
+`~/.claude` is a symlink to this repo's `claude/` directory. So `~/.claude/settings.json` — the file Claude Code actually reads — and the committed `claude/settings.json` are the same bytes on disk. That is the whole design, and it is why editing settings here changes your running environment immediately.
+
+The model-router gateway needs `env.ANTHROPIC_BASE_URL` set to the router's loopback endpoint, whose shape is `http://127.0.0.1:<port>/t/<token>`. That token is a per-install ingress credential, and the port is machine-local. This repo is public. So the file has to carry the key for the gateway to work, and must not carry it for the repo to be safe. There is no version of the file that satisfies both, and the diff therefore never resolves — it is a permanent uncommitted change on a file that Claude Code itself also rewrites whenever you run `/model` or `/plugin`.
+
+That permanent diff is not free. Four costs, all of them live today:
+
+- **Merges abort.** Any merge or rebase that touches `claude/settings.json` stops on a dirty working tree. The daily `dotfiles-sync` job works around this by holding the file back whenever the pre-commit guard rejects it, so the machine-local diff never blocks the push — a workaround that exists only because of this.
+- **A stash can capture a degraded stub.** The file is dual-written by Claude Code and by hand, so a stash or checkout taken at the wrong moment can save a partial file. `.claude/rules/dotfiles-settings.md` opens with a rule that you must never stage this file without first asserting it still has `statusLine`, `hooks` and `permissions`. That rule exists because the failure has happened.
+- **Committing the file's other changes needs a manual dance.** Today the documented procedure is to write a stripped copy, `git hash-object -w` it, and `git update-index --cacheinfo` the resulting SHA into the index — because editing the live file to make it committable would change your running environment.
+- **A bespoke guard exists solely to stop a leak.** `_validate_no_local_gateway` in `config/git-hooks/pre-commit` is there because gitleaks does not catch this value: a bare hex token sitting in a URL path has no adjacent secret keyword to trigger on. The guard is pinned by `tests/test_pre_commit_gateway_guard.sh`.
+
+## A managed drop-in is a settings file the user cannot commit
+
+Claude Code supports settings deployed by an organisation's administrator, called [managed settings](https://code.claude.com/docs/en/managed-settings). They live in a system directory rather than the user's home, they are owned by root, and Claude Code reads them **in addition to** the user's own settings — merging them by key, with the managed value winning wherever both set the same key.
+
+There are two file shapes in that directory. `managed-settings.json` is the single shared file. Beside it, an optional `managed-settings.d/` directory holds one `*.json` file per concern; Claude Code merges `managed-settings.json` first, then every file in the directory in alphabetical order, which is why the convention is numeric prefixes like `50-model-router.json`. The directory exists so that several teams can each own part of one policy without editing a shared file. Here there is one owner, but the drop-in shape is still the right one: it leaves `managed-settings.json` free for anything else later.
+
+The system directory is `/Library/Application Support/ClaudeCode/` on macOS and `/etc/claude-code/` on Linux and WSL.
+
+The property that matters for this problem is simple. The drop-in is not in the repo, not under `~/.claude`, and not writable without root. There is no sequence of `git add` that can reach it, so the token cannot be committed by accident — not because a guard catches it, but because the file is not in the tree at all.
+
+## Apply stages the file, one sudo line installs it
+
+`model-router-wire apply` still reads `config/model-router.toml` as the single source, and still renders the router's route config and the generated `claude/agents/<id>.md` files exactly as before. What changes is the third output. Instead of writing the gateway keys into `~/.claude/settings.json`, it renders them to `~/.config/model-router/managed-settings.json` at mode 0600 — a *staged* copy, owned by you — and prints one command:
+
+```
+sudo install -d -m 0755 <system dir>/managed-settings.d && \
+  sudo install -m 0644 -o root -g root <staged file> <system dir>/managed-settings.d/50-model-router.json
+```
+
+The migration is deliberately two-phase, and the ordering is the careful part. `apply` strips the gateway keys from `~/.claude/settings.json` **only** after the installed root-owned file byte-matches what it just staged. Run `apply`, and it stages and tells you to run sudo; run sudo; run `apply` again, and it now sees a matching drop-in and clears the user file. At no point is there a window where neither file carries the gateway, so no session ever silently falls back to direct Anthropic mid-migration. `tests/test_model_router_wire.sh` pins that ordering against temp paths.
+
+**On a machine where the sudo step has not been run, nothing breaks.** The drop-in is absent, `apply` refuses to strip the user file, and that machine keeps working exactly as it does today — gateway on, permanent diff intact. `apply --check` reports the missing drop-in as drift and names it, and `model-router-wire status` prints a warning that the user file still carries the keys. Adoption is therefore per-machine and reversible: the benefit arrives on each machine only when you run sudo there, and until then that machine is in the state it is in now.
+
+Going the other way, `off` strips the user file, deletes the staged copy, and prints the matching `sudo rm -f` line, because it cannot remove a root-owned file either.
+
+To confirm it landed, start a fresh session and run `/status`. The `Setting sources` line names the source in parentheses: with a drop-in and no `managed-settings.json` beside it, that reads `Enterprise managed settings (drop-ins)`.
+
+## Three costs, one of them recurring
+
+**Root is needed on every content change, not just once.** This is the cost I would weigh heaviest, and the PR's own documentation does not state it plainly. The drop-in as the PR renders it contains the picker rows, so adding, removing or renaming a model in `config/model-router.toml` changes the drop-in's content and needs a fresh `sudo install`. What reads as a one-time setup step is actually a root prompt on every model-roster edit. [My recommendation below](#adopt-it-but-narrow-what-goes-in) is aimed squarely at this.
+
+**`CLAUDE_RC_OVERRIDE` is structurally dead, not merely retired.** That escape hatch worked by handing Claude Code a `--settings` file with the gateway keys blanked, so one session could reach Anthropic directly and Remote Control would work. Managed settings sit above command-line arguments in the precedence stack, and the documentation is explicit that [a key you pass with `--settings` does not override the same managed key](https://code.claude.com/docs/en/settings#settings-precedence). Nor can a lower file remove a variable — a settings `env` block can only set one. So no per-session file can undo a managed `ANTHROPIC_BASE_URL`. Three candidate replacements, none of them clean:
+
+- **Park the drop-in.** A root `mv` moves it aside and back, optionally behind a sudoers `NOPASSWD` rule for that one exact command. It works. It is ugly, it needs a root grant, and it is racy — any session that starts inside the window comes up ungated.
+- **`CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`.** This variable is documented to make Claude Code ignore provider and endpoint variables such as `ANTHROPIC_BASE_URL` in settings files, managed ones included. On paper that is exactly the hatch. In practice it is meant to be set by platforms that embed Claude Code, it also makes Claude Code ignore model-selection keys from managed settings, and I have not tested it. Treat this as speculative.
+- **Do not replace it.** Remote Control has been disabled since the gateway was wired — a non-Anthropic `ANTHROPIC_BASE_URL` disables it regardless of where the key lives — romp over Tailscale is the documented remote path, and `rc-direct-settings.json` is already archived. This is the honest default, and it costs nothing you are currently using.
+
+**A malformed drop-in stops every session on the machine.** If a managed settings file cannot be parsed as a JSON object, Claude Code refuses to start and names the source, even when another admin source supplies a valid policy. A broken user settings file degrades; a broken managed file is fatal, and fixing it needs root. The file is machine-generated so this is unlikely, but the blast radius is larger than today's.
+
+One claim in the PR that I would not lean on: the rule text says the drop-in means "every session on the machine gets the gateway whoever launched it — terminal, IDE extension, desktop app, the background-job daemon". That is true, but it is also true today, because the user settings file already covers all of those. It would only be a gain over wiring the gateway through the `claude()` shell wrapper, which was never the proposal. The real and sufficient benefit is committability.
+
+## Managed wins, and the environment is not a level
+
+Precedence runs top to bottom; a key set higher wins over the same key set anywhere below.
+
+```mermaid
+flowchart TB
+  A["1 · Managed settings<br/>managed-settings.json + managed-settings.d/*.json<br/>root-owned, outside the repo<br/>← the gateway keys go here"]
+  B["2 · CLI flags, including --settings"]
+  C["3 · Project local<br/>.claude/settings.local.json"]
+  D["4 · Project shared<br/>.claude/settings.json"]
+  E["5 · User<br/>~/.claude/settings.json ← the repo file, now clean"]
+  X["Shell environment<br/>not a level of this stack:<br/>a settings env block overwrites<br/>the value inherited from the shell"]
+  A --> B --> C --> D --> E
+  X -.-> E
+  classDef top fill:#dbeafe,stroke:#1e40af,stroke-width:2px
+  classDef note fill:#f5f5f4,stroke:#a8a29e,stroke-dasharray:4 3
+  class A top
+  class X note
+```
+
+Two details that make the split work, both from the docs rather than from measurement. `modelPicker` is never merged across sources: Claude Code takes the whole lineup from the highest of managed settings, `--settings` and user settings that defines it, and ignores the key in project and local settings. And `env` is read from every admin source and merged per variable, so a lower admin source can fill in variables a higher one leaves unset.
+
+Within the managed tier itself there is a second ranking — remote settings from a claude.ai organisation, then MDM or OS policy, then the files — and by default the highest source carrying any policy key wins outright rather than merging. The PR's rule text notes that a claude.ai org's server-managed settings would therefore outrank the drop-in. Worth a footnote: server-managed settings are only fetched when the session talks to Anthropic's API directly, and are skipped when `ANTHROPIC_BASE_URL` points elsewhere — which, once the drop-in is installed, it does. `~/.claude/remote-settings.json` is `{}` on this machine in any case.
+
+## Adopt it, but narrow what goes in
+
+**My recommendation: adopt, with one change — put only the two token-bearing keys in the drop-in.**
+
+The problem being solved is real, the mechanism is the right one, and the two-phase ordering is carefully done. But only one thing in that file cannot be committed: the base URL, because it embeds the ingress token. `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL` goes with it since it is meaningless without it. The other three — `ENABLE_TOOL_SEARCH`, `CLAUDE_CODE_MAX_CONTEXT_TOKENS` and the whole `modelPicker` block — carry nothing secret. The picker rows in particular are rendered from `config/model-router.toml`, which is already committed in this public repo, so putting them behind a root-owned file protects nothing.
+
+Narrowing the drop-in to those two keys keeps the entire committability win and changes the cost profile:
+
+- Root is needed **once per install**, not on every model-roster edit. The drop-in's content then changes only when the router's port or token changes.
+- The blast radius of a malformed managed file shrinks to two lines that nothing but `apply` ever writes.
+- Editing the model roster goes back to being a plain `apply` plus a commit, with no privilege escalation in the loop.
+- The picker rows become committable and reviewable in git, which they are not today.
+
+The mechanics are a small change to `render_managed` and to the strip list in `model-router-wire`, plus the matching assertions in `tests/test_model_router_wire.sh`. **I have not made that change** — it alters the shape the PR is proposing, and that is your call rather than mine. If you would rather take the PR as written, it is coherent as it stands; the recurring sudo is the price.
+
+Whichever way you go, the `CLAUDE_RC_OVERRIDE` question needs an explicit answer, and my lean is the third option: let it stay dead, and treat romp as the remote path.
+
+## What has and has not been verified
+
+Verified, by running it: `tests/test_model_router_wire.sh` passes, and it exercises staging, the mode-0600 staged file, the refusal to strip before the drop-in exists, the strip after it matches, a tampered drop-in reported as drift, and `off`. All four router suites pass — `test_model_router_wire.sh`, `test_ensure_model_router*.py` (29 tests), `test_model_router_update.py` (13), `test_update_ai_tools_gateway.py` (5).
+
+Verified, against the published documentation: the system directory paths, the `managed-settings.d/` merge order, the precedence stack, that `--settings` cannot override a managed key, the `modelPicker` whole-value rule, the per-variable `env` merge across admin sources, the `/status` source labels, and the refuse-to-start behaviour on an unparseable managed file.
+
+**Not verified: any of it running on a real machine.** No machine has the drop-in installed — `/etc/claude-code/` does not exist on this Linux box, and `~/.claude/settings.json` still carries all the gateway keys. The tests run against temp paths with a stub `bootstrap.sh`. The first real `sudo install` will be the first end-to-end exercise, which is an argument for doing it on one machine and living with it for a day before touching the others.
+
+One defect the PR introduced, now fixed on the branch: both router hooks resolved `ANTHROPIC_BASE_URL` from the process environment first and `~/.claude/settings.json` second. A hook that a Claude Code session launches always has the variable, because Claude Code copies a settings `env` block into the process environment whichever level set it — so in-session recovery was fine. But `update-ai-tools` runs `check_model_router_update.py` from a plain shell, which has no such variable, and once `apply` strips the user file that lookup would have come back empty and the post-update router validation would have skipped in silence. The hooks now read the drop-in between the two, with regression tests that go red without the fix.
+
+## Why `custom_bins/` holds a Python program with no `.py`
+
+Because `custom_bins/` is on `PATH` and holds **commands**, not importable modules, and a command is invoked by its bare name. `secrets`, `figcheck`, `md2artifact`, `any2md`, `utc_date` — none of them would read right as `secrets.py`, and the extension would then have to appear in every invocation, every alias and every script that calls them.
+
+I checked rather than assumed, and the repo is consistent. `custom_bins/` holds 80 entries. Exactly one carries an extension: `_annotation_layer.py`. It is the only entry that is **not** a command — it has no execute bit (`rw-rw-r--`), no shebang, and it is imported as a module by `custom_bins/md2artifact`, `custom_bins/annotate-html` and `tests/test_annotate_html.py`. Its leading underscore says the same thing.
+
+Eleven Python programs sit in there with no extension, `model-router-wire` among them: `annotate-html`, `any2md`, `app-lifecycle-config`, `check-transcripts`, `claude-config-sync`, `claude-jobs-reap`, `claude-usage-audit`, `figcheck`, `md2artifact`, `model-router-wire`, `openrouter-cli`. So the rule the directory actually follows is "extension if and only if it is a module, never if it is a command", and `model-router-wire` is on the right side of it. Its language is declared where it belongs, in the shebang — here `#!/usr/bin/env -S uv run --quiet --script`, which also pins `requires-python >= 3.11`, because an earlier `#!/usr/bin/env python3` resolved to Apple's 3.9 on macOS and could not import `tomllib`.

--- a/artifacts/gateway-managed-dropin/index.html
+++ b/artifacts/gateway-managed-dropin/index.html
@@ -1,0 +1,1405 @@
+<title>The gateway keys move out of a public file</title>
+<style>
+:root {
+  --bg:#faf9f7; --panel:#fff; --ink:#1a1a1a; --soft:#5d5a55; --rule:#e4dfd7;
+  --accent:#bd5d3a; --accent-bg:#f7e9e2; --good:#2f6b4f; --good-bg:#e4f0e9;
+  --bad:#a33f2a; --bad-bg:#f9e4de; --code:#f4f2ee; --mark:#fbe6a2;
+}
+@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) {
+  --bg:#17181a; --panel:#1f2124; --ink:#eceae6; --soft:#a9a59e; --rule:#34373c;
+  --accent:#e08a63; --accent-bg:#35251f; --good:#7fc39c; --good-bg:#1d2b24;
+  --bad:#e08a75; --bad-bg:#33211d; --code:#191b1e; --mark:#5c4a15;
+} }
+:root[data-theme="dark"] {
+  --bg:#17181a; --panel:#1f2124; --ink:#eceae6; --soft:#a9a59e; --rule:#34373c;
+  --accent:#e08a63; --accent-bg:#35251f; --good:#7fc39c; --good-bg:#1d2b24;
+  --bad:#e08a75; --bad-bg:#33211d; --code:#191b1e; --mark:#5c4a15;
+}
+*{box-sizing:border-box}
+body{background:var(--bg);color:var(--ink);margin:0;padding:2.5rem 1rem 6rem;
+ font-family:ui-sans-serif,-apple-system,"Segoe UI",sans-serif;line-height:1.65}
+.shell{max-width:48rem;margin:0 auto}
+.shell.has-toc{display:grid;grid-template-columns:15rem minmax(0,1fr);gap:2.4rem;max-width:72rem}
+.toc{position:sticky;top:1.5rem;align-self:start;max-height:calc(100vh - 3rem);overflow:auto;
+ font-size:.84rem;border-right:1px solid var(--rule);padding-right:.9rem}
+.toc h4{font-size:.72rem;text-transform:uppercase;letter-spacing:.06em;color:var(--soft);
+ margin:0 0 .45rem;font-weight:700}
+.toc a{display:block;color:var(--soft);text-decoration:none;padding:.22rem .45rem;
+ border-radius:5px;border-left:2px solid transparent}
+.toc a.lvl3{padding-left:1.2rem;font-size:.8rem}
+.toc a:hover{background:var(--code);color:var(--ink)}
+.toc a.on{color:var(--ink);background:var(--code);border-left-color:var(--accent);font-weight:600}
+.doc{min-width:0}
+h1{font-size:1.75rem;line-height:1.25;margin:0 0 .8rem;letter-spacing:-.015em}
+h2{font-size:1.2rem;margin:2.4rem 0 .7rem;padding-bottom:.32rem;border-bottom:1px solid var(--rule)}
+h3{font-size:1.02rem;margin:1.7rem 0 .45rem}
+p,li{margin:0 0 .85rem}
+ul,ol{padding-left:1.35rem}
+blockquote{margin:1rem 0;padding:.1rem 1rem;border-left:3px solid var(--accent);
+ background:var(--accent-bg);border-radius:0 6px 6px 0}
+pre{background:var(--code);border:1px solid var(--rule);border-radius:7px;padding:.75rem .9rem;
+ overflow-x:auto;font-size:.83rem;line-height:1.5}
+code{font-family:ui-monospace,"SF Mono",Menlo,monospace}
+p code,li code,td code,h2 code,h3 code{background:var(--code);padding:.06rem .32rem;border-radius:4px;font-size:.9em}
+table{border-collapse:collapse;width:100%;font-size:.9rem;margin:1rem 0;display:block;overflow-x:auto}
+th,td{border-bottom:1px solid var(--rule);padding:.45rem .6rem;text-align:left}
+th{font-size:.78rem;text-transform:uppercase;letter-spacing:.04em;color:var(--soft)}
+hr{border:0;border-top:1px solid var(--rule);margin:2rem 0}
+.doc svg{max-width:100%;height:auto}
+p.svg-note{color:var(--bad);background:var(--bad-bg);border-radius:6px;
+ padding:.4rem .7rem;font-size:.85rem}
+a{color:var(--accent)}
+details{border:1px solid var(--rule);border-radius:7px;background:var(--panel);
+ margin:1rem 0;padding:.55rem .9rem}
+details>summary{cursor:pointer;font-weight:600;margin:-.55rem -.9rem;padding:.55rem .9rem;
+ border-radius:7px;list-style-position:inside}
+details>summary:hover{color:var(--accent)}
+details[open]>summary{border-bottom:1px solid var(--rule);border-radius:7px 7px 0 0;
+ margin-bottom:.8rem;background:var(--code)}
+@media (max-width:56rem){
+  .shell.has-toc{display:block}
+  .toc{position:static;max-height:none;border-right:0;border-bottom:1px solid var(--rule);
+   padding:0 0 .8rem;margin-bottom:1.4rem}
+  .toc a{display:inline-block;margin:.15rem .3rem .15rem 0;border-left:0}
+  .toc a.lvl3{padding-left:.45rem}
+}
+</style>
+<div class="shell has-toc">
+<nav class="toc" aria-label="Contents"><h4>Contents</h4><a href="#one-file-cannot-be-both-live-and-committable" class="lvl2">One file cannot be both live and committable</a><a href="#a-managed-drop-in-is-a-settings-file-the-user-cannot-commit" class="lvl2">A managed drop-in is a settings file the user cannot commit</a><a href="#apply-stages-the-file-one-sudo-line-installs-it" class="lvl2">Apply stages the file, one sudo line installs it</a><a href="#three-costs-one-of-them-recurring" class="lvl2">Three costs, one of them recurring</a><a href="#managed-wins-and-the-environment-is-not-a-level" class="lvl2">Managed wins, and the environment is not a level</a><a href="#adopt-it-but-narrow-what-goes-in" class="lvl2">Adopt it, but narrow what goes in</a><a href="#what-has-and-has-not-been-verified" class="lvl2">What has and has not been verified</a><a href="#why-custom-bins-holds-a-python-program-with-no-py" class="lvl2">Why `custom_bins/` holds a Python program with no `.py`</a></nav>
+<div class="doc">
+<h1 id="the-gateway-keys-move-out-of-a-public-file">The gateway keys move out of a public file</h1>
+<p>PR <a href="https://github.com/yulonglin/dotfiles/pull/117">#117</a> moves the model-router gateway keys out of <code>claude/settings.json</code> and into a root-owned managed settings drop-in. This explains what that means, what it buys, what it costs, and what I think you should do. Nothing here has run on a real machine yet — see <a href="#what-has-and-has-not-been-verified">What has and has not been verified</a>.</p>
+<h2 id="one-file-cannot-be-both-live-and-committable">One file cannot be both live and committable</h2>
+<p><code>~/.claude</code> is a symlink to this repo's <code>claude/</code> directory. So <code>~/.claude/settings.json</code> — the file Claude Code actually reads — and the committed <code>claude/settings.json</code> are the same bytes on disk. That is the whole design, and it is why editing settings here changes your running environment immediately.</p>
+<p>The model-router gateway needs <code>env.ANTHROPIC_BASE_URL</code> set to the router's loopback endpoint, whose shape is <code>http://127.0.0.1:&lt;port&gt;/t/&lt;token&gt;</code>. That token is a per-install ingress credential, and the port is machine-local. This repo is public. So the file has to carry the key for the gateway to work, and must not carry it for the repo to be safe. There is no version of the file that satisfies both, and the diff therefore never resolves — it is a permanent uncommitted change on a file that Claude Code itself also rewrites whenever you run <code>/model</code> or <code>/plugin</code>.</p>
+<p>That permanent diff is not free. Four costs, all of them live today:</p>
+<ul>
+<li><strong>Merges abort.</strong> Any merge or rebase that touches <code>claude/settings.json</code> stops on a dirty working tree. The daily <code>dotfiles-sync</code> job works around this by holding the file back whenever the pre-commit guard rejects it, so the machine-local diff never blocks the push — a workaround that exists only because of this.</li>
+<li><strong>A stash can capture a degraded stub.</strong> The file is dual-written by Claude Code and by hand, so a stash or checkout taken at the wrong moment can save a partial file. <code>.claude/rules/dotfiles-settings.md</code> opens with a rule that you must never stage this file without first asserting it still has <code>statusLine</code>, <code>hooks</code> and <code>permissions</code>. That rule exists because the failure has happened.</li>
+<li><strong>Committing the file's other changes needs a manual dance.</strong> Today the documented procedure is to write a stripped copy, <code>git hash-object -w</code> it, and <code>git update-index --cacheinfo</code> the resulting SHA into the index — because editing the live file to make it committable would change your running environment.</li>
+<li><strong>A bespoke guard exists solely to stop a leak.</strong> <code>_validate_no_local_gateway</code> in <code>config/git-hooks/pre-commit</code> is there because gitleaks does not catch this value: a bare hex token sitting in a URL path has no adjacent secret keyword to trigger on. The guard is pinned by <code>tests/test_pre_commit_gateway_guard.sh</code>.</li>
+</ul>
+<h2 id="a-managed-drop-in-is-a-settings-file-the-user-cannot-commit">A managed drop-in is a settings file the user cannot commit</h2>
+<p>Claude Code supports settings deployed by an organisation's administrator, called <a href="https://code.claude.com/docs/en/managed-settings">managed settings</a>. They live in a system directory rather than the user's home, they are owned by root, and Claude Code reads them <strong>in addition to</strong> the user's own settings — merging them by key, with the managed value winning wherever both set the same key.</p>
+<p>There are two file shapes in that directory. <code>managed-settings.json</code> is the single shared file. Beside it, an optional <code>managed-settings.d/</code> directory holds one <code>*.json</code> file per concern; Claude Code merges <code>managed-settings.json</code> first, then every file in the directory in alphabetical order, which is why the convention is numeric prefixes like <code>50-model-router.json</code>. The directory exists so that several teams can each own part of one policy without editing a shared file. Here there is one owner, but the drop-in shape is still the right one: it leaves <code>managed-settings.json</code> free for anything else later.</p>
+<p>The system directory is <code>/Library/Application Support/ClaudeCode/</code> on macOS and <code>/etc/claude-code/</code> on Linux and WSL.</p>
+<p>The property that matters for this problem is simple. The drop-in is not in the repo, not under <code>~/.claude</code>, and not writable without root. There is no sequence of <code>git add</code> that can reach it, so the token cannot be committed by accident — not because a guard catches it, but because the file is not in the tree at all.</p>
+<h2 id="apply-stages-the-file-one-sudo-line-installs-it">Apply stages the file, one sudo line installs it</h2>
+<p><code>model-router-wire apply</code> still reads <code>config/model-router.toml</code> as the single source, and still renders the router's route config and the generated <code>claude/agents/&lt;id&gt;.md</code> files exactly as before. What changes is the third output. Instead of writing the gateway keys into <code>~/.claude/settings.json</code>, it renders them to <code>~/.config/model-router/managed-settings.json</code> at mode 0600 — a <em>staged</em> copy, owned by you — and prints one command:</p>
+<pre><code>sudo install -d -m 0755 &lt;system dir&gt;/managed-settings.d &amp;&amp; \
+  sudo install -m 0644 -o root -g root &lt;staged file&gt; &lt;system dir&gt;/managed-settings.d/50-model-router.json
+</code></pre>
+<p>The migration is deliberately two-phase, and the ordering is the careful part. <code>apply</code> strips the gateway keys from <code>~/.claude/settings.json</code> <strong>only</strong> after the installed root-owned file byte-matches what it just staged. Run <code>apply</code>, and it stages and tells you to run sudo; run sudo; run <code>apply</code> again, and it now sees a matching drop-in and clears the user file. At no point is there a window where neither file carries the gateway, so no session ever silently falls back to direct Anthropic mid-migration. <code>tests/test_model_router_wire.sh</code> pins that ordering against temp paths.</p>
+<p><strong>On a machine where the sudo step has not been run, nothing breaks.</strong> The drop-in is absent, <code>apply</code> refuses to strip the user file, and that machine keeps working exactly as it does today — gateway on, permanent diff intact. <code>apply --check</code> reports the missing drop-in as drift and names it, and <code>model-router-wire status</code> prints a warning that the user file still carries the keys. Adoption is therefore per-machine and reversible: the benefit arrives on each machine only when you run sudo there, and until then that machine is in the state it is in now.</p>
+<p>Going the other way, <code>off</code> strips the user file, deletes the staged copy, and prints the matching <code>sudo rm -f</code> line, because it cannot remove a root-owned file either.</p>
+<p>To confirm it landed, start a fresh session and run <code>/status</code>. The <code>Setting sources</code> line names the source in parentheses: with a drop-in and no <code>managed-settings.json</code> beside it, that reads <code>Enterprise managed settings (drop-ins)</code>.</p>
+<h2 id="three-costs-one-of-them-recurring">Three costs, one of them recurring</h2>
+<p><strong>Root is needed on every content change, not just once.</strong> This is the cost I would weigh heaviest, and the PR's own documentation does not state it plainly. The drop-in as the PR renders it contains the picker rows, so adding, removing or renaming a model in <code>config/model-router.toml</code> changes the drop-in's content and needs a fresh <code>sudo install</code>. What reads as a one-time setup step is actually a root prompt on every model-roster edit. <a href="#adopt-it-but-narrow-what-goes-in">My recommendation below</a> is aimed squarely at this.</p>
+<p><strong><code>CLAUDE_RC_OVERRIDE</code> is structurally dead, not merely retired.</strong> That escape hatch worked by handing Claude Code a <code>--settings</code> file with the gateway keys blanked, so one session could reach Anthropic directly and Remote Control would work. Managed settings sit above command-line arguments in the precedence stack, and the documentation is explicit that <a href="https://code.claude.com/docs/en/settings#settings-precedence">a key you pass with <code>--settings</code> does not override the same managed key</a>. Nor can a lower file remove a variable — a settings <code>env</code> block can only set one. So no per-session file can undo a managed <code>ANTHROPIC_BASE_URL</code>. Three candidate replacements, none of them clean:</p>
+<ul>
+<li><strong>Park the drop-in.</strong> A root <code>mv</code> moves it aside and back, optionally behind a sudoers <code>NOPASSWD</code> rule for that one exact command. It works. It is ugly, it needs a root grant, and it is racy — any session that starts inside the window comes up ungated.</li>
+<li><strong><code>CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST</code>.</strong> This variable is documented to make Claude Code ignore provider and endpoint variables such as <code>ANTHROPIC_BASE_URL</code> in settings files, managed ones included. On paper that is exactly the hatch. In practice it is meant to be set by platforms that embed Claude Code, it also makes Claude Code ignore model-selection keys from managed settings, and I have not tested it. Treat this as speculative.</li>
+<li><strong>Do not replace it.</strong> Remote Control has been disabled since the gateway was wired — a non-Anthropic <code>ANTHROPIC_BASE_URL</code> disables it regardless of where the key lives — romp over Tailscale is the documented remote path, and <code>rc-direct-settings.json</code> is already archived. This is the honest default, and it costs nothing you are currently using.</li>
+</ul>
+<p><strong>A malformed drop-in stops every session on the machine.</strong> If a managed settings file cannot be parsed as a JSON object, Claude Code refuses to start and names the source, even when another admin source supplies a valid policy. A broken user settings file degrades; a broken managed file is fatal, and fixing it needs root. The file is machine-generated so this is unlikely, but the blast radius is larger than today's.</p>
+<p>One claim in the PR that I would not lean on: the rule text says the drop-in means &quot;every session on the machine gets the gateway whoever launched it — terminal, IDE extension, desktop app, the background-job daemon&quot;. That is true, but it is also true today, because the user settings file already covers all of those. It would only be a gain over wiring the gateway through the <code>claude()</code> shell wrapper, which was never the proposal. The real and sufficient benefit is committability.</p>
+<h2 id="managed-wins-and-the-environment-is-not-a-level">Managed wins, and the environment is not a level</h2>
+<p>Precedence runs top to bottom; a key set higher wins over the same key set anywhere below.</p>
+<pre class="mermaid">
+flowchart TB
+  A["1 · Managed settings&lt;br/&gt;managed-settings.json + managed-settings.d/*.json&lt;br/&gt;root-owned, outside the repo&lt;br/&gt;← the gateway keys go here"]
+  B["2 · CLI flags, including --settings"]
+  C["3 · Project local&lt;br/&gt;.claude/settings.local.json"]
+  D["4 · Project shared&lt;br/&gt;.claude/settings.json"]
+  E["5 · User&lt;br/&gt;~/.claude/settings.json ← the repo file, now clean"]
+  X["Shell environment&lt;br/&gt;not a level of this stack:&lt;br/&gt;a settings env block overwrites&lt;br/&gt;the value inherited from the shell"]
+  A --&gt; B --&gt; C --&gt; D --&gt; E
+  X -.-&gt; E
+  classDef top fill:#dbeafe,stroke:#1e40af,stroke-width:2px
+  classDef note fill:#f5f5f4,stroke:#a8a29e,stroke-dasharray:4 3
+  class A top
+  class X note
+</pre>
+<p>Two details that make the split work, both from the docs rather than from measurement. <code>modelPicker</code> is never merged across sources: Claude Code takes the whole lineup from the highest of managed settings, <code>--settings</code> and user settings that defines it, and ignores the key in project and local settings. And <code>env</code> is read from every admin source and merged per variable, so a lower admin source can fill in variables a higher one leaves unset.</p>
+<p>Within the managed tier itself there is a second ranking — remote settings from a claude.ai organisation, then MDM or OS policy, then the files — and by default the highest source carrying any policy key wins outright rather than merging. The PR's rule text notes that a claude.ai org's server-managed settings would therefore outrank the drop-in. Worth a footnote: server-managed settings are only fetched when the session talks to Anthropic's API directly, and are skipped when <code>ANTHROPIC_BASE_URL</code> points elsewhere — which, once the drop-in is installed, it does. <code>~/.claude/remote-settings.json</code> is <code>{}</code> on this machine in any case.</p>
+<h2 id="adopt-it-but-narrow-what-goes-in">Adopt it, but narrow what goes in</h2>
+<p><strong>My recommendation: adopt, with one change — put only the two token-bearing keys in the drop-in.</strong></p>
+<p>The problem being solved is real, the mechanism is the right one, and the two-phase ordering is carefully done. But only one thing in that file cannot be committed: the base URL, because it embeds the ingress token. <code>_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL</code> goes with it since it is meaningless without it. The other three — <code>ENABLE_TOOL_SEARCH</code>, <code>CLAUDE_CODE_MAX_CONTEXT_TOKENS</code> and the whole <code>modelPicker</code> block — carry nothing secret. The picker rows in particular are rendered from <code>config/model-router.toml</code>, which is already committed in this public repo, so putting them behind a root-owned file protects nothing.</p>
+<p>Narrowing the drop-in to those two keys keeps the entire committability win and changes the cost profile:</p>
+<ul>
+<li>Root is needed <strong>once per install</strong>, not on every model-roster edit. The drop-in's content then changes only when the router's port or token changes.</li>
+<li>The blast radius of a malformed managed file shrinks to two lines that nothing but <code>apply</code> ever writes.</li>
+<li>Editing the model roster goes back to being a plain <code>apply</code> plus a commit, with no privilege escalation in the loop.</li>
+<li>The picker rows become committable and reviewable in git, which they are not today.</li>
+</ul>
+<p>The mechanics are a small change to <code>render_managed</code> and to the strip list in <code>model-router-wire</code>, plus the matching assertions in <code>tests/test_model_router_wire.sh</code>. <strong>I have not made that change</strong> — it alters the shape the PR is proposing, and that is your call rather than mine. If you would rather take the PR as written, it is coherent as it stands; the recurring sudo is the price.</p>
+<p>Whichever way you go, the <code>CLAUDE_RC_OVERRIDE</code> question needs an explicit answer, and my lean is the third option: let it stay dead, and treat romp as the remote path.</p>
+<h2 id="what-has-and-has-not-been-verified">What has and has not been verified</h2>
+<p>Verified, by running it: <code>tests/test_model_router_wire.sh</code> passes, and it exercises staging, the mode-0600 staged file, the refusal to strip before the drop-in exists, the strip after it matches, a tampered drop-in reported as drift, and <code>off</code>. All four router suites pass — <code>test_model_router_wire.sh</code>, <code>test_ensure_model_router*.py</code> (29 tests), <code>test_model_router_update.py</code> (13), <code>test_update_ai_tools_gateway.py</code> (5).</p>
+<p>Verified, against the published documentation: the system directory paths, the <code>managed-settings.d/</code> merge order, the precedence stack, that <code>--settings</code> cannot override a managed key, the <code>modelPicker</code> whole-value rule, the per-variable <code>env</code> merge across admin sources, the <code>/status</code> source labels, and the refuse-to-start behaviour on an unparseable managed file.</p>
+<p><strong>Not verified: any of it running on a real machine.</strong> No machine has the drop-in installed — <code>/etc/claude-code/</code> does not exist on this Linux box, and <code>~/.claude/settings.json</code> still carries all the gateway keys. The tests run against temp paths with a stub <code>bootstrap.sh</code>. The first real <code>sudo install</code> will be the first end-to-end exercise, which is an argument for doing it on one machine and living with it for a day before touching the others.</p>
+<p>One defect the PR introduced, now fixed on the branch: both router hooks resolved <code>ANTHROPIC_BASE_URL</code> from the process environment first and <code>~/.claude/settings.json</code> second. A hook that a Claude Code session launches always has the variable, because Claude Code copies a settings <code>env</code> block into the process environment whichever level set it — so in-session recovery was fine. But <code>update-ai-tools</code> runs <code>check_model_router_update.py</code> from a plain shell, which has no such variable, and once <code>apply</code> strips the user file that lookup would have come back empty and the post-update router validation would have skipped in silence. The hooks now read the drop-in between the two, with regression tests that go red without the fix.</p>
+<h2 id="why-custom-bins-holds-a-python-program-with-no-py">Why <code>custom_bins/</code> holds a Python program with no <code>.py</code></h2>
+<p>Because <code>custom_bins/</code> is on <code>PATH</code> and holds <strong>commands</strong>, not importable modules, and a command is invoked by its bare name. <code>secrets</code>, <code>figcheck</code>, <code>md2artifact</code>, <code>any2md</code>, <code>utc_date</code> — none of them would read right as <code>secrets.py</code>, and the extension would then have to appear in every invocation, every alias and every script that calls them.</p>
+<p>I checked rather than assumed, and the repo is consistent. <code>custom_bins/</code> holds 80 entries. Exactly one carries an extension: <code>_annotation_layer.py</code>. It is the only entry that is <strong>not</strong> a command — it has no execute bit (<code>rw-rw-r--</code>), no shebang, and it is imported as a module by <code>custom_bins/md2artifact</code>, <code>custom_bins/annotate-html</code> and <code>tests/test_annotate_html.py</code>. Its leading underscore says the same thing.</p>
+<p>Eleven Python programs sit in there with no extension, <code>model-router-wire</code> among them: <code>annotate-html</code>, <code>any2md</code>, <code>app-lifecycle-config</code>, <code>check-transcripts</code>, <code>claude-config-sync</code>, <code>claude-jobs-reap</code>, <code>claude-usage-audit</code>, <code>figcheck</code>, <code>md2artifact</code>, <code>model-router-wire</code>, <code>openrouter-cli</code>. So the rule the directory actually follows is &quot;extension if and only if it is a module, never if it is a command&quot;, and <code>model-router-wire</code> is on the right side of it. Its language is declared where it belongs, in the shebang — here <code>#!/usr/bin/env -S uv run --quiet --script</code>, which also pins <code>requires-python &gt;= 3.11</code>, because an earlier <code>#!/usr/bin/env python3</code> resolved to Apple's 3.9 on macOS and could not import <code>tomllib</code>.</p>
+
+</div>
+</div>
+
+<script>
+const tocLinks = Array.from(document.querySelectorAll(".toc a"));
+const targets = tocLinks
+  .map((a) => ({ a, el: document.getElementById(a.getAttribute("href").slice(1)) }))
+  .filter((t) => t.el);
+if ("IntersectionObserver" in window && targets.length) {
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => {
+      if (!e.isIntersecting) return;
+      const hit = targets.find((t) => t.el === e.target);
+      if (!hit) return;
+      tocLinks.forEach((a) => a.classList.remove("on"));
+      hit.a.classList.add("on");
+    });
+  }, { rootMargin: "-12% 0px -75% 0px" });
+  targets.forEach((t) => io.observe(t.el));
+}
+</script>
+<!-- annotation-layer v2 -->
+<style>
+:root{--an-bg:#fff;--an-ink:#1a1a1a;--an-soft:#5d5a55;--an-rule:#d9d4cc;--an-accent:#bd5d3a;
+ --an-mark:#fbe6a2;--an-bad:#a33f2a;--an-good:#2f6b4f;--an-good-bg:#e4f0e9;--an-field:#faf9f7}
+@media (prefers-color-scheme: dark){:root:not([data-theme="light"]){--an-bg:#1f2124;--an-ink:#eceae6;
+ --an-soft:#a9a59e;--an-rule:#3a3d42;--an-accent:#e08a63;--an-mark:#5c4a15;--an-bad:#e08a75;
+ --an-good:#7fc39c;--an-good-bg:#1d2b24;--an-field:#17181a}}
+:root[data-theme="dark"]{--an-bg:#1f2124;--an-ink:#eceae6;--an-soft:#a9a59e;--an-rule:#3a3d42;
+ --an-accent:#e08a63;--an-mark:#5c4a15;--an-bad:#e08a75;--an-good:#7fc39c;--an-good-bg:#1d2b24;--an-field:#17181a}
+mark.note{background:var(--an-mark);color:inherit;border-bottom:2px solid var(--an-accent);cursor:pointer;border-radius:2px}
+/* A suggested edit must not read as a comment highlight: the original is
+   struck rather than filled, and the replacement carries the insert colour. */
+mark.anedit{background:transparent;color:var(--an-soft);text-decoration:line-through;
+ text-decoration-color:var(--an-bad);text-decoration-thickness:2px;cursor:pointer;border-radius:2px}
+.anins{background:var(--an-good-bg);color:var(--an-good);border-bottom:2px solid var(--an-good);
+ border-radius:2px;padding:0 .12em;cursor:pointer}
+[data-annotation-layer]{font-family:ui-sans-serif,-apple-system,"Segoe UI",sans-serif;color:var(--an-ink);line-height:1.5}
+[data-annotation-layer] *{box-sizing:border-box}
+#anPop{position:absolute;z-index:1050;display:none;background:var(--an-bg);border:1px solid var(--an-rule);
+ border-radius:8px;box-shadow:0 6px 22px rgba(0,0,0,.18);padding:.6rem;width:min(20rem,calc(100vw - 1.5rem));
+ max-height:min(80vh,26rem);overflow:auto}
+/* A control that would overwrite unsaved words points at them instead. */
+#anPop.nudge{outline:2px solid var(--an-accent);outline-offset:2px}
+/* iOS zooms the whole page when a focused field is under 16px. */
+@media (pointer:coarse){#anPop textarea,#anExportText{font-size:16px}}
+#anPop textarea{width:100%;min-height:4.5rem;border:1px solid var(--an-rule);border-radius:5px;
+ background:var(--an-field);color:var(--an-ink);padding:.4rem;font:inherit;font-size:.86rem;resize:vertical}
+.anbtn{background:var(--an-accent);color:#fff;border:0;border-radius:5px;padding:.35rem .8rem;
+ font:inherit;font-size:.84rem;font-weight:600;cursor:pointer}
+.anbtn.ghost{background:transparent;color:var(--an-soft);border:1px solid var(--an-rule)}
+.anbtn.ghost.danger,.anbtn.ghost.tiny.danger{color:var(--an-bad);border-color:var(--an-bad)}
+.anbtn[disabled]{opacity:.42;cursor:default}
+/* A copied comment is marked by taking its accent AWAY, never by adding a
+   chip: after the first round most of the list is copied, so anything
+   additive becomes noise on the majority. The fresh ones keep the accent and
+   are what the eye lands on. */
+.cmt.ancopied{border-left-color:var(--an-rule)}
+/* An armed control must not look like the button that just did nothing, so it
+   fills: the second click is visibly a different act from the first. */
+.anbtn.anarmed,.anbtn.ghost.danger.anarmed,.anbtn.ghost.tiny.danger.anarmed{
+ background:var(--an-bad);color:#fff;border-color:var(--an-bad)}
+.anbtn.tiny{padding:.12rem .5rem;font-size:.76rem;margin-top:.4rem}
+#anPop:not(.editing) #anDelete{display:none}
+/* The mode strip is deliberately NOT in .anrow: Save has to stay the first
+   control of that row, which is also its tab order. */
+.anmodebar{display:flex;gap:.3rem;margin-bottom:.45rem}
+.anmode{flex:1;background:transparent;color:var(--an-soft);border:1px solid var(--an-rule);
+ border-radius:5px;padding:.22rem .5rem;font:inherit;font-size:.78rem;font-weight:600;cursor:pointer}
+.anmode.ansel{background:var(--an-accent);color:#fff;border-color:var(--an-accent)}
+/* Reopening an existing note is not the place to change what it is. */
+#anPop.editing .anmodebar{display:none}
+.cmt.ansuggest{border-left-color:var(--an-good)}
+.cmt .q.struck{text-decoration:line-through}
+.cmt .ins{color:var(--an-good)}
+/* Save leads: it is the first button in the DOM, so it is also first in tab
+   order. Delete is pushed to the far end so it is never the near miss. */
+.anrow{display:flex;gap:.4rem;align-items:center;margin-top:.45rem;flex-wrap:wrap}
+#anDelete{margin-left:auto}
+.anhint{color:var(--an-soft);font-size:.72rem;margin-top:.35rem}
+.anhint kbd{font:inherit;font-size:.95em;border:1px solid var(--an-rule);border-bottom-width:2px;
+ border-radius:4px;padding:0 .25rem;background:var(--an-field)}
+#anComments{max-width:48rem;margin:3rem auto 5rem;padding:0 1rem}
+#anComments h2{font-size:1.2rem;margin:0 0 .5rem;padding-bottom:.32rem;border-bottom:1px solid var(--an-rule)}
+#anComments .anscope{color:var(--an-soft);font-size:.86rem;margin:0 0 .6rem}
+.anbar{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;margin:.5rem 0 1rem}
+.anacts{display:flex;gap:.4rem;margin-top:.4rem}
+.ancount{color:var(--an-soft);font-size:.87rem}
+.ancount.warn{color:var(--an-bad);font-weight:650}
+.cmt{background:var(--an-bg);border:1px solid var(--an-rule);border-left:3px solid var(--an-accent);
+ border-radius:0 7px 7px 0;padding:.6rem .8rem;margin:.5rem 0;font-size:.88rem;overflow-wrap:anywhere}
+.cmt .q{color:var(--an-soft);font-style:italic;margin-bottom:.3rem}
+.cmt .where{font-size:.72rem;color:var(--an-soft);text-transform:uppercase;letter-spacing:.06em}
+.cmt .orphan{font-size:.74rem;color:var(--an-bad)}
+#anExport{display:none;position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1060;
+ background:var(--an-bg);border:1px solid var(--an-rule);border-radius:10px;padding:.9rem;
+ width:min(46rem,92vw);box-shadow:0 12px 40px rgba(0,0,0,.3)}
+#anExport .exphead{display:flex;align-items:center;gap:.6rem;margin-bottom:.5rem;font-size:.9rem;flex-wrap:wrap}
+#anExport .exphint{color:var(--an-soft);font-size:.8rem}
+#anExport .anbtn{margin-left:auto}
+#anExportText{width:100%;height:min(24rem,55vh);border:1px solid var(--an-rule);border-radius:6px;
+ background:var(--an-field);color:var(--an-ink);padding:.6rem;font-family:ui-monospace,Menlo,monospace;
+ font-size:.82rem;resize:vertical}
+.anok{background:var(--an-good-bg);color:var(--an-good);padding:.2rem .55rem;border-radius:5px;font-size:.83rem}
+.anwarn{background:var(--an-bad);color:#fff;padding:.2rem .55rem;border-radius:5px;font-size:.83rem}
+/* Toggle controls. The generator emits the markup; this styles it, so a
+   hand-written page that emits the same `data-an-state-id` wrapper gets the
+   look, the persistence and the export without copying any CSS.
+   The bullet is dropped only inside an UNORDERED list: a bare `li.antask`
+   also reaches an ordered checklist, where `list-style:none` deletes the step
+   numbers the author wrote the list as a numbered one to keep. */
+ul>li.antask{list-style:none}
+.anstate{display:inline-flex;align-items:baseline;gap:.45em}
+.anstatebox{flex:none;align-self:center;width:1em;height:1em;accent-color:var(--an-accent);cursor:pointer}
+.anstatebtn{flex:none;background:var(--an-field);color:var(--an-ink);border:1px solid var(--an-rule);
+ border-radius:999px;padding:.05em .6em;font:inherit;font-size:.8em;font-weight:650;
+ white-space:nowrap;cursor:pointer}
+.anstatebtn:hover{border-color:var(--an-accent);color:var(--an-accent)}
+.anstatebtn:focus-visible,.anstatebox:focus-visible{outline:2px solid var(--an-accent);outline-offset:2px}
+#anBadge{position:fixed;right:calc(.9rem + env(safe-area-inset-right,0px));
+ bottom:calc(.9rem + env(safe-area-inset-bottom,0px));z-index:1045;background:var(--an-bg);color:var(--an-ink);
+ border:1px solid var(--an-rule);border-radius:999px;padding:.4rem .8rem;font:inherit;font-size:.85rem;
+ font-weight:600;box-shadow:0 4px 14px rgba(0,0,0,.18);cursor:pointer}
+#anBadge.warn{border-color:var(--an-bad);color:var(--an-bad)}
+</style>
+<div data-annotation-layer="v2" data-key="review-explainer">
+<section id="anComments">
+<h2 id="your-comments">Your comments</h2>
+<p class="anscope">Select any text on this page to attach a note, then press Enter. Switch the box to <strong>Suggest edit</strong> to propose replacement wording instead. Both are saved in this browser and survive a refresh or a republish of this page &mdash; copy them to keep them anywhere else.</p>
+<div class="anbar">
+  <span class="ancount" id="anCount">No comments yet</span>
+  <button class="anbtn" id="anCopy">Copy all</button>
+  <button class="anbtn ghost danger" id="anClearCopied">Delete copied</button>
+  <button class="anbtn ghost danger" id="anClear">Delete all</button>
+  <span id="anToast"></span>
+</div>
+<div id="anList"></div>
+</section>
+<div id="anPop" role="dialog" aria-label="Comment">
+  <div class="anmodebar" role="group" aria-label="Annotation mode">
+    <button class="anmode ansel" type="button" id="anModeComment" aria-pressed="true">Comment</button>
+    <button class="anmode" type="button" id="anModeEdit" aria-pressed="false">Suggest edit</button>
+  </div>
+  <textarea id="anTxt" placeholder="What do you think?"></textarea>
+  <div class="anrow">
+    <button class="anbtn" id="anSave">Save</button>
+    <button class="anbtn ghost" id="anCancel">Cancel</button>
+    <button class="anbtn ghost danger" id="anDelete">Delete</button>
+  </div>
+  <div class="anhint"><kbd>Enter</kbd> saves &middot; <kbd>Shift</kbd>+<kbd>Enter</kbd> newline &middot; <kbd>Esc</kbd> discards &middot; <kbd>Ctrl</kbd>+<kbd>E</kbd> switches mode</div>
+</div>
+<div id="anExport" role="dialog" aria-label="Export comments">
+  <div class="exphead">
+    <strong>Your comments as Markdown</strong>
+    <span class="exphint">already selected &mdash; copy with your usual shortcut</span>
+    <button class="anbtn ghost tiny" id="anExportClose">Close</button>
+  </div>
+  <textarea id="anExportText" readonly></textarea>
+</div>
+<button id="anBadge" type="button" aria-label="Jump to your comments">&#128172; 0</button>
+</div>
+<script>
+(function(){
+"use strict";
+var $ = function(id){ return document.getElementById(id); };
+var root = document.querySelector("[data-annotation-layer]");
+var KEY = (root && root.dataset.key) || ("annot:" + document.title);
+// Namespaced with a PREFIX, never a suffix. With `KEY + "-draft"`, a page
+// titled "Spec-draft" owns the same key as the draft of a page titled "Spec",
+// so pressing Escape on one deletes the other's comments outright.
+var DIRTY = "an-dirty:" + KEY;
+var DRAFT = "an-draft:" + KEY;
+var STATES = "an-states:" + KEY;
+
+// ---- storage -------------------------------------------------------------
+// localStorage, and nothing else. An IndexedDB mirror, a backup key and a
+// scan of neighbouring keys all lived here and all came out: the mirror let a
+// save that raced its own asynchronous recovery destroy the comments it was
+// recovering; the backup key resurrected comments the user had deliberately
+// cleared; and the neighbour scan adopted a different document's comments
+// whenever one quote happened to appear on this page. The republish they were
+// meant to survive is already covered, because the generator fixes the key
+// (`data-key`) from the filename rather than the title.
+// `getItem` cannot say WHY it returned null: a missing key and a read the
+// browser refused look identical, and reading a refusal as "nothing stored"
+// overwrites the page with an assumed-empty value. A read that cares takes
+// lsRead and compares against FAILED.
+var FAILED = {};
+function lsRead(k){ try { return localStorage.getItem(k); } catch (e) { return FAILED; } }
+function lsGet(k){ var v = lsRead(k); return v === FAILED ? null : v; }
+function lsSet(k, v){ try { localStorage.setItem(k, v); return true; } catch (e) { return false; } }
+function lsDel(k){ try { localStorage.removeItem(k); } catch (e) {} }
+
+// Stored as a bare array, which every generation of this layer can read. An
+// older deployed page does `JSON.parse(...).reduce(...)` on this value and
+// throws on an object, and that kills its whole script: no handlers, no
+// saving, a page that looks fine and silently does nothing.
+function readComments(){
+  var d; try { d = JSON.parse(lsGet(KEY) || "[]"); } catch (e) { return []; }
+  if (Array.isArray(d)) return d;
+  if (d && Array.isArray(d.comments)) return d.comments;  // envelope from a newer layer
+  return [];
+}
+// Not a per-tab counter: two tabs on one page would both hand out id 1.
+function newId(){ return Date.now() * 1000 + Math.floor(Math.random() * 1000); }
+
+var comments = readComments(), notesUnsaved = false, statesUnsaved = false;
+// One refused-write signal for two writers. A lost tick is as lost as a lost
+// note -- on a page that is all checklist and no prose, which is what a review
+// queue is, the tick IS the work -- so both raise the same badge, the same
+// panel line and the same unload guard. Each writer clears only its own flag:
+// a `persist()` that succeeded says nothing about whether any state got
+// stored. `statesUnsaved` is not set from a write's return value at all -- it
+// is `pendingStates` being non-empty, one entry per control, and an entry
+// leaves that set only on evidence read back out of that control's own key.
+// See THE WRITE RULE in the toggle-state section.
+function unsaved(){ return notesUnsaved || statesUnsaved; }
+comments.forEach(function(c){ if (!c.id) c.id = newId(); });
+
+// Per-comment export state. `copiedAt` is stamped only where the page-level
+// flag was cleared before -- a clipboard write that resolved, or a real copy
+// event on the fallback textarea -- so its absence means "never left this
+// browser". The asymmetry is deliberate: an unstamped comment can never fall
+// into the delete-copied set, so a miss costs one redundant copy rather than
+// a page of lost notes. That is also why there is no "delete the uncopied"
+// action: every comment predating this key reads as uncopied, so such a
+// button would have wiped every existing page on first run.
+function isCopied(c){ return !!c.copiedAt; }
+function copiedSet(){ return comments.filter(isCopied); }
+function freshCount(){ return comments.length - copiedSet().length; }
+function isDirty(){ return freshCount() > 0; }
+// The legacy page-level key is still written, in lockstep, because a stale tab
+// running an older layer reads it and would otherwise raise or stand down its
+// unload guard against state it cannot see.
+function syncLegacyFlag(){ lsSet(DIRTY, isDirty() ? "1" : "0"); }
+
+// One-time migration for comments written before `copiedAt` existed. Without
+// it every upgraded page announces "N of N not yet copied out" and re-arms the
+// unload guard for someone who copied everything out yesterday: a false alarm
+// on every page in existence, which is how a warning stops being read.
+// The legacy flag is EVIDENCE, not an inference -- an explicit "0" was written
+// by a copy that actually happened. A key that is MISSING is not evidence and
+// is left alone, so absence can never manufacture a safe state.
+(function migrateFromLegacyFlag(){
+  if (lsGet(DIRTY) !== "0" || !comments.length) return;
+  var now = Date.now(), touched = false;
+  comments.forEach(function(c){ if (!c.copiedAt) { c.copiedAt = now; touched = true; } });
+  if (touched) persist();
+})();
+var pop = $("anPop"), txt = $("anTxt"), badge = $("anBadge");
+var pending = null, editingId = null;
+// The box has two modes and one dirty flag. `dirty` is set by the first user
+// modification and by nothing else: an edit box OPENS with the selection
+// already in its textarea, so keying the draft autosave and the "a box with
+// words in it refuses to close" invariant on non-emptiness would turn every
+// opened edit box into an unclosable phantom draft nobody typed.
+var mode = "comment", dirty = false;
+// An entry written before v2 carries no `type`, so absence means comment.
+function isEdit(c){ return c && c.type === "edit"; }
+function bodyOf(c){ return isEdit(c) ? (c.replacement || "") : (c.note || ""); }
+
+window.addEventListener("pagehide", saveDraft);
+document.addEventListener("visibilitychange", function(){
+  if (document.visibilityState === "hidden") saveDraft();
+});
+window.addEventListener("beforeunload", function(e){
+  saveDraft();
+  // Two reasons to stop someone. Comments that exist and have not been copied
+  // out are the ordinary one -- they are in localStorage, and this warns only
+  // that nothing outside this browser has them yet. A refused write is the
+  // other, and it is the one that would otherwise be silent on a page carrying
+  // only a checklist: the ticks are not in localStorage at all, and closing
+  // the tab is when they stop existing.
+  if (!unsaved() && (!isDirty() || !comments.length)) return;
+  e.preventDefault(); e.returnValue = ""; return "";
+});
+// A second tab on the same page used to be last-writer-wins. Take its write
+// instead — unless a note is open here, because nothing may pull the DOM out
+// from under a range the user is still typing against.
+//
+// NOT FIXED HERE, and stated rather than implied: this is the wholesale
+// replace the toggle states used to carry, so a comment THIS tab wrote while
+// the store was refusing is dropped from `comments` when the other tab writes,
+// and the next `persist()` that succeeds clears `notesUnsaved` over its grave.
+// The toggle-state fix -- one localStorage key per item, so two writers
+// touching different items never touch the same key -- is the right shape here
+// too, and it does not transfer as written. A state is one value under one id
+// the document itself supplies; a comment is a member of an ordered array with
+// an id this layer mints at random, and the array is the unit that add, edit,
+// delete, `copiedAt` and delete-copied all operate on. Per-comment keys mean
+// enumerating the store by prefix to read them back, a tombstone to express a
+// delete, and a compatibility break with every deployed layer generation,
+// which reads this key as a bare array. That is its own project with its own
+// tests, not a copy of this one.
+window.addEventListener("storage", function(e){
+  if (e.key !== KEY || isOpen()) return;
+  comments.slice().forEach(function(c){ unwrap(c.id); });
+  comments = readComments();
+  comments.forEach(function(c){ if (!c.id) c.id = newId(); });
+  restoreHighlights(); render();
+});
+
+function inLayer(node){
+  while (node && node.nodeType === 3) node = node.parentNode;
+  return !!(node && node.closest && node.closest("[data-annotation-layer]"));
+}
+function sectionOf(node){
+  while (node && node.nodeType === 3) node = node.parentNode;
+  var sec = node && node.closest ? node.closest("section") : null;
+  if (sec) { var h = sec.querySelector("h1,h2,h3"); if (h) return h.textContent.trim(); }
+  while (node && node !== document.body) {
+    var p = node.previousElementSibling;
+    while (p) { if (/^H[1-3]$/.test(p.tagName)) return p.textContent.trim(); p = p.previousElementSibling; }
+    node = node.parentNode;
+  }
+  return "document";
+}
+function isOpen(){ return pop.style.display === "block"; }
+function hasText(){ return !!txt.value.trim(); }
+// `rect` is viewport-relative. Measure the box while it is laid out but not
+// yet painted, so it never appears at the wrong place for one frame — that
+// single-frame jump is itself a flicker.
+function placePop(rect){
+  pop.style.visibility = "hidden";
+  pop.style.display = "block";
+  var w = pop.offsetWidth, h = pop.offsetHeight;
+  var vw = document.documentElement.clientWidth, vh = document.documentElement.clientHeight;
+  var top = rect.bottom + 8;
+  if (top + h > vh - 8) top = rect.top - h - 8;             // no room below: flip above
+  top = Math.max(8, Math.min(top, Math.max(8, vh - h - 8))); // and keep it on screen either way
+  pop.style.left = (Math.max(8, Math.min(rect.left, vw - w - 12)) + window.scrollX) + "px";
+  pop.style.top = (top + window.scrollY) + "px";
+  pop.style.visibility = "";
+}
+// Words the user has not saved are not something another control may
+// overwrite: clicking a second highlight used to replace the text outright.
+// `focus` is false on the touch path, where focusing a field while iOS shows
+// its selection handles collapses the selection.
+function nudge(focus){
+  if (focus !== false) txt.focus();
+  pop.classList.add("nudge");
+  setTimeout(function(){ pop.classList.remove("nudge"); }, 700);
+}
+// Applies a mode WITHOUT touching the textarea. The prefill belongs to the
+// user-driven switch below; the restore paths (an existing entry, a recovered
+// draft) supply their own text and must not have it overwritten.
+function setModeState(next){
+  mode = next;
+  var isE = mode === "edit";
+  $("anModeComment").classList.toggle("ansel", !isE);
+  $("anModeEdit").classList.toggle("ansel", isE);
+  $("anModeComment").setAttribute("aria-pressed", isE ? "false" : "true");
+  $("anModeEdit").setAttribute("aria-pressed", isE ? "true" : "false");
+  txt.placeholder = isE ? "Replacement text; an empty box suggests deleting it"
+                        : "What do you think?";
+}
+// The user-driven switch rewrites the textarea, so it declines while there are
+// unsaved words and points at them instead, exactly as a second highlight
+// click does. Reopening an existing entry is not the place to change its kind,
+// so the strip is hidden then and this is a no-op.
+function switchMode(next){
+  if (mode === next || editingId !== null) return;
+  if (dirty) { nudge(); return; }
+  setModeState(next);
+  txt.value = (next === "edit" && pending) ? pending.quote : "";
+  dirty = false;
+  txt.focus();
+}
+$("anModeComment").onclick = function(){ switchMode("comment"); };
+$("anModeEdit").onclick = function(){ switchMode("edit"); };
+
+function openEdit(c, anchor, focus){
+  if (isOpen() && editingId !== c.id && dirty) { nudge(focus); return; }
+  editingId = c.id; pending = null;
+  setModeState(isEdit(c) ? "edit" : "comment");
+  txt.value = bodyOf(c);
+  dirty = false;
+  pop.classList.add("editing");
+  placePop(anchor ? anchor.getBoundingClientRect() : { left: 16, top: 100, bottom: 100 });
+  if (focus !== false) txt.focus();
+}
+// Both parts of a suggested edit carry the entry id, as a comment highlight
+// does, so clicking the strikethrough or the replacement reopens the same box.
+document.addEventListener("click", function(ev){
+  var m = ev.target.closest && ev.target.closest("[data-cid]");
+  if (!m || pop.contains(ev.target)) return;
+  var c = comments.find(function(x){ return x.id === Number(m.dataset.cid); });
+  if (!c) return;
+  ev.preventDefault(); openEdit(c, m);
+});
+
+// Wraps a range in a highlight. surroundContents refuses a range that crosses
+// element boundaries, so fall back to lifting the contents out and wrapping.
+function wrapRange(range, id, title, cls){
+  var m = document.createElement("mark");
+  m.className = cls || "note"; m.title = title; m.dataset.cid = String(id);
+  try { range.surroundContents(m); }
+  catch (e) { m.appendChild(range.extractContents()); range.insertNode(m); }
+  return m;
+}
+// The ONE place the replacement span is created, rewritten or removed. Three
+// call sites need it (save a new edit, revise one, restore one on load) and
+// they drift apart if each does its own DOM work: an edit revised to empty has
+// to lose its span and become pure strikethrough again.
+function renderEditInline(c){
+  var m = document.querySelector('mark.anedit[data-cid="' + c.id + '"]');
+  if (!m) return;
+  m.title = c.replacement ? "suggested: " + c.replacement : "suggested deletion";
+  var s = document.querySelector('span.anins[data-cid="' + c.id + '"]');
+  if (!c.replacement) { if (s) s.remove(); return; }
+  if (!s) {
+    s = document.createElement("span");
+    s.className = "anins"; s.dataset.cid = String(c.id);
+    // The marker docTextNodes() looks for. Without it the first saved edit
+    // corrupts the anchor of every comment after it, because the replacement's
+    // words join the text that quotes are searched in.
+    s.setAttribute("data-an-inserted", "1");
+    m.parentNode.insertBefore(s, m.nextSibling);
+  }
+  s.textContent = c.replacement;
+}
+// Every text node of the page, skipping the layer's own UI, existing
+// highlights, and anything the layer itself put on the page. Re-anchoring
+// matches ORIGINAL document text only.
+function docTextNodes(){
+  var host = document.querySelector(".doc") || document.querySelector("main") || document.body;
+  var walker = document.createTreeWalker(host, NodeFilter.SHOW_TEXT, { acceptNode: function(n){
+    var p = n.parentNode;
+    if (!p || !p.closest) return NodeFilter.FILTER_ACCEPT;
+    // `.anstatebtn` holds the state WORD, which the layer wrote and the reader
+    // did not: letting it join the searched text anchors a quote onto the
+    // control, where the next cycle overwrites the highlight.
+    if (p.closest("mark.note") || p.closest("mark.anedit") || p.closest("[data-an-inserted]") ||
+        p.closest(".anstatebtn") ||
+        p.closest("[data-annotation-layer]") || p.closest("script,style")) return NodeFilter.FILTER_REJECT;
+    return NodeFilter.FILTER_ACCEPT;
+  }});
+  var out = [], n;
+  while ((n = walker.nextNode())) out.push(n);
+  return out;
+}
+// Collapses runs of whitespace to one space, and records where each kept
+// character sits in the raw text, so a match can be mapped back to real nodes.
+function collapsedIndex(nodes){
+  var norm = "", rawAt = [], raw = 0, lastWasSpace = false;
+  for (var k = 0; k < nodes.length; k++) {
+    var v = nodes[k].nodeValue;
+    for (var i = 0; i < v.length; i++, raw++) {
+      var isSpace = /\s/.test(v[i]);
+      if (isSpace && lastWasSpace) continue;
+      norm += isSpace ? " " : v[i];
+      rawAt.push(raw);
+      lastWasSpace = isSpace;
+    }
+  }
+  return { norm: norm, rawAt: rawAt };
+}
+// Finds a stored quote again after a reload. Selection.toString() gives
+// rendered text, where a newline inside a paragraph reads as a single space,
+// so the comparison has to collapse whitespace.
+function rangeForQuote(quote){
+  if (!quote) return null;
+  var nodes = docTextNodes();
+  if (!nodes.length) return null;
+  var starts = [], raw = 0;
+  for (var k = 0; k < nodes.length; k++) { starts.push(raw); raw += nodes[k].nodeValue.length; }
+  var idx = collapsedIndex(nodes);
+  var needle = quote.replace(/\s+/g, " ").trim();
+  if (!needle) return null;
+  var at = idx.norm.indexOf(needle);
+  if (at < 0) return null;
+  var rawFrom = idx.rawAt[at], rawTo = idx.rawAt[at + needle.length - 1] + 1;
+  function locate(offset, isEnd){
+    for (var j = 0; j < nodes.length; j++) {
+      var base = starts[j], end = base + nodes[j].nodeValue.length;
+      if (isEnd ? (offset > base && offset <= end) : (offset >= base && offset < end)) return [nodes[j], offset - base];
+    }
+    return null;
+  }
+  var s = locate(rawFrom, false), f = locate(rawTo, true);
+  if (!s || !f) return null;
+  var r = document.createRange(); r.setStart(s[0], s[1]); r.setEnd(f[0], f[1]);
+  return r;
+}
+// A reload rebuilds the DOM, so saved highlights are gone while the comments
+// survive in localStorage. Put the marks back, or a comment cannot be clicked
+// open to edit or delete. Quotes no longer on the page stay listed as orphans.
+function restoreHighlights(){
+  var missed = 0;
+  comments.forEach(function(c){
+    if (document.querySelector('mark[data-cid="' + c.id + '"]')) return;
+    var r = rangeForQuote(c.quote);
+    if (!r) { missed++; return; }
+    try {
+      if (isEdit(c)) { wrapRange(r, c.id, "", "anedit"); renderEditInline(c); }
+      else wrapRange(r, c.id, c.note, "note");
+    } catch (e) { missed++; }
+  });
+  return missed;
+}
+function hasMark(c){ return !!document.querySelector('mark[data-cid="' + c.id + '"]'); }
+// A selection touching an existing suggested edit, if there is one. Overlapping
+// edits cannot be exported appliably, and a quote that spans inserted text can
+// never be re-anchored, so such a selection is declined rather than annotated.
+function editOverlapping(range){
+  var els = document.querySelectorAll('mark.anedit[data-cid], span.anins[data-cid]');
+  for (var i = 0; i < els.length; i++) {
+    var el = els[i], hit = false;
+    try { hit = range.intersectsNode(el); } catch (e) { hit = false; }
+    if (!hit) continue;
+    var cid = Number(el.dataset.cid);
+    var c = comments.find(function(x){ return x.id === cid; });
+    if (c) return { entry: c, el: el };
+  }
+  return null;
+}
+
+// Opens the note box for the current selection. autofocus is false on touch:
+// focusing a textarea while iOS is showing its selection handles collapses the
+// selection before the user has typed anything.
+//
+// This function only ever OPENS. Nothing about the selection closes the box —
+// that asymmetry is the whole flicker fix. Opening the box focuses the
+// textarea, focusing collapses the document selection, and the old code read
+// that collapse back as "the user deselected" and closed the box it had just
+// opened. The box now closes only on Save, Cancel/Escape, or a press outside
+// it while it is still empty.
+function openForSelection(autofocus){
+  if (editingId !== null) return false;
+  var sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return false;
+  var text = sel.toString().trim();
+  if (!text) return false;
+  if (inLayer(sel.anchorNode) || inLayer(sel.focusNode)) return false;
+  // Already open on this exact selection: do not wipe a half-typed note.
+  if (pending && pending.quote === text && isOpen()) return true;
+  // Open on some other selection the user has MODIFIED: leave it be rather
+  // than throwing away work. The test is `dirty`, not non-emptiness: an
+  // untouched prefilled edit box yields to a fresh selection, and a dirty
+  // EMPTY edit box (a pending deletion) is work and must not be overwritten.
+  if (isOpen() && dirty) return true;
+  var range = sel.getRangeAt(0), rect = range.getBoundingClientRect();
+  // Overlaps an existing suggested edit: point at that edit rather than open a
+  // second box on the range.
+  var hit = editOverlapping(range);
+  if (hit) { openEdit(hit.entry, hit.el, autofocus); nudge(autofocus); return true; }
+  editingId = null; pop.classList.remove("editing");
+  // Comment is the default on every fresh selection. A mode that stayed where
+  // it was last left would silently change what select-type-Enter means.
+  setModeState("comment");
+  pending = { quote: text, where: sectionOf(sel.anchorNode), range: range.cloneRange() };
+  placePop(rect);
+  txt.value = "";
+  dirty = false;
+  if (autofocus) txt.focus();
+  return true;
+}
+// Synchronous, so the focus stays inside the user gesture — Safari only
+// raises the soft keyboard for a focus() called within one.
+document.addEventListener("mouseup", function(ev){
+  if (pop.contains(ev.target)) return;
+  if (ev.target.closest && ev.target.closest("[data-cid]")) return;
+  clearTimeout(selTimer);
+  openForSelection(true);
+});
+// A press outside closes a box the user has not modified. A box with words the
+// user put there stays open: no gesture the user did not mean as "save" may
+// commit anything, and plenty of ordinary ones land here — right-clicking your
+// own selection to copy it, grabbing the scrollbar to reread the passage, or
+// pressing Clear all and then cancelling the confirm.
+//
+// The test is the dirty flag, NOT emptiness, because an edit box opens with
+// the selection already in it. Keyed on emptiness, opening one and changing
+// your mind would leave a box that cannot be dismissed.
+document.addEventListener("mousedown", function(ev){
+  if (!isOpen() || pop.contains(ev.target)) return;
+  if (dirty) return;
+  closePop();
+});
+// iOS Safari fires no mouseup for a touch selection drag, so a mouseup-only
+// handler makes the page uncommentable on iPhone and iPad. selectionchange
+// fires on every platform; debounce it so it runs once the selection settles.
+var selTimer = null;
+document.addEventListener("selectionchange", function(){
+  if (document.activeElement === txt) return;
+  if (editingId !== null) return;
+  // Same test as openForSelection: modified work stays, an untouched prefill
+  // does not hold the page hostage.
+  if (isOpen() && dirty) return;
+  clearTimeout(selTimer);
+  selTimer = setTimeout(function(){ openForSelection(false); }, 250);
+});
+
+txt.addEventListener("keydown", function(ev){
+  if (ev.key === "Enter" && !ev.shiftKey && !ev.altKey && !ev.isComposing) { ev.preventDefault(); save(); }
+  else if (ev.key === "Escape") { ev.preventDefault(); discard(); }
+  // A CHORD, never a bare letter. A single-key binding on a control that lives
+  // inside a textarea fires on the note being typed: on the context-ledger
+  // page, `d` in a comment marked the selected row dropped.
+  else if ((ev.ctrlKey || ev.metaKey) && (ev.key === "e" || ev.key === "E")) {
+    ev.preventDefault(); switchMode(mode === "edit" ? "comment" : "edit");
+  }
+});
+// The user touched the text: from here the box holds work, whether or not the
+// prefill it opened with is still in it.
+txt.addEventListener("input", function(){ dirty = true; saveDraft(); });
+document.addEventListener("keydown", function(ev){
+  if (ev.key === "Escape" && isOpen() && document.activeElement !== txt) discard();
+});
+
+function closePop(){
+  // #anDelete is one element reused by every entry: an arm left live here
+  // would confirm on the next opened entry's first click.
+  disarm();
+  pop.style.display = "none"; pending = null; editingId = null;
+  pop.classList.remove("editing"); pop.classList.remove("nudge");
+  setModeState("comment"); dirty = false;
+  txt.value = ""; lsDel(DRAFT);
+}
+function discard(){ closePop(); }
+// The in-progress note, saved on every keystroke, so a forced refresh reopens
+// the box where it was instead of losing what was typed into it.
+// `dirty` gates this, not emptiness: an edit box opens pre-filled with the
+// selection, and autosaving that would leave a draft nobody typed, which then
+// reopens the box on the next load for a note that was never begun.
+// In edit mode an EMPTY dirty box is meaningful: the prefill was cleared to
+// suggest a deletion, and a refresh before Enter must bring that back. In
+// comment mode an empty box is nothing to keep.
+function saveDraft(){
+  if (!isOpen() || !dirty || (!hasText() && mode !== "edit")) { lsDel(DRAFT); return; }
+  lsSet(DRAFT, JSON.stringify({
+    note: txt.value, editingId: editingId, mode: mode,
+    quote: pending ? pending.quote : null, where: pending ? pending.where : null
+  }));
+}
+function restoreDraft(){
+  var d = unpackDraft();
+  if (!d) return;
+  if (d.editingId != null) {
+    var c = comments.find(function(x){ return x.id === d.editingId; });
+    // The comment was deleted elsewhere. Drop the draft rather than leave it
+    // to reattach itself to whichever comment is handed that id next.
+    if (!c) { lsDel(DRAFT); return; }
+    openEdit(c, document.querySelector('mark[data-cid="' + c.id + '"]'));
+    txt.value = d.note; dirty = true;
+    return;
+  }
+  var r = rangeForQuote(d.quote);
+  if (!r) return;
+  var sel = window.getSelection();
+  if (sel) { try { sel.removeAllRanges(); sel.addRange(r); } catch (e) {} }
+  editingId = null; pop.classList.remove("editing");
+  setModeState(d.mode === "edit" ? "edit" : "comment");
+  pending = { quote: d.quote, where: d.where || sectionOf(r.startContainer), range: r.cloneRange() };
+  placePop(r.getBoundingClientRect());
+  // Restored words ARE user work, whatever they started as.
+  txt.value = d.note; dirty = true;
+}
+function unpackDraft(){
+  var d = null; try { d = JSON.parse(lsGet(DRAFT) || "null"); } catch (e) {}
+  if (!d || typeof d.note !== "string") return null;
+  // An empty note is a draft only for an edit that still knows its target: a
+  // pending deletion of `quote`, or a revision of an existing edit.
+  if (!d.note.trim() && !(d.mode === "edit" && (d.quote || d.editingId != null))) return null;
+  return d;
+}
+// These keep their names and every existing call site; what changed is that
+// the state lives on the comments now and the page-level key is derived from
+// it. Renaming them to say "copied out" is a separate no-behaviour commit.
+function markDirty(){ syncLegacyFlag(); }
+// A snapshot of exactly what went into the copied text, so a comment edited
+// while an async clipboard write was in flight is not stamped as copied. The
+// copy carried the OLD wording; the comment now holds new wording that has
+// never left the page, and stamping it would put unsent words in the
+// delete-copied set.
+function copySnapshot(){
+  return comments.map(function(c){
+    return { id: c.id, where: c.where, quote: c.quote, note: bodyOf(c) };
+  });
+}
+function markClean(snap){
+  var now = Date.now(), by = {};
+  (snap || copySnapshot()).forEach(function(x){ by[x.id] = x; });
+  comments.forEach(function(c){
+    var x = by[c.id];
+    if (x && x.where === c.where && x.quote === c.quote && x.note === bodyOf(c)) c.copiedAt = now;
+  });
+  persist(); syncLegacyFlag();
+}
+
+// ---- toggle state controls ------------------------------------------------
+// A page may carry toggle controls in its body: a task-list checkbox, or a
+// button cycling a declared state set such as approve / approve-pending-edits
+// / deny. Both wear one wrapper, `[data-an-state-id]`, so this layer needs no
+// configuration and a page with none of them is untouched.
+//
+// ONE KEY PER CONTROL. Each control's state lives under its own localStorage
+// key, `an-state:<page key>:<control id>`, prefix-namespaced exactly as the
+// draft and dirty keys are, so nothing here can collide with the comment array
+// -- which every layer generation parses as a bare array and dies on anything
+// else.
+//
+// This replaces a shared document holding every control at once, and with it
+// the reconciliation six rounds built on top of that document. It rested on
+// "an untick is said by REMOVING a key, and a merge-style write cannot say
+// it", which is false: an untick is an explicit " ", as a tick is an explicit
+// "x". Once a value can say not-ticked, nothing needs to replace a document,
+// and the read-modify-write -- unfixable here, because localStorage offers no
+// compare-and-set -- is gone rather than reconciled. So: two tabs touching
+// DIFFERENT controls write DIFFERENT keys and cannot collide, which is the
+// shape of every reproduction that beat the previous rounds (A ticks item 1
+// while B ticks item 3); no write is derived from a read, so a stale or failed
+// read cannot clobber; a refused write for one control cannot reach another's
+// value, so the loss flag is per control. Two tabs touching the SAME control
+// resolve last-writer-wins, which is correct and is not a bug to file: they
+// disagree about one value and the last to speak decides.
+//
+// The lesson the previous round's 16-state enumeration got wrong, recorded so
+// it is not rediscovered: "localStorage is synchronous and the page is
+// single-threaded, so read -> merge -> write -> read-back is one indivisible
+// step" holds WITHIN a tab and says nothing ACROSS tabs. Single-threaded stops
+// this tab's handlers interleaving; a second tab is a separate process.
+var STATE_PREFIX = "an-state:" + KEY + ":";
+
+function stateKeyOf(id){ return STATE_PREFIX + id; }
+function stateIdOf(key){
+  return (typeof key === "string" && key.indexOf(STATE_PREFIX) === 0)
+    ? key.slice(STATE_PREFIX.length) : null;
+}
+// The control's OWN key: a write reads this back for evidence that it landed,
+// so the fallback below must not be allowed to answer for it.
+function readStateKey(id){ return lsRead(stateKeyOf(id)); }
+// State written by the shared-document layer migrates LAZILY, here, one control
+// at a time: an id with no per-item value falls back to that document, which is
+// READ where it lies and never written or deleted, so a rolled-back page still
+// finds every tick. There is no copy pass, so nothing has to answer "did every
+// item land?" -- which a store that refuses one write in three cannot be asked,
+// and the marker that answered "yes" regardless abandoned the rest for good.
+function readState(id){
+  var v = readStateKey(id);
+  if (v !== null) return v;                   // a stored value, or FAILED
+  var raw = lsRead(STATES), d = null;
+  if (raw === FAILED) return FAILED;
+  try { d = JSON.parse(raw || "null"); } catch (e) {}
+  return (d && typeof d === "object" && !Array.isArray(d) && typeof d[id] === "string") ? d[id] : null;
+}
+
+var pendingStates = {};   // id -> value this tab wrote that the store did not take
+var stateDefaults = {};   // id -> the value the document itself shipped
+
+function hasPending(){ return Object.keys(pendingStates).length > 0; }
+// THE WRITE RULE, now one rule instead of three: write the one key this
+// control owns, then read that one key back. `setItem` returning without
+// throwing is not evidence -- a browser that silently no-ops the write would
+// stand the warning down over work that never left the page -- so the flag
+// comes from what the store holds after. No other control is touched, and the
+// render is for the refused-write line, the only place a lost tick is visible.
+function writeState(id, value){
+  var was = statesUnsaved;
+  lsSet(stateKeyOf(id), value);
+  if (readStateKey(id) === value) delete pendingStates[id];
+  else pendingStates[id] = value;
+  statesUnsaved = hasPending();
+  paintStateId(id);
+  if (statesUnsaved || was) render();
+}
+// Pending over stored over the document's own value. The last of those three
+// is what keeps an id the store has dropped from going on being displayed as
+// ticked, and a `[x]` the author wrote from being blanked when it does.
+function paintState(u){
+  var id = u.dataset.anStateId;
+  // A control this tab has never wired -- one injected after load -- has been
+  // touched by nobody, so what it is showing now IS the value it shipped.
+  if (!stateDefaults.hasOwnProperty(id)) stateDefaults[id] = stateValue(u);
+  var v = pendingStates.hasOwnProperty(id) ? pendingStates[id] : readState(id);
+  // A read that FAILED says nothing about the stored value, so what the reader
+  // is looking at stays: blanking it would show an untick nobody made.
+  if (v === FAILED) return;
+  if (typeof v !== "string" || !applyState(u, v)) applyState(u, stateDefaults[id]);
+}
+function paintStateId(id){
+  stateUnits().forEach(function(u){ if (u.dataset.anStateId === id) paintState(u); });
+}
+function syncStateDom(){ stateUnits().forEach(paintState); }
+function stateUnits(){ return Array.prototype.slice.call(document.querySelectorAll("[data-an-state-id]")); }
+function stateSetOf(unit){
+  var raw = unit.getAttribute("data-an-states");
+  if (!raw) return null;
+  var a; try { a = JSON.parse(raw); } catch (e) { return null; }
+  return (Array.isArray(a) && a.length) ? a : null;
+}
+// The reader-visible text of the item, which is also the control's accessible
+// name. Read from the DOM rather than written by the generator, so it is the
+// rendered text a screen reader would reach anyway.
+function stateLabel(unit){
+  var l = unit.querySelector(".anstatelabel");
+  return ((l ? l.textContent : unit.textContent) || "").trim().replace(/\s+/g, " ");
+}
+function stateValue(unit){
+  var box = unit.querySelector(".anstatebox");
+  if (box) return box.checked ? "x" : " ";
+  var b = unit.querySelector(".anstatebtn");
+  return b ? (b.dataset.anState || "") : "";
+}
+// Applies a state to the DOM and to nothing else. A value outside the declared
+// set is refused rather than shown: a rebuilt page can meet a key written
+// under a different state set, and rendering `maybe` on a control that has no
+// such state leaves a button whose next click has nowhere to go.
+function applyState(unit, value){
+  var box = unit.querySelector(".anstatebox");
+  // A checkbox has a declared set too -- it is `x` and a space -- so a stored
+  // value from some other state set is refused here rather than silently read
+  // as "not x" and shown as an untick the reader never made.
+  if (box) {
+    if (value !== "x" && value !== " ") return false;
+    box.checked = value === "x";
+    return true;
+  }
+  var b = unit.querySelector(".anstatebtn"), set = stateSetOf(unit);
+  if (!b || !set || set.indexOf(value) < 0) return false;
+  b.dataset.anState = value;
+  b.textContent = value;
+  b.setAttribute("aria-label", stateLabel(unit) + ": " + value);
+  return true;
+}
+function wireStates(){
+  stateUnits().forEach(function(unit){
+    var id = unit.dataset.anStateId;
+    var box = unit.querySelector(".anstatebox"), btn = unit.querySelector(".anstatebtn");
+    // Read BEFORE anything stored is applied, so this is the author's own
+    // marker -- the `[x]` in the source -- and not whatever the store held.
+    stateDefaults[id] = stateValue(unit);
+    if (box) {
+      // A real checkbox: the browser supplies the role, Space toggles it, and
+      // the name is the item's own text.
+      box.setAttribute("aria-label", stateLabel(unit));
+      box.addEventListener("change", function(){
+        writeState(id, box.checked ? "x" : " ");
+      });
+      return;
+    }
+    if (!btn) return;
+    var set = stateSetOf(unit) || [];
+    if (set.length && set.indexOf(stateDefaults[id]) < 0) stateDefaults[id] = set[0];
+    // A <button> is focusable and fires click on Enter and Space, so cycling
+    // works from the keyboard with no key handler here at all.
+    btn.addEventListener("click", function(){
+      if (!set.length) return;
+      var at = set.indexOf(btn.dataset.anState);
+      var next = set[(at + 1) % set.length];
+      if (!applyState(unit, next)) return;
+      writeState(id, next);
+    });
+  });
+  // One path paints the controls, on load and on every later change alike.
+  syncStateDom();
+}
+// Plain text, one shape for both kinds of control: the state sits in the
+// brackets a Markdown task list already uses, so a two-state page exports a
+// task list that can be pasted straight back into the source.
+function stateMarkdown(){
+  return stateUnits().map(function(u){
+    return "- [" + (stateValue(u) || " ") + "] " + stateLabel(u);
+  }).join("\n");
+}
+// A second tab's write is authoritative for the ONE control it carried. The
+// event names a single key, so there is no incoming map to merge and no way
+// for it to speak for a control it did not change -- which is what two earlier
+// rounds got wrong, first by replacing the in-memory map wholesale and then by
+// reconciling one map against the other.
+window.addEventListener("storage", function(e){
+  // A null key is `localStorage.clear()` from the other tab, which takes every
+  // one of these keys with it; ignoring it left controls showing values gone
+  // from the store.
+  var id = stateIdOf(e.key);
+  if (e.key !== null && id === null) return;
+  var was = statesUnsaved;
+  // Nothing is pending once the store holds it, whoever put it there. Only the
+  // ids this event could have changed: one of them, or all on a clear.
+  (id === null ? Object.keys(pendingStates) : [id]).forEach(function(k){
+    if (pendingStates.hasOwnProperty(k) && readStateKey(k) === pendingStates[k]) {
+      delete pendingStates[k];
+    }
+  });
+  statesUnsaved = hasPending();
+  if (id === null) syncStateDom(); else paintStateId(id);
+  if (statesUnsaved || was) render();
+});
+
+// ---- destructive controls ------------------------------------------------
+// No blocking dialog appears here, and none may be added. The Artifact viewer
+// runs the page inside a sandboxed iframe with no `allow-modals` keyword, so
+// `window.confirm` returns false without ever asking -- the browser just logs
+// "Ignored call to ...". Every delete guarded that way returned early on a
+// refusal the reviewer never saw: a dead button in the one place these pages
+// are read, and working perfectly in a local tab, which is why it survived.
+//
+// The guard is in the page instead. A first click arms the button and makes it
+// say what a second click will destroy; it disarms after ARM_MS, on Escape, or
+// on any re-render. Buttons are focusable, so Enter and Space arm and confirm
+// exactly like the pointer does.
+var ARM_MS = 4000;
+var WARN_CHANGED = '<span class="anwarn">the comments changed \u2014 nothing deleted</span>';
+var armedBtn = null, armedLabel = "", armedTimer = 0, armedBinding = null;
+function disarm(){
+  if (!armedBtn) return;
+  // render() may already have thrown this button away; restoring a detached
+  // node is harmless but pointless.
+  if (armedBtn.isConnected) { armedBtn.textContent = armedLabel; armedBtn.classList.remove("anarmed"); }
+  clearTimeout(armedTimer);
+  armedBtn = null; armedLabel = ""; armedTimer = 0; armedBinding = null;
+}
+// What an arm was armed AGAINST: the exact comments, plus enough of their
+// content to notice a change. A second tab's write can land inside the four
+// seconds an arm is live, and the `storage` handler only rebuilds when no note
+// is open -- so the confirming click has to prove the set is still the one the
+// label described, rather than trust that nothing moved under it.
+function bindingOf(list){
+  return list.map(function(c){
+    return c.id + ":" + (c.copiedAt || 0) + ":" + bodyOf(c).length + ":" + c.quote.length;
+  }).join(",");
+}
+// True only on the confirming click, and only while the set it was armed
+// against is unchanged. On any other click it arms `btn` and the caller must
+// return without destroying anything.
+function arm(btn, label, binding){
+  if (armedBtn === btn) {
+    var stale = armedBinding !== null && armedBinding !== binding;
+    disarm();
+    if (stale) { render(); toast(WARN_CHANGED, 4000); return false; }
+    return true;
+  }
+  disarm();
+  armedBtn = btn; armedLabel = btn.textContent;
+  armedBinding = binding === undefined ? null : binding;
+  btn.textContent = label;
+  btn.classList.add("anarmed");
+  armedTimer = setTimeout(disarm, ARM_MS);
+  return false;
+}
+// Escape cancels, whether focus sits on the armed button or anywhere else.
+// Both listeners are needed: the layer root stops key events from bubbling out
+// to the host page, so the document listener never sees a keystroke aimed at
+// the button, and a listener on the root alone would miss one aimed outside.
+function escDisarm(ev){ if (ev.key === "Escape") disarm(); }
+root.addEventListener("keydown", escDisarm);
+document.addEventListener("keydown", escDisarm);
+// A refused write is the one failure the page must not hide: with the quota
+// full, the panel would otherwise count a comment that is already gone.
+function persist(){
+  notesUnsaved = !lsSet(KEY, JSON.stringify(comments));
+}
+function unwrap(id){
+  var s = document.querySelector('span.anins[data-cid="' + id + '"]');
+  if (s) s.remove();
+  var m = document.querySelector('mark[data-cid="' + id + '"]');
+  if (m) { while (m.firstChild) m.parentNode.insertBefore(m.firstChild, m); m.remove(); }
+}
+
+function save(){
+  if (mode === "edit") { saveEdit(txt.value.trim()); return; }
+  var note = txt.value.trim();
+  if (!note) { closePop(); return; }
+  if (editingId !== null) {
+    var c = comments.find(function(x){ return x.id === editingId; });
+    // Reopened to reread and closed unchanged: not an edit, so it must not
+    // reset the export state and re-arm the unload prompt.
+    if (c && c.note === note) { closePop(); return; }
+    // The copy that happened carried the previous wording, so the stamp no
+    // longer describes this comment. Without this, "delete copied" destroys
+    // the only copy of the edit and the next Copy all silently omits it.
+    if (c) { c.note = note; delete c.copiedAt; }
+    var m = document.querySelector('mark.note[data-cid="' + editingId + '"]');
+    if (m) m.title = note;
+  } else if (pending) {
+    var id = newId();
+    try { wrapRange(pending.range, id, note, "note"); } catch (e) {}
+    comments.push({ id: id, type: "comment", where: pending.where, quote: pending.quote, note: note });
+  }
+  markDirty(); persist(); render(); closePop();
+  var sel = window.getSelection(); if (sel) sel.removeAllRanges();
+}
+// An empty replacement is a suggested DELETION, so there is no empty-means-
+// cancel shortcut here: the comment path's `if (!note) closePop()` would throw
+// away exactly the edit the reader worked to express.
+function saveEdit(replacement){
+  if (editingId !== null) {
+    var c = comments.find(function(x){ return x.id === editingId; });
+    if (c && c.replacement === replacement) { closePop(); return; }
+    if (c) { c.replacement = replacement; delete c.copiedAt; renderEditInline(c); }
+  } else if (pending) {
+    // The prefill is not user work: an untouched box saves nothing, so Enter
+    // on a box still holding the selection verbatim is a close, not an entry
+    // proposing to replace the text with itself.
+    if (!dirty) { closePop(); return; }
+    var id = newId();
+    var fresh = { id: id, type: "edit", where: pending.where,
+                  quote: pending.quote, replacement: replacement };
+    try { wrapRange(pending.range, id, "", "anedit"); } catch (e) {}
+    comments.push(fresh);
+    renderEditInline(fresh);
+  }
+  markDirty(); persist(); render(); closePop();
+  var sel = window.getSelection(); if (sel) sel.removeAllRanges();
+}
+
+$("anCancel").onclick = discard;
+$("anDelete").onclick = function(){
+  if (editingId === null) { closePop(); return; }
+  var id = editingId;
+  var c = comments.find(function(x){ return x.id === id; });
+  // A comment's Delete stays immediate -- the popup's CSS hides it while
+  // composing, it sits at the far end of the row, and it acts on one note the
+  // reader has just opened. A suggested edit arms first: it is written
+  // replacement text plus an anchor, and one stray click takes both.
+  if (isEdit(c) && !arm(this, "click again")) return;
+  comments = comments.filter(function(x){ return x.id !== id; });
+  unwrap(id);
+  markDirty(); persist(); render(); closePop();
+};
+$("anSave").onclick = save;
+
+// Builds into a fragment and swaps once, so the list never blanks between
+// clearing and refilling.
+function render(){
+  // Any armed row button is about to be replaced, and an arm left standing on
+  // a list this rebuild has changed would confirm a different comment.
+  disarm();
+  var list = $("anList"), count = $("anCount");
+  // Kept in step with the list on every rebuild, and disabled rather than
+  // hidden: a control that vanishes and reappears is harder to aim at than one
+  // that greys out, and its count is the only place the copied total is shown.
+  var nCopied = copiedSet().length, clearCopied = $("anClearCopied");
+  clearCopied.textContent = "Delete copied (" + nCopied + ")";
+  clearCopied.disabled = !nCopied;
+  var fresh = freshCount();
+  badge.textContent = "\uD83D\uDCAC " + comments.length;
+  badge.className = unsaved() || (isDirty() && comments.length) ? "warn" : "";
+  if (!comments.length) {
+    // A page with no comments still has somewhere to report a refused write:
+    // on a checklist-only page this line is the ONLY place the reader is told
+    // the ticks did not survive, so it outranks the empty-state wording.
+    count.textContent = statesUnsaved
+      ? "This browser refused to store the checklist \u2014 copy it out now"
+      : notesUnsaved
+        ? "This browser refused to store the change \u2014 copy your work out now"
+        : "No comments yet";
+    count.className = "ancount" + (unsaved() ? " warn" : "");
+    var empty = document.createElement("p");
+    empty.className = "anscope"; empty.textContent = "Select any text above to comment.";
+    list.replaceChildren(empty);
+    return;
+  }
+  // Once the list can be part copied and part not, a single verdict is a lie
+  // for one half of it. The split form appears only when the list is actually
+  // mixed, so the common uniform cases stay as short as they were. The same
+  // applies to the noun: "N comments" is wrong for half a mixed page, and the
+  // plain wording is kept for the comment-only page, which is most of them.
+  var nEdits = comments.filter(isEdit).length;
+  var what = nEdits
+    ? comments.length + (comments.length === 1 ? " item (" : " items (") +
+      nEdits + (nEdits === 1 ? " suggested edit)" : " suggested edits)")
+    : comments.length + (comments.length === 1 ? " comment" : " comments");
+  count.textContent = what +
+    (unsaved() ? " \u2014 this browser refused to store them, copy them now"
+               : !fresh ? " \u2014 copied out"
+               : fresh === comments.length ? " \u2014 not yet copied out"
+               : " \u2014 " + fresh + " of " + comments.length + " not yet copied out");
+  count.className = "ancount" + (unsaved() || isDirty() ? " warn" : "");
+  var frag = document.createDocumentFragment();
+  comments.forEach(function(c){
+    var d = document.createElement("div");
+    d.className = "cmt" + (isCopied(c) ? " ancopied" : "") + (isEdit(c) ? " ansuggest" : "");
+    var w = document.createElement("div"); w.className = "where"; w.textContent = c.where;
+    var q = document.createElement("div");
+    q.className = isEdit(c) ? "q struck" : "q";
+    q.textContent = "\u201C" + c.quote + "\u201D";
+    var n = document.createElement("div");
+    if (isEdit(c)) {
+      n.className = "ins";
+      n.textContent = c.replacement
+        ? "\u2192 " + c.replacement
+        : "\u2192 delete this text";
+    } else n.textContent = c.note;
+    var a = document.createElement("button"); a.className = "anbtn ghost tiny"; a.textContent = "edit";
+    a.onclick = function(){
+      var m = document.querySelector('mark[data-cid="' + c.id + '"]');
+      if (m) { m.scrollIntoView({ block: "center" }); m.click(); }
+      else openEdit(c, null);
+    };
+    // Deleting one comment used to require opening its popup first, which is a
+    // detour for the commonest correction. It asks twice, because the note
+    // itself is the only copy and there is no undo.
+    var x = document.createElement("button");
+    x.className = "anbtn ghost tiny danger"; x.textContent = "delete";
+    x.onclick = function(){
+      if (!arm(x, "click again")) return;
+      comments = comments.filter(function(y){ return y.id !== c.id; });
+      unwrap(c.id);
+      if (editingId === c.id) closePop();
+      markDirty(); persist(); render();
+    };
+    d.append(w, q, n);
+    if (!hasMark(c)) { var o = document.createElement("div"); o.className = "orphan"; o.textContent = "quoted text not found on this version of the page"; d.append(o); }
+    var acts = document.createElement("div"); acts.className = "anacts";
+    acts.append(a, x);
+    d.append(acts); frag.appendChild(d);
+  });
+  list.replaceChildren(frag);
+}
+
+function markdown(list){
+  return list.map(function(c){
+    return "- **" + c.where + "** \u2014 " + c.note + "\n  > " + c.quote.replace(/\n/g, "\n  > ");
+  }).join("\n");
+}
+// Numbered, so a session applying them can say which one it could not place.
+function editMarkdown(list){
+  return list.map(function(c, i){
+    return (i + 1) + ". **" + c.where + "**" +
+      "\n   Replace:\n   > " + c.quote.replace(/\n/g, "\n   > ") +
+      "\n   With:" + (c.replacement
+        ? "\n   > " + c.replacement.replace(/\n/g, "\n   > ")
+        : " _(nothing \u2014 delete this text)_");
+  }).join("\n\n");
+}
+// The quotes are RENDERED text and the source is Markdown, so emphasis
+// markers, links and code spans differ between the two. The note below says so
+// in the export itself, because the export leaves this page and is read
+// without it. Nobody builds a sed loop over this format.
+var APPLY_NOTE = "These quotes are the page's RENDERED text; the source is Markdown. " +
+  "Locate each quote in the source and adapt the markup \u2014 do not apply these " +
+  "blocks byte-for-byte.";
+// A page with no suggested edits exports exactly what it did under v1: no
+// headings appear, so every existing paste-into-a-session habit still works.
+function exportText(){
+  var edits = comments.filter(isEdit);
+  var notes = comments.filter(function(c){ return !isEdit(c); });
+  var units = stateUnits();
+  var out = "# Comments \u2014 " + document.title + "\n\n";
+  // The checklist leads: it is the verdict, and the notes explain it.
+  if (units.length) out += "## Checklist\n\n" + stateMarkdown() + "\n\n";
+  if (edits.length) out += "## Suggested edits\n\n" + APPLY_NOTE + "\n\n" + editMarkdown(edits) + "\n\n";
+  if ((units.length || edits.length) && notes.length) out += "## Comments\n\n";
+  return out + (notes.length ? markdown(notes) + "\n" : "");
+}
+function toast(html, ms){ var t = $("anToast"); t.innerHTML = html; setTimeout(function(){ t.innerHTML = ""; }, ms || 1800); }
+// There is deliberately no download path. The Artifact viewer never grants a
+// page download permission, so a Download button was inert exactly where these
+// pages are read, while still making every publish warn about an offered file.
+// Copy all is the one export, with the textarea below as its fallback.
+// What the textarea currently holds. The box can sit open while the page is
+// edited behind it, so the copy event stamps the snapshot the text was built
+// from, not whatever the list happens to be when the user finally hits copy.
+var exportSnap = null;
+function openExport(){
+  var ta = $("anExportText"); ta.value = exportText();
+  exportSnap = copySnapshot();
+  $("anExport").style.display = "block";
+  ta.focus(); ta.select();
+}
+
+// Only a copy that actually happened may clear the export state — otherwise
+// the panel says the comments are safely out of the browser, and the unload
+// guard stands down, when nothing left it.
+$("anCopy").onclick = async function(){
+  // A page can be all checklist and no notes, and copying it out is the whole
+  // point of the checklist.
+  if (!comments.length && !stateUnits().length) { toast('<span class="anok">nothing to copy</span>', 1600); return; }
+  var ok = false;
+  // Both taken before the await: the clipboard promise can resolve after an
+  // edit has landed, and the text that went out is this one.
+  var snap = copySnapshot(), text = exportText();
+  try { await navigator.clipboard.writeText(text); ok = true; }
+  catch (e) {
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed"; ta.style.top = "0"; ta.style.opacity = "0";
+    document.body.appendChild(ta); ta.select();
+    try { ok = document.execCommand("copy") === true; } catch (e2) { ok = false; }
+    ta.remove();
+  }
+  // Clipboard refused: fall back to the selectable textarea. Opening it is not
+  // exporting -- the state clears when the text is actually copied out of it.
+  if (!ok) { openExport(); toast('<span class="anwarn">clipboard blocked \u2014 copy from the box</span>', 4000); return; }
+  markClean(snap); render();
+  toast('<span class="anok">copied ' + (comments.length || "the checklist") + '</span>');
+};
+$("anExportText").addEventListener("copy", function(){
+  // A copy of PART of the box carried part of the Markdown, so it did not
+  // take every comment out of the browser. Stamping them all would drop
+  // comments the user never copied into the "Delete copied" set, which is now
+  // a set something deletes. The whole-blob case is the normal one: the box
+  // opens with everything already selected.
+  var ta = this;
+  if (ta.selectionStart !== 0 || ta.selectionEnd !== ta.value.length) {
+    toast('<span class="anwarn">partial copy \u2014 nothing marked copied out</span>', 4000);
+    return;
+  }
+  markClean(exportSnap); render();
+  toast('<span class="anok">copied ' + comments.length + '</span>');
+});
+$("anExportClose").onclick = function(){ $("anExport").style.display = "none"; };
+// The safe prune, and the reason the literal request was inverted: this
+// deletes only what a copy actually carried out of the browser, so the next
+// Copy all sends fresh feedback rather than re-sending an actioned list.
+$("anClearCopied").onclick = function(){
+  var set = copiedSet();
+  if (!set.length) return;
+  if (!arm(this, "Click again to delete " + set.length + " copied out", bindingOf(set))) return;
+  var doomed = {};
+  set.forEach(function(c){ doomed[c.id] = true; unwrap(c.id); });
+  comments = comments.filter(function(c){ return !doomed[c.id]; });
+  if (editingId !== null && doomed[editingId]) closePop();
+  persist(); syncLegacyFlag(); render();
+};
+$("anClear").onclick = function(){
+  if (!comments.length) return;
+  // "Not copied out yet" is the whole reason this control asks twice, so the
+  // warning goes on the armed button, where it is read, rather than into a
+  // dialog the viewer never shows.
+  // The armed label carries the warning, because the dialog that would
+  // otherwise carry it never appears in the viewer. Naming the unsent count
+  // separately from the total is the whole point: "delete all 12" and "3 of
+  // these have never left this browser" are different facts.
+  var fresh = freshCount();
+  var warn = fresh
+    ? fresh + " not yet copied out \u2014 click again to delete all " + comments.length
+    : "All copied out \u2014 click again to delete all " + comments.length;
+  if (!arm(this, warn, bindingOf(comments))) return;
+  comments.slice().forEach(function(c){ unwrap(c.id); });
+  comments = []; markClean(); persist(); render();
+};
+badge.onclick = function(){ $("anComments").scrollIntoView({ behavior: "smooth", block: "start" }); };
+
+// A host page may bind single-key shortcuts on document or window -- a triage
+// console where `d` means delete, a slideshow where `j` means next. Typing a
+// note would fire them: the keystroke bubbles out of this textarea and reaches
+// those listeners, so the page acts on every letter of the comment.
+//
+// Attached at the layer root in the BUBBLE phase, which is the only position
+// that separates the two. Handlers inside the layer (the textarea's own Enter
+// and Escape) sit deeper and have already run; document- and window-level
+// handlers sit higher and never see the event. A capture-phase listener on
+// window would be too early and would kill this layer's own keys as well.
+["keydown", "keypress", "keyup"].forEach(function(type){
+  root.addEventListener(type, function(ev){ ev.stopPropagation(); });
+});
+
+// Before restoreHighlights: a restored state word changes the page text that
+// quotes are re-anchored against, so it has to be settled first.
+wireStates();
+restoreHighlights();
+render();
+restoreDraft();
+})();
+</script>
+<!-- /annotation-layer -->

--- a/artifacts/gateway-managed-dropin/meta.yml
+++ b/artifacts/gateway-managed-dropin/meta.yml
@@ -1,0 +1,27 @@
+title: The gateway keys move out of a public file
+url: https://claude.ai/code/artifact/d1d52cd8-b565-4f98-a863-3870026adc8b
+org: lin.yulong@gmail.com's Organization   # claude auth status, 2026-09-12 (subscriptionType max)
+first_published: 2026-09-12
+last_updated: 2026-09-12
+status: live
+
+summary: >-
+  what PR #117 changes, for a reader deciding whether to adopt it. `~/.claude` is a symlink to
+  this repo, so the file Claude Code reads and the file git tracks are the same bytes — the
+  gateway needs a loopback URL with a per-install token in it, and the repo is public, so the
+  diff can never resolve. A root-owned managed drop-in ends that because the file is not in the
+  tree at all. The costs are a manual `sudo install` per machine and the loss of the
+  `CLAUDE_RC_OVERRIDE` escape hatch. Nothing in it has run on a real machine yet
+
+source: explainer.md
+built: index.html
+builds_with: |
+  md2artifact artifacts/gateway-managed-dropin/explainer.md -o artifacts/gateway-managed-dropin/index.html
+
+related: https://github.com/yulonglin/dotfiles/pull/117
+
+established: |
+  Nothing is measured here. The page explains a proposed change and states the costs; the
+  drop-in path, the two-phase apply ordering and the CLAUDE_RC_OVERRIDE consequence are read
+  from the PR's own code and from the Claude Code managed-settings documentation, not observed
+  on a machine. The "what has and has not been verified" section says so on the page itself.


### PR DESCRIPTION
PR #117 proposes moving the model-router gateway keys into a root-owned managed settings drop-in. The page explains why the permanent uncommitted diff on claude/settings.json exists at all, what it costs today, how the drop-in ends it, and the two prices — a manual sudo install per machine and the loss of the CLAUDE_RC_OVERRIDE escape hatch. It states plainly that none of it has run on a real machine.
