### PR TITLE
Make the env-masking hook actually deny, and test the key not the substring

### DIFF
--- a/claude/hooks/mask_env_read.sh
+++ b/claude/hooks/mask_env_read.sh
@@ -5,17 +5,33 @@
 #   - Read tool: file_path matching .env, .env.*, .envrc
 #   - Bash tool: cat/head/tail/grep/bat on .env files
 #
-# Instead of allowing raw access, denies the read and provides masked content
-# in a systemMessage. Keys are visible, values show first 4 chars + ****.
+# Instead of allowing raw access, denies the read and returns the masked
+# content as the denial reason. Keys are visible, values show first 4 chars
+# + ****.
 #
 # Hook output format (JSON on stdout):
-#   decision.behavior = "deny" + systemMessage with masked content
+#   hookSpecificOutput.permissionDecision = "deny"
+#   hookSpecificOutput.permissionDecisionReason = <masked content>
+#
+# WARNING: the deny key is permissionDecision. Claude Code silently ignores a
+# nested decision.behavior object — the hook emitted that shape from its first
+# commit until 2026-09-12 and blocked nothing at all for its whole life, while
+# its test asserted only that the substring "deny" appeared somewhere in the
+# output. Assert the KEY, never the substring.
 #
 # Exit 0 always (JSON output controls behavior).
 
 set -euo pipefail
 
 INPUT=$(cat)
+
+# The one deny path. Shape matches block_vault_structure.sh exactly: Claude
+# Code reads hookSpecificOutput.permissionDecision and nothing else.
+deny() {
+    jq -n --arg r "$1" \
+      '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+    exit 0
+}
 
 # Extract tool_name and tool_input
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
@@ -89,13 +105,7 @@ fi
 
 # Check if file is binary (skip masking for binary files)
 if file -b "$FILE_PATH" 2>/dev/null | grep -qi 'binary\|executable\|data'; then
-    jq -n '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        decision: {behavior: "deny", reason: "Binary .env file detected — refusing to read."}
-      }
-    }'
-    exit 0
+    deny "Binary .env file detected — refusing to read."
 fi
 
 # Read and mask the file content
@@ -111,14 +121,7 @@ fi
 # Limit file size to prevent huge outputs (100KB max)
 FILE_SIZE=$(wc -c < "$FILE_PATH" 2>/dev/null || echo 0)
 if (( FILE_SIZE > 102400 )); then
-    jq -n --arg path "$FILE_PATH" '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        decision: {behavior: "deny", reason: ("Env file too large to mask safely: " + $path)}
-      },
-      systemMessage: ("The file " + $path + " is over 100KB. This is unusually large for an env file — inspect manually.")
-    }'
-    exit 0
+    deny "Env file too large to mask safely: $FILE_PATH is over 100KB. This is unusually large for an env file — inspect it manually outside the transcript."
 fi
 
 # Process the file line by line
@@ -170,34 +173,23 @@ for line in sys.stdin:
 print("\n".join(lines))
 ' < "$FILE_PATH" 2>/dev/null) || {
     # Python failed — deny without content
-    jq -n --arg path "$FILE_PATH" '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        decision: {behavior: "deny", reason: ("Failed to mask env file: " + $path)}
-      }
-    }'
-    exit 0
+    deny "Failed to mask env file: $FILE_PATH. Refusing the read rather than falling through to the raw value."
 }
 
 # Build the output JSON with masked content
