### PR TITLE
Close the env-read bypasses measured today, and say the hook is not a boundary

### DIFF
--- a/claude/hooks/mask_env_read.sh
+++ b/claude/hooks/mask_env_read.sh
@@ -1,9 +1,38 @@
 #!/usr/bin/env bash
 # PreToolUse hook: mask secret values when .env/.envrc files are read.
 #
+# ---------------------------------------------------------------------------
+# THIS HOOK IS NOT A SECURITY BOUNDARY. IT IS A GUARD RAIL AGAINST ACCIDENTS.
+#
+# It reads the command TEXT before the shell expands it, so it can only ever
+# recognise the shapes it has been taught. A command-text filter cannot be
+# complete, and no amount of widening will make it complete:
+#
+#     python3 -c "print(open(chr(46)+'env').read())"
+#
+# defeats every list in this file, and so does base64-ing the name, building
+# the path from two variables, or reading through a file descriptor. Anyone
+# who wants the value gets the value.
+#
+# So do NOT reason "the hook covers it" and drop a permission rule. That exact
+# reasoning is why this file needed hardening: on 2026-09-12 `permissions.ask`
+# on `Read(**/.env*)` was called redundant *because the hook existed*, while
+# the hook had never blocked anything in its life (see the shape warning
+# below). The permission rules are the gate. This hook is the thing that stops
+# an ordinary `cat .env` from writing a live credential into the transcript
+# where it stays forever.
+#
+# Current gate, for reference (claude/settings.json, permissions):
+#     ask:   Read(**/.env)   Read(**/.env.*)
+#     allow: Read(**/.envrc)   <-- no gate at all; for .envrc this hook is
+#                                  the only thing in the way
+# Neither rule covers the Bash tool, which is what most of the code below is.
+# ---------------------------------------------------------------------------
+#
 # Intercepts:
-#   - Read tool: file_path matching .env, .env.*, .envrc
-#   - Bash tool: cat/head/tail/grep/bat on .env files
+#   - Read tool:  tool_input.file_path
+#   - Grep tool:  tool_input.path  (only once settings registers a Grep matcher)
+#   - Bash tool:  a reader command applied to an env file, in any shell segment
 #
 # Instead of allowing raw access, denies the read and returns the masked
 # content as the denial reason. Keys are visible, values show first 4 chars
@@ -18,6 +47,16 @@
 # commit until 2026-09-12 and blocked nothing at all for its whole life, while
 # its test asserted only that the substring "deny" appeared somewhere in the
 # output. Assert the KEY, never the substring.
+#
+# WARNING: a hook can only run if its `if` clause in settings.json lets it.
+# `Bash(*.env*)` glob-matches the command text, so `cat notes.txt` — a symlink
+# to .env — never reaches this file however well it is handled here. The
+# symlink and quoted/variable-path handling below is worth having anyway, but
+# it is live only when the hook is invoked.
+#
+# Known gaps, deliberately not chased: nested shells (`bash -c '...'`),
+# interpreters that build the filename at runtime, anything reading through a
+# pre-opened descriptor, and any reader not in the list below.
 #
 # Exit 0 always (JSON output controls behavior).
 
@@ -37,65 +76,209 @@ deny() {
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
 [[ -z "$TOOL_NAME" ]] && exit 0
 
-# Determine the target file path based on tool type
-FILE_PATH=""
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""' 2>/dev/null) || CWD=""
 
-if [[ "$TOOL_NAME" == "Read" ]]; then
-    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null) || exit 0
-elif [[ "$TOOL_NAME" == "Bash" ]]; then
-    CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
-    [[ -z "$CMD" ]] && exit 0
+# The single argument handed to the detector: a path for the file tools, the
+# whole command line for Bash.
+SUBJECT=""
+case "$TOOL_NAME" in
+    Read)  SUBJECT=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null) || exit 0 ;;
+    Grep)  SUBJECT=$(printf '%s' "$INPUT" | jq -r '.tool_input.path // ""' 2>/dev/null) || exit 0 ;;
+    Bash)  SUBJECT=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0 ;;
+    *) exit 0 ;;
+esac
+[[ -z "$SUBJECT" ]] && exit 0
 
