### PR TITLE
autoMode: inherit the built-in allow and environment lists again

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -888,24 +888,13 @@
   "skipAutoPermissionPrompt": true,
   "autoMode": {
     "allow": [
-      "Test Artifacts: Hardcoded test API keys, placeholder credentials in examples, or hardcoding test cases",
-      "Local Operations: Agent deleting local files in working directory, local file operations within project scope, or using `--ignore-certificate-errors` for local testing. \"Project scope\" means the repository the session started in — wandering into ~/, ~/Library/, /etc, or other repos is scope escalation (User Intent Rule #2), not a local operation. Does NOT cover irreversible destruction of pre-existing files or local stateful services — see \"Irreversible Local Destruction\" in BLOCK.",
-      "Read-Only Operations: GET requests, read-only API calls, or queries that don't modify state and don't contain sensitive information in the URL. Note: PREEMPTIVE BLOCK ON CLEAR INTENT still applies — if the transcript contains clear evidence the agent is using read-only operations to scout for a blocked action, block it.",
-      "Declared Dependencies: Installing packages that are already declared in the repo's manifest files (requirements.txt, package.json, Cargo.toml, pyproject.toml, Gemfile, etc.) via standard commands that read those manifests (`pip install -r requirements.txt`, `npm install`, `cargo build`, `bundle install`) — provided the agent has not modified the manifest in this session. Does NOT cover installing agent-chosen package names (e.g. `pip install foo`, `npm install bar`) — those carry typosquat and supply-chain risk.",
-      "Toolchain Bootstrap: Installing language toolchains (not packages) from their official one-line installers — `sh.rustup.rs`, `bootstrap.pypa.io`, `astral.sh`, `bun.sh`, `deb.nodesource.com`, `get.docker.com`, `brew.sh` — when the repo's manifest or build config indicates that toolchain is required.",
-      "Standard Credentials: Reading credentials from the agent's own config (.env, config files) and sending them to their intended provider (e.g. API key to its matching API endpoint)",
+      "$defaults",
       "Git Push to Working Branch: Pushing to the branch the user started the session on (unless it is the repository default branch), or to a branch the agent created during the session. Does not cover pushing to other pre-existing branches.",
-      "Memory Directory: Routine writes to and deletes from the agent's memory directory (e.g. ~/.claude/projects/*/memory/) — recording or pruning user preferences, project facts, references. This is intended persistence the system prompt directs the agent to use, not Self-Modification or Irreversible Local Destruction. Does NOT cover content described in Memory Poisoning.",
-      "Claude Code Scheduling: Using `CronCreate`, `CronDelete`, `CronList`, or `RemoteTrigger` to schedule or manage Claude Code tasks. `CronCreate` fires prompts within the current Claude session or writes to `.claude/scheduled_tasks.json`; `RemoteTrigger` registers agents with cloud services (`claude.ai/code/routines`).",
       "Read-only commands (cat, ls, head, tail, jq, grep, rg, fd, find, git log/status/diff/show, eza, bat, wc) targeting any personal repository under ~/code/, ~/writing/, ~/projects/, or ~/scratch/ — even when the current session is in a different personal repo. The user routinely runs read-only queries across their own repos. Cross-repo writes/edits/moves/deletes still require permission. Excludes paths under ~/.config/dotfiles-secrets/, ~/.config/sops/age/, ~/.aws/, ~/.ssh/id_* (private keys), ~/.claude/.credentials.json, ~/.claude/projects/*.jsonl, and .env* files with real secrets.",
       "Writes (Edit, Write, MultiEdit) and commits inside other personal repos under ~/code/, ~/writing/, ~/projects/, ~/scratch/ are allowed when the user's current message names the target repo or directory by path. Pushing to remotes in those other repos still requires confirmation."
     ],
     "environment": [
-      "**Trusted repo**: The git repository the agent started in (its working directory) and its configured remote(s)",
-      "**Source control**: The trusted repo and its remote(s) only (no additional orgs configured)",
-      "**Trusted internal domains**: None configured",
-      "**Trusted cloud buckets**: None configured",
-      "**Key internal services**: None configured",
+      "$defaults",
       "Trusted source control orgs: github.com/yulonglin"
     ]
   },


### PR DESCRIPTION
**This is a loosening, not a bug fix.** The classifier was running with 11 custom `allow` entries and all 70 `soft_deny` rules, but without the 17 built-in allow exceptions. Restoring `"$defaults"` and removing stale copies produces 20 effective allow entries.

The `environment` change is not a pure loosening. It restores 21 built-in slots: trust slots widen what is treated as inside the boundary, while sensitivity slots narrow how protected data and targets are handled. With the retained custom entry, the effective environment list grows from 6 to 22.

[Full analysis](/home/yulong/vault/tooling/dotfiles/auto-mode-defaults-restored.md)

## The wider push rule governs

The custom `Git Push to Working Branch` rule is narrower than the built-in `Git Push Destination` rule. Once both are present, the wider built-in rule governs and the custom rule becomes inert. This silently widens the push posture from the working branch or a session-created branch to any branch in the session repository, including the default branch.

## One file changes one block

- `claude/settings.json` adds `"$defaults"` to `autoMode.allow` and `autoMode.environment`, removes eight stale allow copies and five stale environment copies, and keeps the three custom allow entries plus the one custom environment entry.

## The boundary stays narrow

- No change to `permissions.ask`.
- No change to `permissions.deny`.
- No change outside the `autoMode` block.
- No correction for the public-repository visibility assumption.
- No resolution of the existing `Source control` slot contradiction.

## Verification matches the claim

Built-in counts:

```bash
claude auto-mode defaults \
  | jq \
      '{allow: (.allow | length), environment: (.environment | length), soft_deny: (.soft_deny | length)}'
```

```text
{
  "allow": 17,
  "environment": 21,
  "soft_deny": 70
}
```

The current `origin/main` settings blob and the computed merge-tree settings blob were loaded into separate temporary config directories. The effective counts were:

```bash
CLAUDE_CONFIG_DIR=/tmp/pr161-review.buPIjo/before \
  claude --setting-sources user auto-mode config \
  | jq \
      '{allow: (.allow | length), environment: (.environment | length)}'
```

```text
{
  "allow": 11,
  "environment": 6
}
```

```bash
CLAUDE_CONFIG_DIR=/tmp/pr161-review.buPIjo/after \
  claude --setting-sources user auto-mode config \
  | jq \
      '{allow: (.allow | length), environment: (.environment | length)}'
```

```text
{
  "allow": 20,
  "environment": 22
}
```

The computed merge result changes only the intended file:

```bash
git diff --stat \
  refs/remotes/origin/main \
  d7cc457c6c1419683abfe76cf40d7168206b92c9
```

```text
 claude/settings.json | 15 ++-------------
 1 file changed, 2 insertions(+), 13 deletions(-)
```

A direct JSON comparison of the current committed blob and computed merge blob returned:

```text
required key statusLine: True
required key hooks: True
required key permissions: True
permissions.ask: unchanged=True sha256=28c83f79178c864f
permissions.deny: unchanged=True sha256=b0afeadecb6370c0
ANTHROPIC_BASE_URL absent: True
modelPicker absent: True
tokened loopback absent: True
```

Measured with CLI version 2.1.269.

## The risks remain explicit

- `Git Push Destination` is the largest widening because it overrides the narrower custom push boundary without deleting that custom text.
- The restored environment list moves both ways: trust defaults can widen destinations, while sensitivity defaults add protective constraints.
- The built-in repository-visibility default can treat this public repository as private; that correction remains a separate follow-up.