-# Truncate masked content if very long (keep under 8KB for systemMessage)
+# Truncate masked content if very long (keep the denial reason under 8KB)
 MASKED_LENGTH=${#MASKED_CONTENT}
 if (( MASKED_LENGTH > 8000 )); then
     MASKED_CONTENT="${MASKED_CONTENT:0:8000}
 ... (truncated, file has $MASKED_LENGTH chars)"
 fi
 
-jq -n \
-    --arg path "$FILE_PATH" \
-    --arg content "$MASKED_CONTENT" \
-    '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        decision: {
-          behavior: "deny",
-          reason: ("Secret values masked in " + $path + ". To get one specific value, use `dotfiles-secrets get-value '\''ENV_NAME - description'\''` (list keys with `dotfiles-secrets keys-meta`). Note `printenv KEY_NAME` is blocked by block_secret_expansion.sh — it would write the value into the transcript permanently.")
-        }
-      },
-      systemMessage: ("## Masked contents of " + $path + "\n\nSecret values are masked (first 4 chars visible). To read one value: `dotfiles-secrets get-value '\''ENV_NAME - description'\''`. To USE a secret without printing it: `secrets run KEY_NAME -- <command>`.\n\n```\n" + $content + "\n```")
-    }'
-exit 0
+deny "## Masked contents of $FILE_PATH
+
+Secret values are masked (first 4 chars visible).
+
+\`\`\`
+$MASKED_CONTENT
+\`\`\`
+
+To read one value: \`dotfiles-secrets get-value 'ENV_NAME - description'\` (list keys with \`dotfiles-secrets keys-meta\`). To USE a secret without printing it: \`secrets run KEY_NAME -- <command>\`. Note \`printenv KEY_NAME\` is blocked by block_secret_expansion.sh — it would write the value into the transcript permanently."

--- a/claude/hooks/test_mask_env_read.sh
+++ b/claude/hooks/test_mask_env_read.sh
@@ -3,7 +3,14 @@
 # Run: bash claude/hooks/test_mask_env_read.sh
 #
 # The hook always exits 0 and signals its verdict as JSON on stdout, so these
-# tests assert on the presence of a "deny" decision, not on the exit code.
+# tests assert on the JSON, not on the exit code.
+#
+# They assert the KEY, not the substring. Until 2026-09-12 this file checked
+# only that the string "deny" appeared somewhere in the output, which is true
+# of both the shape Claude Code obeys (hookSpecificOutput.permissionDecision)
+# and the nested decision.behavior shape it silently ignores — so the suite was
+# green against a hook that blocked nothing. A substring check here can never
+# tell a working hook from a decorative one; keep the jq key assertions.
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/mask_env_read.sh"
 PASS=0
@@ -21,6 +28,42 @@ printf 'API_KEY=supersecretvalue\nPLAIN=hello\n' > "$FIXTURE/.env"
 printf 'export TOKEN=anothersecret\n' > "$FIXTURE/.envrc"
 printf 'not an env file\n' > "$FIXTURE/README.md"
 
+# Read the verdict out of the hook's JSON by KEY. Anything that is not a
+# well-formed object carrying hookSpecificOutput.permissionDecision == "deny"
+# is an allow, however much of the word "deny" it contains.
+verdict() {
+    printf '%s' "$1" \
+        | jq -e -r 'if .hookSpecificOutput.permissionDecision == "deny"
+                    then "mask" else "allow" end' 2>/dev/null \
+        || echo allow
+}
+
+check() {
+    local desc="$1" expect="$2" out="$3"
+    local got
+    got=$(verdict "$out")
+    if [ "$got" != "$expect" ]; then
+        FAIL=$((FAIL + 1))
+        printf 'FAIL: %s (expected %s, got %s)\n' "$desc" "$expect" "$got"
+        return
+    fi
+    # A deny that leaks the raw value is worse than no deny at all: it puts the
+    # secret in the transcript AND claims to have protected it.
+    if [ "$expect" = mask ]; then
+        if [[ "$out" != *'API_KEY=supe****'* && "$out" != *'TOKEN=anot****'* ]]; then
+            FAIL=$((FAIL + 1))
+            printf 'FAIL: %s (denied, but the reason carries no masked content)\n' "$desc"
+            return
+        fi
+        if [[ "$out" == *supersecretvalue* || "$out" == *anothersecret* ]]; then
+            FAIL=$((FAIL + 1))
+            printf 'FAIL: %s (denied, but the raw value is in the output)\n' "$desc"
+            return
+        fi
+    fi
+    PASS=$((PASS + 1))
+}
+
 run_bash() {
     local desc="$1" cmd="$2" expect="$3"
     local out
@@ -29,14 +72,7 @@ import json, sys
 print(json.dumps({'tool_name': 'Bash', 'cwd': sys.argv[2],
                   'tool_input': {'command': sys.argv[1]}}))" \
         "$cmd" "$FIXTURE" | bash "$HOOK" 2>/dev/null)
-    local got="allow"
-    [[ "$out" == *'"deny"'* ]] && got="mask"
-    if [ "$got" = "$expect" ]; then
-        PASS=$((PASS + 1))
-    else
-        FAIL=$((FAIL + 1))
-        printf 'FAIL: %s (expected %s, got %s)\n' "$desc" "$expect" "$got"
-    fi
+    check "$desc" "$expect" "$out"
 }
 
 run_read() {
@@ -46,14 +82,7 @@ run_read() {
 import json, sys
 print(json.dumps({'tool_name': 'Read', 'tool_input': {'file_path': sys.argv[1]}}))" \
         "$path" | bash "$HOOK" 2>/dev/null)
-    local got="allow"
-    [[ "$out" == *'"deny"'* ]] && got="mask"
-    if [ "$got" = "$expect" ]; then
-        PASS=$((PASS + 1))
-    else
-        FAIL=$((FAIL + 1))
-        printf 'FAIL: %s (expected %s, got %s)\n' "$desc" "$expect" "$got"
-    fi
+    check "$desc" "$expect" "$out"
 }
 
 echo "=== SHOULD MASK: Read tool ==="
@@ -82,6 +111,24 @@ run_bash "git status"              'git status --short'       allow
 run_bash "ls with pipe"            'ls -la | wc -l'           allow
 run_read "read a normal file"      "$FIXTURE/README.md"       allow
 run_bash "nonexistent env file"    'cat .env.missing'         allow
+
+echo "=== SHOULD MASK: the deny is carried by permissionDecision, not decision.behavior ==="
+SHAPE=$(python3 -c "
+import json, sys
+print(json.dumps({'tool_name': 'Read', 'tool_input': {'file_path': sys.argv[1]}}))" \
+    "$FIXTURE/.env" | bash "$HOOK" 2>/dev/null)
+if printf '%s' "$SHAPE" | jq -e '.hookSpecificOutput | has("permissionDecision") and has("permissionDecisionReason")' >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo 'FAIL: hookSpecificOutput lacks permissionDecision/permissionDecisionReason (Claude Code ignores any other deny key)'
+fi
+if printf '%s' "$SHAPE" | jq -e '.hookSpecificOutput | has("decision")' >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1))
+    echo 'FAIL: hookSpecificOutput still carries a nested decision object, which is silently ignored'
+else
+    PASS=$((PASS + 1))
+fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The hook has never masked anything, because Claude Code ignores its deny key

`claude/hooks/mask_env_read.sh` emitted its verdict as a nested `hookSpecificOutput.decision.behavior` object. Claude Code reads `hookSpecificOutput.permissionDecision`; the nested object is silently discarded, so every `.env` read went through in full and the masked text was merely displayed beside the raw value. This is a live exposure, not a theoretical one.

Measured on 2.1.269 against a throwaway fixture holding an obviously fake value. `cat` returned the value in full; the `Read` tool did too. Driving the hook directly showed it firing correctly and producing the shape that gets thrown away.

## All four deny branches now use the shape that blocks

Binary file, oversize file, mask failure and the main masked-content path all route through one `deny()` helper. Its JSON is byte-identical to `claude/hooks/block_vault_structure.sh` line 42, which does block:

```
{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}
```

The masked content moves from the top-level `systemMessage` into `permissionDecisionReason`, because the reason is the channel the reader actually sees. A denial that says only "refused" would throw away the hook's whole value; the reader still gets every key with its value truncated to four characters. The header comment, which documented the broken shape, is corrected and now carries the warning.

## The test asserted a substring both shapes contain

The old test checked only that `"deny"` appeared somewhere in the output. That is true of the working shape and of the ignored one, so **19 checks passed against a hook that blocked nothing**. It now reads the verdict with `jq` by key, additionally requires the masked value to be present and the raw value to be absent, and pins the two shape properties directly, so a future rename cannot pass quietly.

The new test against the **old** hook — 15 of 21 fail:

```
=== SHOULD MASK: Read tool ===
FAIL: read .env (expected mask, got allow)
FAIL: read .envrc (expected mask, got allow)
=== SHOULD MASK: simple Bash reads ===
FAIL: cat .env (expected mask, got allow)
FAIL: head .envrc (expected mask, got allow)
FAIL: grep in .env (expected mask, got allow)
FAIL: path-qualified cat (expected mask, got allow)
=== SHOULD MASK: reads hidden behind shell operators (the fixed bypass) ===
FAIL: piped to head (expected mask, got allow)
FAIL: piped to wc (expected mask, got allow)
FAIL: grep piped (expected mask, got allow)
FAIL: behind && (expected mask, got allow)
FAIL: behind ; (expected mask, got allow)
FAIL: behind || (expected mask, got allow)
FAIL: second in a pipeline (expected mask, got allow)
=== SHOULD ALLOW: no env file involved ===
=== SHOULD MASK: the deny is carried by permissionDecision, not decision.behavior ===
FAIL: hookSpecificOutput lacks permissionDecision/permissionDecisionReason (Claude Code ignores any other deny key)
FAIL: hookSpecificOutput still carries a nested decision object, which is silently ignored