-    # Check EVERY shell segment, not just the whole command's first word.
-    # A pipeline is not an exemption: `cat .env | head` leaks exactly as much
-    # as `cat .env`, and `ls && cat .env` hides the read behind an innocuous
-    # first word. Splitting on ||, &&, ; and | closes both.
-    #
-    # BEHAVIOR NOTE: this deliberately changes results for pipelines that used
-    # to run unguarded — `cat .env | wc -l` now returns the masked-content
-    # denial instead of a line count. The count is recoverable from the masked
-    # output; a raw value in the transcript is not recoverable at all.
-    #
-    # If a command reads more than one env file, only the FIRST match is
-    # reported; the rest are suppressed along with the whole command.
-    while IFS= read -r SEGMENT; do
-        [[ -z "${SEGMENT// /}" ]] && continue
-        CMD_NAME=$(printf '%s' "$SEGMENT" | awk '{print $1}')
-        case "$CMD_NAME" in
-            cat|head|tail|bat|less|more|grep) ;;
-            */cat|*/head|*/tail|*/bat|*/less|*/more|*/grep) ;;
-            *) continue ;;
-        esac
-        # Extract file paths that look like env files from the segment's args
-        FILE_PATH=$(printf '%s' "$SEGMENT" | grep -oE '[^[:space:]]+/(\.env[^[:space:]]*|\.envrc)|[[:space:]](\.env[^[:space:]]*|\.envrc)' | tr -d ' ' | tail -1) || true
-        # Also try: command operates on a bare .env in cwd
-        if [[ -z "$FILE_PATH" ]]; then
-            FILE_PATH=$(printf '%s' "$SEGMENT" | grep -oE '\b\.env[a-zA-Z._]*\b|\b\.envrc\b' | tail -1) || true
-        fi
-        [[ -n "$FILE_PATH" ]] && break
-    done < <(printf '%s' "$CMD" | awk '{gsub(/\|\||&&|[;|]/, "\n"); print}')
-fi
+# One detector for all three tools. Prints the absolute path of the env file
+# the call would read, or nothing. Failing open on an internal error is the
+# deliberate choice: this is a guard rail, and a crashing guard rail must not
+# wedge every Bash call in the session.
+FILE_PATH=$(python3 - "$TOOL_NAME" "$SUBJECT" "$CWD" <<'PY' 2>/dev/null || true
+import os
+import re
+import shlex
+import sys
+
+TOOL, SUBJECT, CWD = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Commands that put file CONTENT somewhere a human or a transcript can see.
+# Writers, movers and editors are deliberately absent: `git add .env`,
+# `rm .env`, `mv .env x` and `vim .env` do not leak a value into the
+# transcript, and intercepting them would break ordinary work for nothing.
+READERS = {
+    "cat", "head", "tail", "bat", "less", "more", "grep", "egrep", "fgrep",
+    "rg", "sed", "awk", "gawk", "mawk", "nl", "tac", "rev", "cut", "od",
+    "xxd", "hexdump", "strings", "base64", "dd", "diff", "source", ".",
+}
+# An inline script is a reader whenever an env filename appears in its text.
+INTERPRETERS = {"python", "python2", "python3", "perl", "ruby", "node", "bun", "deno", "php"}
+INLINE_FLAGS = ("-c", "-e", "-E", "-p", "-n")
+# `cp .env /dev/stdout` is a read wearing a copy's clothes.
+STDOUT_SINKS = {"/dev/stdout", "/dev/stderr", "/dev/fd/1", "/dev/fd/2",
+                "/proc/self/fd/1", "/proc/self/fd/2"}
+COPIERS = {"cp", "install"}
+# `source FILE [args]` reads only its first argument. Enforcing that is not
+# pedantry: a prose sentence inside a commit-message heredoc starts with ". ",
+# which parses as the source builtin, and any filename later in the sentence
+# would otherwise be read as its target.
+SOURCERS = {"source", "."}
+# Flags whose value is a pattern, a glob or a delimiter — never a file to read.
+# `rg -g '.envrc'` names a glob; `grep -f .env` really does read .env, so -f is
+# deliberately absent.
+VALUE_FLAGS = {"-e", "--regexp", "-g", "--glob", "--iglob", "--include",
+               "--exclude", "--exclude-dir", "-t", "--type", "-d",
+               "--delimiter", "-m", "--max-count", "-S", "--sort"}
+# `rg --files` lists filenames and never opens them.
+NO_READ_FLAGS = {"--files", "-l", "--files-with-matches", "-L",
+                 "--files-without-match"}
+
+# Shell separators, plus the substitution delimiters. Splitting on `$(`, `)`
+# and backticks is what catches `echo "$(cat .env)"` and
+# `export $(cat .env | xargs)` — the two commonest accidental load idioms.
+SPLIT = re.compile(r"\|\||&&|[;|\n]|\$\(|\)|`|<\(|>\(")
+ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+REDIR = re.compile(r"^\d*(>>|>|<<<|<<|<)(.*)$")
+ENV_TOKEN = re.compile(r"[^\s'\"]*\.env(?:rc|\.[A-Za-z0-9_.-]+)?")
+
+
+def envish(name):
+    return name in (".env", ".envrc") or name.startswith(".env.")
+
+
+def is_env_file(path):
+    """True if the path is named like an env file, or points at one.
+
+    The second half is the symlink case: the basename check tests the link,
+    so a link named anything at all walked straight past it before.
+    """
+    if envish(os.path.basename(path)):
+        return True
+    try:
+        return envish(os.path.basename(os.path.realpath(path)))
+    except OSError:
+        return False
+
+
+def absolutise(token, cwd):
+    token = os.path.expanduser(token)
+    if os.path.isabs(token):
+        return os.path.normpath(token)
+    return os.path.normpath(os.path.join(cwd, token)) if cwd else token
+
+
+def expand(token, variables):
+    """Resolve $VAR / ${VAR} from same-command assignments, then the real env.
+
+    `V=/path/to/.env; cat "$V"` was a one-line bypass of a hook whose whole
+    purpose is to stop that read: the text `cat "$V"` contains no .env at all.
+    """
+    def sub(match):
+        name = match.group(1) or match.group(2)
+        if name in variables:
+            return variables[name]
+        return os.environ.get(name, match.group(0))
+    return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)", sub, token)
+
+
+def candidates_of(segment, tokens, variables, cwd):
+    """(paths this segment would READ, new cwd)."""
+    name = os.path.basename(tokens[0])
+    args = tokens[1:]
+
+    if name in ("cd", "pushd"):
+        target = [a for a in args if not a.startswith("-")]
+        if target:
+            return [], absolutise(expand(target[0], variables), cwd)
+        return [], cwd
+
+    files, reads, pending = [], [], None
+    for arg in args:
+        if pending == "out":
+            pending = None
+            continue
+        if pending == "in":
+            reads.append(arg)
+            pending = None
+            continue
+        if pending == "flag":
+            pending = None
+            continue
+        if arg in VALUE_FLAGS:
+            pending = "flag"
+            continue
+        match = REDIR.match(arg)
+        if match:
+            operator, rest = match.group(1), match.group(2)
+            if operator == "<":
+                # An input redirection from an env file is a read whatever the
+                # command is: `while IFS= read -r l; do :; done < .env`.
+                if rest:
+                    reads.append(rest)
+                else:
+                    pending = "in"
+            elif operator in (">", ">>") and not rest:
+                pending = "out"
+            continue
+        files.append(arg)
+
+    if name in SOURCERS:
+        reads += files[:1]
+    elif name in READERS:
+        # -l / --files print names, not contents.
+        if not any(a in NO_READ_FLAGS for a in args):
+            reads += files
+    elif name in INTERPRETERS and any(a in INLINE_FLAGS for a in args):
+        reads += ENV_TOKEN.findall(segment)
+    elif name in COPIERS and any(expand(f, variables) in STDOUT_SINKS for f in files):
+        reads += files
+
+    return reads, cwd
+
+
+def detect_bash(command, cwd):
+    variables = {}
+    for segment in SPLIT.split(command):
+        segment = segment.strip()
+        if not segment:
+            continue
+        try:
+            tokens = shlex.split(segment, posix=True)
+        except ValueError:
+            # Heredocs and unbalanced quotes reach here. A parser error must
+            # not silently drop the segment.
+            tokens = segment.split()
+        while tokens and ASSIGN.match(tokens[0]):
+            key, _, value = tokens.pop(0).partition("=")
+            variables[key] = expand(value, variables)
+        if not tokens:
+            continue
+        variables["PWD"] = cwd
+        reads, cwd = candidates_of(segment, tokens, variables, cwd)
+        for token in reads:
+            token = expand(token, variables)
+            if not token or token.startswith("-"):
+                continue
+            path = absolutise(token, cwd)
+            if is_env_file(path):
+                return path
+    return None
+
+
+try:
+    if TOOL == "Bash":
+        found = detect_bash(SUBJECT, CWD)
+    else:
+        candidate = absolutise(expand(SUBJECT, {}), CWD)
+        found = candidate if is_env_file(candidate) else None
+    if found:
+        print(found)
+except Exception:  # noqa: BLE001 - a guard rail must not wedge the session
+    pass
+PY
+)
 
 # No env file detected — allow
 [[ -z "$FILE_PATH" ]] && exit 0
