### PR TITLE
review-pr-queue: post the subagent review to the PR, and name the families that survive a security review

### DIFF
--- a/claude/rules/background-jobs.md
+++ b/claude/rules/background-jobs.md
@@ -9,6 +9,6 @@ Unscoped, irreversible or security-sensitive calls stay the user's however obvio
 In worktree-isolated jobs, the CLI's git guard requires command text to prove all touched paths stay inside the worktree. It refuses:
 
 - `git -C` outside the worktree, even reads — inspect parent refs with `git log main`, `git diff main...HEAD`, or `gh pr view`.
-- Variable or `$(...)` command names — resolve the executable path first; invoke its literal path in a separate call.
+- Variable or `$(...)` command names, and variable revisions (`git show "$rev"` in a loop) — resolve first, invoke the literal text in a separate call. A blocked revision comes back empty rather than refused, so an unexplained empty `git show` is this.
 - Git combined with heredocs or output redirection — separate git calls from file writes.
 - Shell text that merely quotes git commands — write that content with Write or Edit.

--- a/claude/skills/review-pr-queue/SKILL.md
+++ b/claude/skills/review-pr-queue/SKILL.md
@@ -45,6 +45,18 @@ The shape that works is a two-stage pipeline: one fixer per PR, then an adversar
 
 Verification is not optional theatre. Across one queue, adversarial readers returned blocking findings on **four of four** code-carrying branches, including two silent data-corruption bugs that every passing test suite had missed. A same-family agent reviewing the same session's work echoes it; the second opinion has to come from elsewhere.
 
+## A subagent's review only counts once it is on the PR
+
+Findings that live in a returned agent message are not a review: nothing on the pull request records that the branch was read, so the next person starts from zero and the merge has no stated reason. Run the loop so every stage leaves a trace on the PR itself — the reader posts its findings, the fixer lands the edit against them, and the merge happens only after both exist.
+
+```bash
+gh api -X POST repos/<owner>/<repo>/pulls/<n>/reviews -f event=COMMENT -F body=@findings.md
+```
+
+`event=COMMENT` is the only event available here — the self-approval row below says why. Post before merging rather than after, because the review thread of a merged PR is where the reasoning has to be found later.
+
+A refused action belongs in that trace too. When the classifier denies a merge or an edit, quote its verdict text verbatim, name the exact diff it refused, and put both in the PR comment and in the closing summary — then stop and let the user look. Re-running the same intent in a different shape converts a decision the user should see into one they never hear about.
+
 ## Expect the first fix to be too narrow
 
 This is the single most valuable lesson from running the loop. A fix is written against the reported input and is usually wrong for its near cousin:
@@ -102,10 +114,10 @@ When a tool rewrites files in bulk, the repo's own files are a weak test — the
 
 | Symptom | Cause and what to do |
 |---|---|
-| `gh pr edit --body-file` fails with a Projects-classic GraphQL deprecation error | Repo-wide, hits every agent. Use `gh api -X PATCH repos/<owner>/<repo>/pulls/<n> -F body=@<file>` |
+| `gh pr edit --body-file` fails with a Projects-classic GraphQL deprecation error | Repo-wide, hits every agent, and it can report success while writing nothing. Use `gh api -X PATCH repos/<owner>/<repo>/pulls/<n> -F body=@<file>`, then confirm with `gh pr view <n> --json body` |
 | `gh pr review --approve` fails: "Can not approve your own pull request" | The PR author and the authenticated `gh` account are the same person. Reviews can only land as `COMMENTED`, never `APPROVED`. Attempting it also trips a `[Self-Approval]` security flag — do not retry it, and say so if a merge gate wants an approval state |
 | `gh pr merge` denied by the auto-mode classifier as `[Merge Without Review]` | Inconsistent: it may allow several then refuse. Post a real review first, and if it still refuses, ask rather than route around it |
-| An adversarial reviewer dies with a cybersecurity content flag | Security prose trips a provider-side classifier. Route that one review to a different family, and describe the mechanism in words — file and line, never payload text. See `claude/rules/sensitive-content.md` |
+| An adversarial reviewer dies with a cybersecurity content flag | Security prose trips a provider-side classifier. Measured on one sanitiser review: the OpenAI-routed seats died twice with an HTTP 400 content flag, Kimi completed the same brief, and GLM answered but stalled through six retries on one task. Re-route to Kimi first, and describe the mechanism in words — file and line, never payload text. See `claude/rules/sensitive-content.md` |
 
 ## Merge, and what to hold back
 


### PR DESCRIPTION
Six of the seven failures from the last PR-queue session were already written down in `review-pr-queue` (#132) — items 1, 2, 5 and 7 verbatim, items 3 and 4 in part. This adds what was missing. Three of the seven (2, 5, 7) needed no change at all and I edited none of them.

**The sequence a reviewed merge leaves behind.** The skill fanned out fixers and adversarial readers but never said where the findings go, so a verified branch merged with nothing on the PR recording that anyone had read it. The new section states it: the reader posts a `COMMENT` review, the fixer lands the edit against it, the merge follows both. A refused action joins the same trace — quote the classifier verdict verbatim, name the diff it refused, put both on the PR and in the closing summary, then stop.

**Two failure-mode rows get the detail that makes them actionable.** `gh pr edit --body-file` can report success while writing nothing, so the row now says to confirm with `gh pr view <n> --json body`. The reviewer content-flag row said "route to a different family" without naming one; it now carries the measurement — OpenAI-routed seats died twice with an HTTP 400 on a sanitiser review, Kimi completed the same brief, GLM answered but stalled through six retries.

**One bullet in `background-jobs.md`.** #119 listed what the worktree git guard refuses, including variable command names. A variable *revision* is an argument, not a command name, and was not covered. For a revision the refusal surfaces as empty output rather than an error, which produces a confidently wrong answer instead of a visible retry.

## What I deliberately did not do

- **No new always-loaded rule.** Nothing on the list is relevant in every session.
- **No new hook.** Each candidate needs a network check, a judgement call, or knowledge of a remote API's shape — none of which a string matcher can do. The one mechanical candidate, intercepting `gh pr edit`, would misfire in every repo where it works.
- **No change to `approval_classifier_rules.md`.** Relaxing a classifier is a security decision, and in any case that file governs the repo's own `PermissionRequest` hook, which is **not** what issued the `[Self-Modification]` denial that prompted this. Its log holds zero `DENY` entries for 2026-09-12 and zero mentioning `git push` at any point; the bracketed label is the native auto-mode classifier's format, and no file in this repo documents its policy. Nothing here tells an agent to split a command to get past a verdict.
- **No change to `delegation.md` or `council`** for the model-family finding: delegation is always-on and already over its ceiling, and a single observation about today's provider endpoints belongs in a table row that gets corrected, not in every session's context.

## Verification

`md-unwrap --check` clean on both files.

`tests/test_memory_tier_budget.py` is **red before and after** — 7 failed, 12 passed at both base commit `7e2df60` and this branch, with identical failures. The always-on tier is over its aggregate ceiling on `main` today (30384 > 29900) and this change adds 145 bytes to `background-jobs.md`, which was already 1342 against a 1150 per-file ceiling. Worth knowing separately from this PR: `rg memory_tier` finds no match in `.github/workflows/`, `config/git-hooks/`, `scripts/` or the `justfile`, so nothing runs that test.

I could not reproduce the variable-revision guard failure. Running the literal and variable forms back to back returned identical output with exit 0, because this session is not worktree-isolated and the guard was not active; the guard lives in the CLI, not in this repo, so there is nothing here to test it against. The reported symptom is recorded as reported.