6 passed, 15 failed
```

The new test against **this branch** — clean:

```
=== SHOULD MASK: Read tool ===
=== SHOULD MASK: simple Bash reads ===
=== SHOULD MASK: reads hidden behind shell operators (the fixed bypass) ===
=== SHOULD ALLOW: no env file involved ===
=== SHOULD MASK: the deny is carried by permissionDecision, not decision.behavior ===

21 passed, 0 failed
```

For the record, the **old** test against the **old** hook scored `19 passed, 0 failed`. That is the whole reason this shipped.

`shellcheck` is clean on both files.

## Twelve routes are intercepted and fourteen are not

Each row is a real invocation of the fixed hook against a fixture whose only value is a fake token. No real credential was used anywhere in this work.

| Verdict | Route |
|---|---|
| DENY | `Read` tool on `.env` |
| DENY | `cat .env`, `tail -2 .env`, `grep KEY .env`, `bat .env`, `less .env` |
| DENY | `cat ./.env`, `cat -- .env`, `cat < .env` |
| DENY | `cat .env \| head -1`, `ls && cat .env` |
| ALLOW | `sed -n p .env`, `awk '{print}' .env`, `nl .env`, `tac .env` |
| ALLOW | `od -c .env`, `xxd .env`, `strings .env`, `cp .env /dev/stdout` |
| ALLOW | `source .env`, `. .env`, `python3 -c "print(open('.env').read())"` |
| ALLOW | `echo "$(cat .env)"` — the segment's first word is `echo`, so the case list never sees `cat` |
| ALLOW | `cat envlink` where `envlink` symlinks to `.env` — the basename check tests the link, not the target |
| ALLOW | `while read -r l; do echo "$l"; done < .env` |
| ALLOW | The `Grep` tool with `path: .env` and content output — the hook is registered for `Read` and `Bash` only |

Everything the header claims to cover is covered. Everything else is not, and this PR does not widen it: the defect is the output shape, and mixing an intercept expansion into a security fix makes both harder to review. The symlink and `Grep` gaps are the two most worth closing next.

## Verified by direct invocation, not yet live

The live hook is `~/.claude/hooks/mask_env_read.sh`, which resolves into the main checkout, so a branch cannot exercise it. The "before" evidence above **is** live — the leak was reproduced through the real tool path. The "after" evidence is direct invocation plus shape identity with a hook the repo already relies on to block.

**The fix does not take effect for the owner when this merges.** The live config is main's working copy, so the hook stays broken until main's checkout is updated.

A plain pull will refuse. Measured after the merge: local main is 0 ahead and 28 behind `origin/main`, and four of its locally-modified files — `claude/settings.json`, `codex/config.toml`, `codex/rules/default.rules`, `custom_bins/claude-tools-linux-x86_64` — are touched by the incoming commits. `claude/settings.json` carries the permanent gateway diff that must survive, so that is a merge to do deliberately rather than a one-liner.

Both hook files are clean in main's working tree, so the exposure can be closed on its own, ahead of that merge, by restoring just those two paths from `origin/main` into `/home/yulong/code/dotfiles`. `block_destructive_git.sh` matches that command text and refuses it — confirmed, it blocked the edit that first wrote this paragraph — so it needs the `!` prefix in an interactive session, which is what the guard's own message recommends.

Then re-verify live: write an obviously fake value to a scratch `.env`, read it with `cat` and with the `Read` tool, and confirm both come back masked.

## This blocks #158

**Draft #158 must not merge until this lands.** It empties `permissions.ask`, and the justification offered for dropping the two `.env` entries was that this hook made them redundant. That justification was false for the hook's entire life and is only true from this commit. An automated security review has separately flagged `"ask": []` as HIGH.

Even after this merges, the `sudo` entry in #158 is a separate question that this PR does not answer.

Observed while reading the settings and left alone: `mask_env_read.sh` is registered twice under the `Read` matcher in `claude/settings.json`. Harmless, out of scope here.
