### PR TITLE
rules: shell commands for the user are multiline with backslash continuations

### DIFF
--- a/claude/rules/communication.md
+++ b/claude/rules/communication.md
@@ -40,6 +40,14 @@ Reply on the channel you were messaged on, not just the terminal. Give absolute 
 
 **"Where is X?" is answered by the path, first.** When Yulong asks where a file, doc or draft is, the first line of the reply is the absolute path (or URL) in a code block — one per thing asked for — before any status, caveat or pending work. If the thing does not exist yet, the first line says so and names the file it will become. Never bury the path in a paragraph or answer with what is in flight instead (2026-09-08: asked three times for the sabotage TeX path while the reply led with agent status). Interpret transcription artifacts charitably: VoiceInk produces phonetic errors ("VAR" → "FAR").
 
+**A shell command Yulong runs himself is written multiline, one option or argument group per line with `\` continuations.** A single long line soft-wraps in his terminal and the paste breaks at the wrap, so this one arrived split and the shell answered `(eval):2: command not found: --force-with-lease` (2026-09-12); the push failed and he retyped it.
+
+```
+git -C /home/yulong/code/dotfiles/.claude/worktrees/rq-installer-stall \
+  push --force-with-lease \
+  origin worktree-installer-stall
+```
+
 ## Durability
 
 Behavioral instructions ("allow X", "always do Y", "stop doing Z") become durable config — `settings.json` permissions, a hook, or a rules file — not memory, which is only for what config cannot encode. Never create a `.local.md` unless asked; `.md` is version-controlled and the default.


### PR DESCRIPTION
One rule added to `claude/rules/communication.md`, next to the "Where is X?" rule that already governs how things are written for the owner.

**The rule:** a shell command he runs himself is written multiline, one option or argument group per line, with `\` continuations — never a single long line.

**Why, and it is in the rule text because it is the evidence:** a one-line `git ... push --force-with-lease ...` soft-wrapped in his terminal, the paste broke `--force-with-lease` onto its own line, and the shell reported `command not found: --force-with-lease`. The push failed and he retyped it. A backslash continuation keeps each line short enough not to wrap and marks the continuation explicitly.

**Cost:** +497 bytes (6011 to 6508). One paragraph plus the three-line shape.

**Checks**

- `md-unwrap --check claude/rules/communication.md` -> `md-unwrap: 1 file(s) clean`
- `tests/test_memory_tier_budget.py` is red on `origin/main` already (7 failed / 12 passed, `communication.md: 6011 > 3100`). After this change it is 8 failed / 11 passed: the new one is `test_restructure_removed_most_of_the_tier` — `only 59.5% smaller than pre-restructure`, floor 60%. The tier sat 85 bytes above that floor before this commit, so any addition of more than 85 bytes trips it. No workflow in `.github/workflows` and no pre-commit hook runs this test. The planned prune of this file clears both.

Touches one file. No settings, hooks or generated files.