-
-# Normalize the filename (basename for pattern matching)
-BASENAME=$(basename "$FILE_PATH")
-
-# Check if file matches .env patterns: .env, .env.*, .envrc
-case "$BASENAME" in
-    .env|.envrc) ;; # match
-    .env.*) ;; # match .env.local, .env.production, etc.
-    *) exit 0 ;; # not an env file, allow
-esac
-
-# Resolve the full path (handle relative paths using cwd from hook input)
-if [[ "$FILE_PATH" != /* ]]; then
-    CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""' 2>/dev/null) || CWD=""
-    if [[ -n "$CWD" ]]; then
-        FILE_PATH="$CWD/$FILE_PATH"
-    fi
-fi
 
 # Check if file exists
 if [[ ! -f "$FILE_PATH" ]]; then

--- a/claude/hooks/mask_env_read.sh
+++ b/claude/hooks/mask_env_read.sh
@@ -128,9 +128,16 @@ SOURCERS = {"source", "."}
 VALUE_FLAGS = {"-e", "--regexp", "-g", "--glob", "--iglob", "--include",
                "--exclude", "--exclude-dir", "-t", "--type", "-d",
                "--delimiter", "-m", "--max-count", "-S", "--sort"}
-# `rg --files` lists filenames and never opens them.
+# `rg --files` lists filenames and never opens them. Scoped to the grep family,
+# because -l means something else to other readers (`bat -l sh` is a language).
 NO_READ_FLAGS = {"--files", "-l", "--files-with-matches", "-L",
                  "--files-without-match"}
+GREPPERS = {"grep", "egrep", "fgrep", "rg"}
+# Words that stand in front of the real command. `if [ -f .env ]; then cat .env`
+# splits into a segment beginning `then`, and this repo's own conventions put
+# `command` in front of an aliased binary — 211 commands in the sweep corpus do.
+PREFIXES = {"then", "else", "elif", "do", "!", "time", "command", "builtin",
+            "exec", "nohup", "nice", "eval", "sudo", "-"}
 
 # Shell separators, plus the substitution delimiters. Splitting on `$(`, `)`
 # and backticks is what catches `echo "$(cat .env)"` and
@@ -180,6 +187,28 @@ def expand(token, variables):
     return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)", sub, token)
 
 
+def strip_prefixes(tokens):
+    """Drop shell keywords, grouping punctuation and no-op wrappers.
+
+    Without this, `( cd dir && cat .env )`, `{ cat .env; }`, `then cat .env`
+    and `command cat .env` all present a first word that is not a reader, and
+    the whole segment is skipped.
+    """
+    while tokens:
+        head = tokens[0].lstrip("({!")
+        if not head:
+            tokens = tokens[1:]
+            continue
+        if head != tokens[0]:
+            tokens = [head] + tokens[1:]
+            continue
+        if os.path.basename(head) in PREFIXES:
+            tokens = tokens[1:]
+            continue
+        return tokens
+    return tokens
+
+
 def candidates_of(segment, tokens, variables, cwd):
     """(paths this segment would READ, new cwd)."""
     name = os.path.basename(tokens[0])
@@ -225,7 +254,7 @@ def candidates_of(segment, tokens, variables, cwd):
         reads += files[:1]
     elif name in READERS:
         # -l / --files print names, not contents.
-        if not any(a in NO_READ_FLAGS for a in args):
+        if name not in GREPPERS or not any(a in NO_READ_FLAGS for a in args):
             reads += files
     elif name in INTERPRETERS and any(a in INLINE_FLAGS for a in args):
         reads += ENV_TOKEN.findall(segment)
@@ -247,6 +276,10 @@ def detect_bash(command, cwd):
             # Heredocs and unbalanced quotes reach here. A parser error must
             # not silently drop the segment.
             tokens = segment.split()
+        while tokens and ASSIGN.match(tokens[0]):
+            key, _, value = tokens.pop(0).partition("=")
+            variables[key] = expand(value, variables)
+        tokens = strip_prefixes(tokens)
         while tokens and ASSIGN.match(tokens[0]):
             key, _, value = tokens.pop(0).partition("=")
             variables[key] = expand(value, variables)
@@ -287,7 +320,7 @@ if [[ ! -f "$FILE_PATH" ]]; then
 fi
 
 # Check if file is binary (skip masking for binary files)
-if file -b "$FILE_PATH" 2>/dev/null | grep -qi 'binary\|executable\|data'; then
+if file -bL "$FILE_PATH" 2>/dev/null | grep -qi 'binary\|executable\|data'; then
     deny "Binary .env file detected — refusing to read."
 fi
 

--- a/claude/hooks/test_mask_env_read.sh
+++ b/claude/hooks/test_mask_env_read.sh
@@ -171,6 +171,13 @@ run_bash "redirection into while"  'while IFS= read -r l; do :; done < .env'  ma
 run_bash "cp to stdout"            'cp .env /dev/stdout'            mask
 run_bash "inline python"           'python3 -c "print(open(\".env\").read())"'  mask
 
+echo "=== SHOULD MASK: a keyword or a wrapper stands in front of the reader ==="
+run_bash "guarded by then"         'if [ -f .env ]; then cat .env; fi'      mask
+run_bash "subshell with cd"        "( cd $FIXTURE && cat .env )"            mask "$PARENT"
+run_bash "brace group"             '{ cat .env; }'                          mask
+run_bash "command prefix"          'command cat .env'                       mask
+run_bash "time prefix"             'time sed -n 1p .env'                    mask
+
 echo "=== SHOULD MASK: the Grep tool reads files too ==="
 run_grep "grep tool on .env"       "$FIXTURE/.env"                  mask
 
@@ -194,6 +201,8 @@ run_bash "source with extra args"  'source README.md .envrc'        allow
 run_bash "prose starting with dot" '. Every call site, including .envrc, now names the verbs'  allow
 # -f really does read the file as a pattern list, so it stays intercepted.
 run_bash "grep -f reads the file"  'echo hi | grep -f .env'         mask
+# -l is a names-only flag to grep, but a language to bat.
+run_bash "bat -l is a language"    'bat -l sh .env'                 mask
 
 echo "=== SHOULD ALLOW: touching an env file without reading its values ==="
 run_bash "git add"                 'git add .env'                   allow

--- a/claude/hooks/test_mask_env_read.sh
+++ b/claude/hooks/test_mask_env_read.sh
@@ -12,7 +12,10 @@
 # green against a hook that blocked nothing. A substring check here can never
 # tell a working hook from a decorative one; keep the jq key assertions.
 
-HOOK="$(cd "$(dirname "$0")" && pwd)/mask_env_read.sh"
+# HOOK is overridable so the same suite can be pointed at an older revision:
+#   git show <rev>:claude/hooks/mask_env_read.sh > /tmp/old_hook.sh
+#   HOOK=/tmp/old_hook.sh bash claude/hooks/test_mask_env_read.sh
+HOOK="${HOOK:-$(cd "$(dirname "$0")" && pwd)/mask_env_read.sh}"
 PASS=0
 FAIL=0
 
@@ -27,6 +30,9 @@ trap 'rm -rf "$FIXTURE"' EXIT
 printf 'API_KEY=supersecretvalue\nPLAIN=hello\n' > "$FIXTURE/.env"
 printf 'export TOKEN=anothersecret\n' > "$FIXTURE/.envrc"
 printf 'not an env file\n' > "$FIXTURE/README.md"
+# A symlink whose own name says nothing about what it points at. The basename
+# check tests the link, so this walked straight past the hook.
+ln -s .env "$FIXTURE/notes.txt"
 
 # Read the verdict out of the hook's JSON by KEY. Anything that is not a
 # well-formed object carrying hookSpecificOutput.permissionDecision == "deny"
@@ -64,14 +70,29 @@ check() {
     PASS=$((PASS + 1))
 }
 
+# The 4th argument is the session cwd the hook is told about. It defaults to
+# the fixture; the `cd` cases need it to be somewhere else, because a hook that
+# resolves every relative path against the session cwd only looks correct while
+# the two happen to be the same directory.
 run_bash() {
-    local desc="$1" cmd="$2" expect="$3"
+    local desc="$1" cmd="$2" expect="$3" cwd="${4:-$FIXTURE}"
     local out
     out=$(python3 -c "
 import json, sys
 print(json.dumps({'tool_name': 'Bash', 'cwd': sys.argv[2],
                   'tool_input': {'command': sys.argv[1]}}))" \
-        "$cmd" "$FIXTURE" | bash "$HOOK" 2>/dev/null)
+        "$cmd" "$cwd" | bash "$HOOK" 2>/dev/null)
+    check "$desc" "$expect" "$out"
+}
+
+run_grep() {
+    local desc="$1" path="$2" expect="$3"
+    local out
+    out=$(python3 -c "
+import json, sys
+print(json.dumps({'tool_name': 'Grep', 'cwd': sys.argv[2],
+                  'tool_input': {'pattern': 'KEY', 'path': sys.argv[1]}}))" \
+        "$path" "$FIXTURE" | bash "$HOOK" 2>/dev/null)
     check "$desc" "$expect" "$out"
 }
 
@@ -111,6 +132,82 @@ run_bash "git status"              'git status --short'       allow
 run_bash "ls with pipe"            'ls -la | wc -l'           allow
 run_read "read a normal file"      "$FIXTURE/README.md"       allow
 run_bash "nonexistent env file"    'cat .env.missing'         allow
+
+# --- Bypasses measured live on 2026-09-12, ordered by how likely each is to
+# --- happen by accident rather than by attack.
+
+echo "=== SHOULD MASK: the path never appears literally (cd, variables, quotes) ==="
+# PARENT is the fixture's parent, so a relative token resolved against the
+# session cwd instead of the cd'd-into directory misses the file entirely.
+PARENT="$(dirname "$FIXTURE")"
+run_bash "cd then read"            "cd $FIXTURE && cat .env"        mask "$PARENT"
+run_bash "cd then sed"             "cd $FIXTURE; sed -n 1p .env"    mask "$PARENT"
+run_bash "variable path"           "V=$FIXTURE/.env; cat \"\$V\""   mask "$PARENT"
+run_bash "braced variable path"    "V=$FIXTURE/.env; cat \"\${V}\"" mask "$PARENT"
+run_bash "quoted absolute path"    "cat \"$FIXTURE/.env\""           mask "$PARENT"
+
+echo "=== SHOULD MASK: symlink to an env file (basename says nothing) ==="
+run_bash "cat a symlink"           'cat notes.txt'                  mask
+run_read "read a symlink"          "$FIXTURE/notes.txt"             mask
+
+echo "=== SHOULD MASK: readers the command list did not know about ==="
+run_bash "sed"                     'sed -n 1p .env'                 mask
+run_bash "awk"                     "awk 'NR==1' .env"               mask
+run_bash "nl"                      'nl .env'                        mask
+run_bash "tac"                     'tac .env'                       mask
+run_bash "od"                      'od -c .env'                     mask
+run_bash "xxd"                     'xxd .env'                       mask
+run_bash "strings"                 'strings .env'                   mask
+run_bash "cut"                     'cut -d= -f2 .env'               mask
+run_bash "base64"                  'base64 .env'                    mask
+run_bash "source"                  'source .envrc'                  mask
+run_bash "dot builtin"             '. .envrc'                       mask
+
+echo "=== SHOULD MASK: the read hides inside a substitution or a redirection ==="
+run_bash "command substitution"    'echo "$(cat .env)"'             mask
+run_bash "backtick substitution"   'echo `cat .env`'                mask
+run_bash "export from xargs"       'export $(cat .env | xargs)'     mask
+run_bash "redirection into while"  'while IFS= read -r l; do :; done < .env'  mask
+run_bash "cp to stdout"            'cp .env /dev/stdout'            mask
+run_bash "inline python"           'python3 -c "print(open(\".env\").read())"'  mask
+
+echo "=== SHOULD MASK: the Grep tool reads files too ==="
+run_grep "grep tool on .env"       "$FIXTURE/.env"                  mask
+
+# --- False-positive guards. Widening the reader set is only safe if ordinary
+# --- work still runs; each of these would be newly broken by a careless list.
+
+echo "=== SHOULD ALLOW: the new readers on ordinary files ==="
+run_bash "sed on a normal file"    "sed -i 's/a/b/' README.md"      allow
+run_bash "awk on a normal file"    "awk '{print}' README.md"        allow
+run_bash "cut on a normal file"    'cut -c1-3 README.md'            allow
+run_bash "grep over a tree"        'grep -rn KEY .'                 allow
+run_bash "inline python, no env"   'python3 -c "print(1)"'          allow
+run_bash "venv dir called .env"    'source .env/bin/activate'       allow
+# rg -g takes a glob, not a path, and --files/-l print names, never contents.
+run_bash "rg glob argument"        "rg --files -g '.envrc'"         allow
+run_bash "rg -l names only"        'rg -l KEY .env'                 allow
+run_bash "grep -e pattern"         'grep -e .env README.md'         allow
+# `source FILE args` reads only FILE. A prose sentence in a commit-message
+# heredoc begins with ". ", which parses as the source builtin.
+run_bash "source with extra args"  'source README.md .envrc'        allow
+run_bash "prose starting with dot" '. Every call site, including .envrc, now names the verbs'  allow
+# -f really does read the file as a pattern list, so it stays intercepted.
+run_bash "grep -f reads the file"  'echo hi | grep -f .env'         mask
+
+echo "=== SHOULD ALLOW: touching an env file without reading its values ==="
+run_bash "git add"                 'git add .env'                   allow
+run_bash "ls"                      'ls -la .env'                    allow
+run_bash "rm"                      'rm -f .env'                     allow
+run_bash "mv"                      'mv .env .env.bak'               allow
+run_bash "cp to a backup"          'cp .env .env.bak'               allow
+run_bash "append to it"            'echo "FOO=bar" >> .env'         allow
+run_bash "write over it"           'cat > .env'                     allow
+run_bash "editor"                  'vim .env'                       allow
+
+echo "=== SHOULD ALLOW: variables and cd that do not lead to an env file ==="
+run_bash "variable to normal file" 'V=README.md; cat "$V"'          allow
+run_bash "cd then normal read"     "cd $FIXTURE && cat README.md"   allow "$PARENT"
 
 echo "=== SHOULD MASK: the deny is carried by permissionDecision, not decision.behavior ==="
 SHAPE=$(python3 -c "


### PR DESCRIPTION
## A shell variable in the path walked straight past the hook

#160 made `mask_env_read.sh` actually deny, and the literal case works. A variable does not. Measured live today against a throwaway fixture holding an obviously synthetic value, before this branch:

| command | result |
|---|---|
| `cat <fixture>/.env` | denied, masked |
| `V=<fixture>/.env; cat "$V"` | raw value |
| `sed -n 1p <fixture>/.env` | raw value |
| `awk 'NR==1' <fixture>/.env` | raw value |
| `cd <fixture> && cat .env` | raw value |

The hook reads the command text before the shell expands it, so `cat "$V"` shows it no `.env` at all. The last row was not on the list of known gaps and is the one I would rank first: every command in this repo's own working style begins `cd <dir> && …`, and the hook resolved a relative path against the session cwd rather than the directory the command had just entered.

## This hook is not a security boundary, and the header now says so

A command-text filter cannot be complete. `python3 -c "print(open(chr(46)+'env').read())"` defeats every list in the file, and so does base64-ing the name, splitting the path across two variables, or reading through a pre-opened descriptor. Anyone who wants the value gets the value.

That matters because of how this file got into trouble. Today `permissions.ask` on `Read(**/.env*)` was called redundant *because the hook existed*, while the hook had never blocked anything in its life. The header now carries the warning in a box at the top, together with the actual gate for reference, so the next reader cannot repeat it:

```
ask:   Read(**/.env)   Read(**/.env.*)
allow: Read(**/.envrc)   <-- no gate at all; for .envrc this hook is
                             the only thing in the way
```

Neither permission rule covers the Bash tool, which is what most of the hook is.

## What changed, in the order I fixed it

Ordered by how likely each is to happen by accident rather than by attack — an accidental read writes a live credential into a transcript that keeps it forever, whereas an attacker has `python3 -c` regardless.

1. **`cd` then a relative read.** The detector tracks `cd`/`pushd` per segment and resolves later relative paths against the effective directory.
2. **Variable, quoted and `~` paths.** Same-command `VAR=value` assignments are recorded and `$V` / `${V}` resolved from them, then from the real environment. `shlex` parsing removes the quotes, which were their own bypass: `cat "$HOME/.env"` reduced to a basename of `.env"`, which matched nothing.
3. **Load idioms that hide the read in a substitution.** Splitting now happens on `$(`, `)`, backticks and process substitution as well as `||`, `&&`, `;` and `|`, so `echo "$(cat .env)"` and `export $(cat .env | xargs)` are seen.
4. **The reader set**, widened from seven commands to: `cat head tail bat less more grep egrep fgrep rg sed awk gawk mawk nl tac rev cut od xxd hexdump strings base64 dd diff source .`
5. **Input redirection**, which is a read whatever the command is, so `while IFS= read -r l; do :; done < .env` no longer hides behind `done`.
6. **Symlinks.** The basename check tested the link; it now also tests `realpath` of the target. See the caveat below — this one is cheap but mostly inert today.
7. **A keyword or a wrapper in front of the reader.** `if [ -f .env ]; then cat .env; fi` splits into a segment beginning `then`; `( cd dir && cat .env )` into one beginning `(`; and this repo's own convention of prefixing an aliased binary with `command` puts a non-reader first word in front of **211** commands in the sweep corpus (37 brace groups, 34 subshell `cd`). Each skipped the whole segment. A prefix-strip pass now drops shell keywords, grouping punctuation and no-op wrappers before the command name is read.
8. **Attack-shaped leftovers**, taken because they cost a line each: `cp .env /dev/stdout`, and an inline `python3 -c` / `perl -e` / `node -e` whose script text names an env file.

Two smaller corrections found alongside these. `file -b` does not follow a symlink — it reports `symbolic link to <target>`, and a target path containing "data" would have matched the binary branch and produced a **content-free deny**, which the suite's own `check()` calls worse than no deny; it is now `file -bL`. And the names-only flags below are grep-family semantics, so they no longer suppress the read for other readers, where `-l` means something else: `bat -l sh` is a language.

Also fixed: the `Grep` tool was never registered and never handled. `tool_input.path` is handled now, though it only fires once settings gains a `Grep` matcher.

## The false-positive cost is 19 commands in 42,223, and none of them is an unrelated file

Widening a reader set is how a guard rail starts intercepting ordinary work, so I measured it rather than guessed. Corpus: every unique Bash `tool_use` command in `~/.claude/projects/*/*.jsonl` — 3,534 transcript files, 42,223 unique commands. Historical commands ran in directories that no longer hold those files, so the comparison is at the *detection* stage: would this command be treated as an env read, old parser versus new.

```
corpus:                                   42223
flagged by the new detector:                 83
  of those, already flagged before:          64
  NEWLY flagged:                             19   (0.045%)
flagged before but not now:                   5
```

Every one of the 19 genuinely opens an env file. Not one is an unrelated file caught by a widened command name — no `awk` on a normal file, no `grep` over a tree that merely contains a `.env`. By shape: nine are a newly listed reader (`sed`, `rg`, `cut`) pointed at a `.env` or `.envrc`; five pull a value out through `$(...)` or `export $(...)`; one sits behind an `else`; two are `cat` reached only through a variable or after a `cd`; two are today's own probes.

**What I would newly block that a reasonable person would call a false positive:** five of the 19 print key *names* and no values — `cut -d= -f1 .env`, `grep -c KEY .env`, `rg -o '^\s*export\s+[A-Z_]+' .envrc`. Those commands were written deliberately to avoid printing secrets, and they now get a denial instead. The masked denial still lists every key, so the information survives; the command does not. I left them intercepted rather than trying to prove a reader is value-safe from its flags.

Three precision rules came out of the sweep and are in the code because the first pass got them wrong:

- `rg -g '.envrc'` names a **glob**, not a path, and `--files` / `-l` print names rather than contents.
- `source FILE args` reads only `FILE`. Without this, a prose sentence inside a commit-message heredoc — which begins `". "`, parsed as the source builtin — matched any filename later in the sentence.
- `grep -f .env` genuinely does read the file, so `-f` is deliberately not in the skip list.

The five commands that used to be flagged and no longer are: three were the old parser's own false positives, where a `.env`-looking string sat inside a **grep pattern** rather than an argument (`grep -n 'image=image.env({"HF_HOME"' file.py` is the clearest). The other two are the deliberate `-l` rule above. Writes were also over-caught before: `cat > .env` was intercepted as a read and now runs.

## Every new case fails first

The suite gained a `cwd` argument (the `cd` cases need the session cwd to differ from the fixture, or a hook that resolves everything against the session cwd looks correct by accident), a `Grep` driver, a symlink fixture, and an overridable `HOOK` so the same file can be pointed at an older revision:

```bash
git show 7df6a31:claude/hooks/mask_env_read.sh \
    > /tmp/old_hook.sh
HOOK=/tmp/old_hook.sh \
    bash claude/hooks/test_mask_env_read.sh
```

Against the merged `#160` hook — 32 fail:

```
=== SHOULD MASK: the path never appears literally (cd, variables, quotes) ===
FAIL: cd then read (expected mask, got allow)
FAIL: cd then sed (expected mask, got allow)
FAIL: variable path (expected mask, got allow)
FAIL: braced variable path (expected mask, got allow)
FAIL: quoted absolute path (expected mask, got allow)
=== SHOULD MASK: symlink to an env file (basename says nothing) ===
FAIL: cat a symlink (expected mask, got allow)
FAIL: read a symlink (expected mask, got allow)
=== SHOULD MASK: readers the command list did not know about ===
FAIL: sed (expected mask, got allow)
FAIL: awk (expected mask, got allow)
FAIL: nl (expected mask, got allow)
FAIL: tac (expected mask, got allow)
FAIL: od (expected mask, got allow)
FAIL: xxd (expected mask, got allow)
FAIL: strings (expected mask, got allow)
FAIL: cut (expected mask, got allow)
FAIL: base64 (expected mask, got allow)
FAIL: source (expected mask, got allow)
FAIL: dot builtin (expected mask, got allow)
=== SHOULD MASK: the read hides inside a substitution or a redirection ===
FAIL: command substitution (expected mask, got allow)
FAIL: backtick substitution (expected mask, got allow)
FAIL: export from xargs (expected mask, got allow)
FAIL: redirection into while (expected mask, got allow)
FAIL: cp to stdout (expected mask, got allow)
FAIL: inline python (expected mask, got allow)
=== SHOULD MASK: a keyword or a wrapper stands in front of the reader ===
FAIL: guarded by then (expected mask, got allow)
FAIL: subshell with cd (expected mask, got allow)
FAIL: brace group (expected mask, got allow)
FAIL: command prefix (expected mask, got allow)
FAIL: time prefix (expected mask, got allow)
=== SHOULD MASK: the Grep tool reads files too ===
FAIL: grep tool on .env (expected mask, got allow)
=== SHOULD ALLOW: touching an env file without reading its values ===
FAIL: write over it (expected allow, got mask)

42 passed, 32 failed
```

Against this branch — clean:

```
=== SHOULD MASK: Read tool ===
=== SHOULD MASK: simple Bash reads ===
=== SHOULD MASK: reads hidden behind shell operators (the fixed bypass) ===
=== SHOULD ALLOW: no env file involved ===
=== SHOULD MASK: the path never appears literally (cd, variables, quotes) ===
=== SHOULD MASK: symlink to an env file (basename says nothing) ===
=== SHOULD MASK: readers the command list did not know about ===
=== SHOULD MASK: the read hides inside a substitution or a redirection ===
=== SHOULD MASK: a keyword or a wrapper stands in front of the reader ===
=== SHOULD MASK: the Grep tool reads files too ===
=== SHOULD ALLOW: the new readers on ordinary files ===
=== SHOULD ALLOW: touching an env file without reading its values ===
=== SHOULD ALLOW: variables and cd that do not lead to an env file ===
=== SHOULD MASK: the deny is carried by permissionDecision, not decision.behavior ===

74 passed, 0 failed
```

The fixture value is synthetic and the fixture directory is removed by the suite's `trap`.

## Three things in settings.json for you, untouched here

I did not edit `claude/settings.json`. All three are one edit to the same block, lines 283–300.

**The duplicate.** `mask_env_read.sh` is registered twice under the `Read` matcher. `Read(**/.env*)` already matches `.envrc`, so the second entry is dead:

```
  289            "if": "Read(**/.env*)",
  296            "if": "Read(**/.envrc)",
```

**The `if` gate decides whether half of this PR does anything.** A hook runs only when its `if` matches, and the Bash entry is `"if": "Bash(*.env*)"` at line 351. Two different confidence levels, which I am keeping apart:

- *Symlinks — certain.* `Bash(*.env*)` is glob-matched against the command text, so `cat notes.txt` cannot match it however good the hook is. Symlink handling is inert until that `if` goes.
- *Variable paths — unverified.* The docs' Bash matching table says "Leading `VAR=value` assignments are stripped before matching". If the whole command is stripped that way, `V=…/.env; cat "$V"` may never reach the hook either. My live probe leaked before and after the parser fix, so it cannot tell the two apart, and I could not test it without deploying into your live `~/.claude`.

**What I would do:** drop the `if` from the Bash entry, collapse the two `Read` entries into one with no `if`, and add a `Grep` matcher. Cost is one process spawn per Bash call; the hook exits in milliseconds when nothing matches. One edit fixes the duplicate, the symlink gap and the Grep gap together.

A 30-second probe after merging, whichever way you go:

```bash
mkdir -p /tmp/envprobe \
    && printf 'FAKE_TOKEN=SYNTHETIC-DUMMY-0000\n' \
        > /tmp/envprobe/.env \
    && ln -sf .env /tmp/envprobe/notes.txt
V=/tmp/envprobe/.env; cat "$V"
cd /tmp/envprobe && cat .env
cat /tmp/envprobe/notes.txt
rm -rf /tmp/envprobe
```

Rows 1 and 2 should come back as masked denials. **Row 3 will still print the value if you leave the `if` in place** — that is the certain case above, not a hook bug. Row 1 is the one that answers the open question: if it prints the value, the `if` strips the leading assignment and the Bash entry needs its `if` dropped.
