### PR TITLE
Empty `ask`, and let the classifier judge `--force-with-lease`

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -100,7 +100,6 @@
       "Bash(git reset --hard *)",
       "Bash(git clean *)",
       "Bash(git push --force *)",
-      "Bash(git push --force-with-lease *)",
       "Bash(git push -f *)",
       "Bash(git branch -D *)",
       "Bash(dd *)",
@@ -155,11 +154,7 @@
       "Bash(* | node -)",
       "Bash(* | node - *)"
     ],
-    "ask": [
-      "Bash(sudo *)",
-      "Read(**/.env)",
-      "Read(**/.env.*)"
-    ],
+    "ask": [],
     "defaultMode": "auto"
   },
   "model": "fable",


### PR DESCRIPTION
This draft removes four explicit permission gates. Three `ask` rules would become classifier decisions, and the `.env` pair would lose defense in depth from settings; that loosening needs an owner decision before this draft can merge.

## Three asks become classifier decisions

The diff removes `Bash(sudo *)`, `Read(**/.env)`, and `Read(**/.env.*)` from `permissions.ask`. An `ask` rule forces a prompt before auto mode can judge the action, so removing each rule delegates that decision to the classifier.

## Environment reads lose defense in depth

Removing the two `.env` entries is a loosening, not cleanup and not a removal of redundant rules. [#160](https://github.com/yulonglin/dotfiles/pull/160) corrected the hook output shape that Claude Code had ignored, so the hook now denies literal cases and returns masked content, but `mask_env_read.sh` is still a best-effort text matcher rather than an equivalent control.

Measured today, `cat /path/.env` is denied and returns masked content. The following routes bypass the hook:

- `V=/path/.env; cat "$V"` returns the raw value because the hook reads command text before shell expansion.
- `sed` can read the file without interception.
- `awk` can read the file without interception.
- `nl` can read the file without interception.
- `tac` can read the file without interception.
- `od` can read the file without interception.
- `xxd` can read the file without interception.
- `strings` can read the file without interception.
- `source` can load the file without interception.
- `python3 -c "open(...)"` can read the file without interception.
- A symlink to the file bypasses the basename check.
- The `Grep` tool is not covered by the hook.

Keeping the two `Read` rules preserves an explicit prompt for matching `Read` calls even while the broader hook is incomplete. Removing them makes those literal `Read` calls depend on the hook and classifier behavior.

## Sudo loses its explicit gate

`Bash(sudo *)` is not redundant with any hook or built-in auto-mode rule. No built-in `soft_deny` rule names `sudo` or privilege escalation, so removing it hands every elevated command to the classifier's general judgment rather than a rule written for elevation.

## The entries can split cleanly

The three `ask` entries do not need to share a fate. Before this draft is ready, the owner can choose among these independent postures:

- Drop `sudo` while keeping the `.env` pair until the hardening work lands.
- Keep `sudo` while dropping the `.env` pair and accepting the best-effort hook.
- Keep or drop all three after reviewing each loosening separately.

## Force-with-lease remains under classifier judgment

The diff also removes the absolute deny for `Bash(git push --force-with-lease *)`. The reason is to permit the lease-protected spelling when the owner explicitly names the force push and target; the built-in Git Destructive `soft_deny` still sends force pushing through classifier judgment. The unguarded `Bash(git push --force *)` and `Bash(git push -f *)` entries remain denied. This decision is independent of the three `ask` entries.

## One file carries four loosenings

- `claude/settings.json`: empties `permissions.ask` by removing the `sudo` and two `.env` rules, and removes the `git push --force-with-lease` deny while retaining the two unguarded force-push denies.

## Scope excludes broader hardening work

- This PR does not expand `mask_env_read.sh` beyond the coverage fixed in #160.
- This PR does not add a `sudo`-specific hook or built-in-style `soft_deny` rule.
- This PR does not change any other `permissions.deny` entry.
- This PR does not decide that the three `ask` entries must move together.

## Verification shows the current boundary

The merged #160 hook and regression test produce this output on current `main`:

```text
$ bash \
    claude/hooks/test_mask_env_read.sh
=== SHOULD MASK: Read tool ===
=== SHOULD MASK: simple Bash reads ===
=== SHOULD MASK: reads hidden behind shell operators (the fixed bypass) ===
=== SHOULD ALLOW: no env file involved ===
=== SHOULD MASK: the deny is carried by permissionDecision, not decision.behavior ===

21 passed, 0 failed
```

The current PR check output is:

```text
$ gh pr checks \
    158 \
    --repo yulonglin/dotfiles
No CLAUDE_CODE_ATTRIBUTION_HEADER opt-out    pass    5s    https://github.com/yulonglin/dotfiles/actions/runs/34685510054/job/103531701768
```

These checks confirm the corrected literal hook paths and the repository settings guard. They do not prove complete `.env` interception; the measured bypasses above define the current boundary.

## Risks remain before any merge

- An automated security review rated `"ask": []` as **HIGH**.
- The `.env` removal reduces defense in depth while known hook bypasses remain and the hardening PR has not landed.
- The `sudo` removal leaves elevated commands to general classifier judgment with no elevation-specific rule.
- The `--force-with-lease` removal changes an absolute deny into a classifier decision.

Keep this PR as a draft until the owner chooses the split.
